### PR TITLE
Bug fixed in SimpleScalarSeparateChainingHashTable::isFull()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,11 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.7
+#      - llvm-toolchain-precise-3.7
     packages:
       - gcc-5
       - g++-5
-      - clang-3.7
+#      - clang-3.7
       - binutils-gold
       - libprotobuf-dev
       - protobuf-compiler

--- a/storage/SimpleScalarSeparateChainingHashTable.hpp
+++ b/storage/SimpleScalarSeparateChainingHashTable.hpp
@@ -230,10 +230,10 @@ class SimpleScalarSeparateChainingHashTable : public HashTable<ValueT,
                                        HashTablePreallocationState *prealloc_state);
 
   // Determine whether it is actually necessary to resize this hash table.
-  // Checks that there is at least one unallocated bucket.
-  inline bool isFull() const {
-    return header_->buckets_allocated.load(std::memory_order_relaxed)
-           >= header_->num_buckets;
+  // Checks that there are at least ``extra_buckets`` unallocated buckets.
+  inline bool isFull(const std::size_t extra_buckets) const {
+    return (header_->buckets_allocated.load(std::memory_order_relaxed) +
+            extra_buckets) >= header_->num_buckets;
   }
 
   // Cache the TypeID of the key.
@@ -831,7 +831,7 @@ void SimpleScalarSeparateChainingHashTable<ValueT,
   // Recheck whether the hash table is still full. Note that multiple threads
   // might wait to rebuild this hash table simultaneously. Only the first one
   // should do the rebuild.
-  if (!isFull()) {
+  if (!isFull(extra_buckets)) {
     return;
   }
 


### PR DESCRIPTION
- Earlier check for isFull() was that whether there is at least one empty bucket available for insertion.
- Now isFull() can check if there is enough space for adding specified number of buckets.
- To reproduce the bug behind this fix: Run TPC-H Q2 on SF100 dataset after
  running the \analyze command. The optimizer allocates smaller than
  necessary space for one of the hash joins. The resize() is triggered
  but never gets executed because of the restrictive isFull() condition.