### PR TITLE
Fix typos in CMakeLists.txt.

### DIFF
--- a/expressions/CMakeLists.txt
+++ b/expressions/CMakeLists.txt
@@ -63,6 +63,6 @@ add_library(quickstep_expressions ../empty_src.cpp ExpressionsModule.hpp)
 target_link_libraries(quickstep_expressions
                       quickstep_expressions_ExpressionFactories
                       quickstep_expressions_Expressions_proto
-                      quickstep_expressions_aggregate
+                      quickstep_expressions_aggregation
                       quickstep_expressions_predicate
                       quickstep_expressions_scalar)

--- a/expressions/aggregation/CMakeLists.txt
+++ b/expressions/aggregation/CMakeLists.txt
@@ -266,7 +266,6 @@ target_link_libraries(quickstep_expressions_aggregation
                       quickstep_expressions_aggregation_AggregationHandleMax
                       quickstep_expressions_aggregation_AggregationHandleMin
                       quickstep_expressions_aggregation_AggregationHandleSum
-                      quickstep_expressions_aggregation_AggregationHandleUtil
                       quickstep_expressions_aggregation_AggregationID)
 
 # Tests:


### PR DESCRIPTION
Both the CMakeLists files in this PR refer to libraries that don't exist. expressions/CMakeLists refers to a library that has probably been renamed. For the other file, I can't find any *_AggregationHandleUtil library. Not sure why it's been working so far! 