### PR TITLE
Fix to clang problems in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,26 @@ cache: ccache
 
 compiler:
   - gcc
-  # clang
+  - clang
 
 env:
   - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=joinwithbinaryexpressions
   - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=none
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=none
+
+before_install:
+  - LLVM_VERSION=3.7.1
+  - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
+  - if [[ $CC = "clang" ]]; then
+      wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH;
+      mkdir -p $HOME/clang-$LLVM_VERSION;
+      tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang-$LLVM_VERSION --strip-components 1;
+      ln -sf $HOME/clang-$LLVM_VERSION/bin/clang++ $HOME/clang-$LLVM_VERSION/bin/clang++-3.7;
+      export PATH=$HOME/clang-$LLVM_VERSION/bin:$PATH;
+      export CPPFLAGS="-I $HOME/clang-$LLVM_VERSION/include/c++/v1";
+      echo "Using clang at " `which $CC-3.7` " and $CXX at " `which $CXX-3.7`;
+    fi
 
 install:
   - if [ "$VECTOR_COPY_ELISION_LEVEL" = "joinwithbinaryexpressions" ] && [ "$CC" = "gcc" ]; then


### PR DESCRIPTION
This PR applies the fix from @pateljm's PR #9, with some other typos and fixes. 

For Clang, build and tests succeed on Travis. 
For GCC, there are OOM errors (unrelated to the present change).