### PR TITLE
Fix a potential segfault in CompressedBlockBuilder

### DIFF
--- a/storage/CompressedBlockBuilder.cpp
+++ b/storage/CompressedBlockBuilder.cpp
@@ -321,6 +321,9 @@ void CompressedBlockBuilder::buildCompressedColumnStoreTupleStorageSubBlock(void
 bool CompressedBlockBuilder::addTupleInternal(Tuple *candidate_tuple) {
   DEBUG_ASSERT(candidate_tuple->size() == relation_.size());
 
+  // Ensure that the tuple is the owner of its values.
+  candidate_tuple->ensureLiteral();
+
   // Modify dictionaries and maximum integers to reflect the new tuple's
   // values. Keep track of what has changed in case a rollback is needed.
   vector<CompressionDictionaryBuilder*> modified_dictionaries;


### PR DESCRIPTION
This PR fixes a potential bug in `CompressedBlockBuilder`. This fix is necessary for a subsequent PR on `TextScanOperator` where each work order first constructs a `ColumnVectorsValueAccessor` and then bulk insert the value accessor into a `CompressedColumnStoreTupleStorageSubBlock`.

In the typical scenario, `CompressedBlockBuilder` first collects tuples from a `ValueAccesor` into a `PtrVector<Tuple>` , then calls `buildDictionary` to process the tuples. However, the collected tuples would not own the underlying attribute values' **`out_of_line_data`** if the value is of `Char` or `VarChar` type. This incurs segmentation fault if the `ValueAccessor` (which owns the `out_of_line_data`) gets released before `buildDictionary` is completed.

The fix is just to ensure that the `PtrVector<Tuple>` owns the underlying `out_of_line_data`.