### PR TITLE
Use shared libraries when building on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ before_script:
   - $CLINKER --version
   - (cd build &&
      cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE
+           -D BUILD_SHARED_LIBS=On
            -D CMAKE_C_FLAGS_DEBUG="$DEBUG_FLAGS"
            -D CMAKE_CXX_FLAGS_DEBUG="$DEBUG_FLAGS"
            -D CMAKE_C_FLAGS_RELEASE="$RELEASE_FLAGS"


### PR DESCRIPTION
[Identical to #21, but that got messed up due to some git foo.]

This change should reduce memory consumption and build time.
Comparing Travis run times for PR #21  (https://travis-ci.org/apache/incubator-quickstep/builds/136474629) with one from earlier today (https://travis-ci.org/apache/incubator-quickstep/builds/136370961), almost all the run times have gone down to a certain extent. It's particularly helpful for the GCC runs with copy elision (>10% speedup).