### PR TITLE
QUICKSTEP-18: Allow BasicColumnStoreTupleStorageSubBlock to be unsorted

### DIFF
--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -384,15 +384,12 @@ set_property(SOURCE ${CMAKE_CURRENT_BINARY_DIR}/SqlParser_gen.cpp APPEND PROPERT
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-Wno-deprecated-register" COMPILER_HAS_WNO_DEPRECATED_REGISTER)
 if (COMPILER_HAS_WNO_DEPRECATED_REGISTER)
-  set_property(TARGET quickstep_parser_SqlLexer APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-deprecated-register")
+  set_target_properties(quickstep_parser_SqlLexer PROPERTIES COMPILE_FLAGS "-Wno-deprecated-register")
 endif()
 
 # GCC will make a warning for unsigned-signed comparisons which are inherent
 # in the lexer. For this, we turn off the sign compare.
-CHECK_CXX_COMPILER_FLAG("-Wno-sign-compare" COMPILER_HAS_WNO_SIGN_COMPARE)
-if (COMPILER_HAS_WNO_SIGN_COMPARE)
-  set_property(TARGET quickstep_parser_SqlLexer APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-sign-compare")
-endif()
+set_target_properties(quickstep_parser_SqlLexer PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
 
 add_subdirectory(tests)
 

--- a/storage/StorageBlockLayout.proto
+++ b/storage/StorageBlockLayout.proto
@@ -1,7 +1,7 @@
 //   Copyright 2011-2015 Quickstep Technologies LLC.
 //   Copyright 2015-2016 Pivotal Software, Inc.
 //   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
-//    University of Wisconsin—Madison.
+//    University of Wisconsin-Madison.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@ message TupleStorageSubBlockDescription {
 
 message BasicColumnStoreTupleStorageSubBlockDescription {
   extend TupleStorageSubBlockDescription {
-    // Extentions may not be marked required in protobuf 2.6 or higher. This
-    // field is considered required when sub_block_type == BASIC_COLUMN_STORE.
+    // Indicates the attribute to sort the column store by. If unset, the
+    // column store will be unsorted.
     optional int32 sort_attribute_id = 64;
   }
 }


### PR DESCRIPTION
This makes sorting an optional (instead of required) property of BasicColumnStoreTupleStorageSubBlock.