### PR TITLE
BugFix: Update NumQueuedWorkOrders to fix scheduling

### DIFF
--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -93,6 +93,7 @@ target_link_libraries(quickstep_queryexecution_PolicyEnforcer
                       quickstep_queryexecution_QueryExecutionMessages_proto
                       quickstep_queryexecution_QueryExecutionTypedefs
                       quickstep_queryexecution_QueryManager
+                      quickstep_queryexecution_WorkerDirectory
                       quickstep_queryexecution_WorkerMessage
                       quickstep_queryoptimizer_QueryHandle
                       quickstep_relationaloperators_WorkOrder

--- a/query_execution/PolicyEnforcer.cpp
+++ b/query_execution/PolicyEnforcer.cpp
@@ -27,6 +27,7 @@
 #include "catalog/CatalogTypedefs.hpp"
 #include "query_execution/QueryExecutionMessages.pb.h"
 #include "query_execution/QueryManager.hpp"
+#include "query_execution/WorkerDirectory.hpp"
 #include "query_optimizer/QueryHandle.hpp"
 #include "relational_operators/WorkOrder.hpp"
 
@@ -72,6 +73,7 @@ void PolicyEnforcer::processMessage(const TaggedMessage &tagged_message) {
       CHECK(proto.ParseFromArray(tagged_message.message(),
                                  tagged_message.message_bytes()));
       query_id = proto.query_id();
+      worker_directory_->decrementNumQueuedWorkOrders(proto.worker_thread_index());
       break;
     }
     case kCatalogRelationNewBlockMessage: {

--- a/query_execution/PolicyEnforcer.hpp
+++ b/query_execution/PolicyEnforcer.hpp
@@ -40,6 +40,7 @@ namespace quickstep {
 class CatalogDatabaseLite;
 class QueryHandle;
 class StorageManager;
+class WorkerDirectory;
 
 /**
  * @brief A class that ensures that a high level policy is maintained
@@ -60,11 +61,13 @@ class PolicyEnforcer {
                  const std::size_t num_numa_nodes,
                  CatalogDatabaseLite *catalog_database,
                  StorageManager *storage_manager,
+                 WorkerDirectory *worker_directory,
                  tmb::MessageBus *bus)
       : foreman_client_id_(foreman_client_id),
         num_numa_nodes_(num_numa_nodes),
         catalog_database_(catalog_database),
         storage_manager_(storage_manager),
+        worker_directory_(worker_directory),
         bus_(bus) {}
 
   /**
@@ -148,6 +151,7 @@ class PolicyEnforcer {
 
   CatalogDatabaseLite *catalog_database_;
   StorageManager *storage_manager_;
+  WorkerDirectory *worker_directory_;
 
   tmb::MessageBus *bus_;
 


### PR DESCRIPTION
Quickstep scheduling is currently broken (since PR #14). The foreman only schedules work for one worker, leaving all other workers idle. This PR fixes that bug. 

The foreman maintains the number of queued work orders for each worker in the WorkerDirectory. This state was not being incremented when WorkOrders are dispatched, and not being decremented when WorkOrders are completed. The search for LeastLoadedWorker would therefore always pick the first worker, resulting in serial execution of the entire query. 

In this PR, I have incremented the number of queued work orders in the Foreman when it dispatches messages. 

When a WorkOrderCompletion message arrives, this number must be decremented. However, the worker's thread ID is not available to the Foreman, since PR #14 moved the message deserialization into the PolicyEnforcer. So, in this PR, I've added a pointer to the WorkerDirectory in the PolicyEnforcer. The PolicyEnforcer decrements the number of queued work orders while processing WorkOrderCompletion messages. 

The WorkerDirectory is not thread-safe, so the decrement should only be done in the Foreman thread. Since the PolicyEnforcer is part of the Foreman thread, this change should be fine. 

Tested on CloudLab machine  (40 workers) with a few example queries. 

[A big thanks to @rogersjeffreyl for helping me debug this!]