### PR TITLE
Bug fixed in \analyze command and reuse code.

### DIFF
--- a/cli/CommandExecutor.cpp
+++ b/cli/CommandExecutor.cpp
@@ -220,6 +220,8 @@ inline TypedValue executeQueryForSingleResult(
   QueryExecutionUtil::ConstructAndSendAdmitRequestMessage(
       main_thread_client_id, foreman_client_id, query_handle.get(), bus);
 
+  QueryExecutionUtil::ReceiveQueryCompletionMessage(main_thread_client_id, bus);
+
   // Retrieve the scalar result from the result relation.
   const CatalogRelation *query_result_relation = query_handle->getQueryResultRelation();
   DCHECK(query_result_relation != nullptr);

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -88,7 +88,6 @@ typedef quickstep::LineReaderDumb LineReaderImpl;
 #include "tmb/id_typedefs.h"
 #include "tmb/message_bus.h"
 #include "tmb/message_style.h"
-#include "tmb/tagged_message.h"
 
 namespace quickstep {
 class CatalogRelation;
@@ -119,7 +118,6 @@ using quickstep::QueryHandle;
 using quickstep::QueryPlan;
 using quickstep::QueryProcessor;
 using quickstep::SqlParserWrapper;
-using quickstep::TaggedMessage;
 using quickstep::Worker;
 using quickstep::WorkerDirectory;
 using quickstep::WorkerMessage;
@@ -128,7 +126,6 @@ using quickstep::kPoisonMessage;
 using quickstep::kWorkloadCompletionMessage;
 
 using tmb::client_id;
-using tmb::AnnotatedMessage;
 
 namespace quickstep {
 
@@ -440,10 +437,8 @@ int main(int argc, char* argv[]) {
             &bus);
 
         try {
-          const AnnotatedMessage annotated_msg =
-              bus.Receive(main_thread_client_id, 0, true);
-          const TaggedMessage &tagged_message = annotated_msg.tagged_message;
-          DCHECK_EQ(kWorkloadCompletionMessage, tagged_message.message_type());
+          QueryExecutionUtil::ReceiveQueryCompletionMessage(
+              main_thread_client_id, &bus);
           end = std::chrono::steady_clock::now();
 
           const CatalogRelation *query_result_relation = query_handle->getQueryResultRelation();

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
@@ -42,7 +42,8 @@
 
 #include "glog/logging.h"
 
-#include "tmb/tagged_message.h"
+#include "tmb/id_typedefs.h"
+#include "tmb/message_bus.h"
 
 namespace quickstep {
 
@@ -101,11 +102,8 @@ void ExecutionGeneratorTestRunner::runTestCase(
             &query_handle,
             &bus_);
 
-        // Receive workload completion message from Foreman.
-        const AnnotatedMessage annotated_msg =
-            bus_.Receive(main_thread_client_id_, 0, true);
-        const TaggedMessage &tagged_message = annotated_msg.tagged_message;
-        DCHECK_EQ(kWorkloadCompletionMessage, tagged_message.message_type());
+        QueryExecutionUtil::ReceiveQueryCompletionMessage(
+            main_thread_client_id_, &bus_);
 
         const CatalogRelation *query_result_relation = query_handle.getQueryResultRelation();
         if (query_result_relation) {

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.hpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.hpp
@@ -35,6 +35,9 @@
 #include "utility/Macros.hpp"
 #include "utility/textbased_test/TextBasedTestDriver.hpp"
 
+#include "tmb/id_typedefs.h"
+#include "tmb/message_bus.h"
+
 namespace quickstep {
 
 namespace optimizer {


### PR DESCRIPTION
The ``\analyze`` command issues SQL queries. Due to a recent change in the execution engine (PR #14), there was a bug in issuing the queries, which is fixed in this branch. The issue is described below:

The workflow to issue queries is as follows:

1. Create a TMB message consisting of the query. 
2. Send the TMB message from main thread to the Foreman thread.
3. Foreman executes the query.
4. Foreman sends a completion message back to the main thread.
5. Main thread receives the completion message and proceeds. 

In the relevant function where ``\analyze`` queries are issued, we were not capturing the response in step 5, which gave a segmentation fault sometimes. 

This branch also puts a common code to receive feedback from Foreman upon query completion in a function, which gets used in multiple places. There are some minor inclusion fixes in the touched files.