### PR TITLE
QUICKSTEP-24 Report generation support for work order execution statistics

### DIFF
--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -1,5 +1,7 @@
 #   Copyright 2011-2015 Quickstep Technologies LLC.
 #   Copyright 2015-2016 Pivotal Software, Inc.
+#   Copyright 2016, Quickstep Research Group, Computer Sciences Department, 
+#     University of Wisconsin—Madison.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/query_execution/Foreman.hpp
+++ b/query_execution/Foreman.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_QUERY_EXECUTION_FOREMAN_HPP_
 
 #include <cstddef>
+#include <cstdio>
 #include <memory>
 #include <vector>
 
@@ -57,6 +58,8 @@ class Foreman final : public ForemanLite {
    * @param storage_manager The StorageManager to use.
    * @param cpu_id The ID of the CPU to which the Foreman thread can be pinned.
    * @param num_numa_nodes The number of NUMA nodes in the system.
+   * @param profile_individual_workorders Whether every workorder's execution
+   *        be profiled or not.
    *
    * @note If cpu_id is not specified, Foreman thread can be possibly moved
    *       around on different CPUs by the OS.
@@ -67,9 +70,26 @@ class Foreman final : public ForemanLite {
           CatalogDatabaseLite *catalog_database,
           StorageManager *storage_manager,
           const int cpu_id = -1,
-          const std::size_t num_numa_nodes = 1);
+          const std::size_t num_numa_nodes = 1,
+          const bool profile_individual_workorders = false);
 
   ~Foreman() override {}
+
+  /**
+   * @brief Print the results of profiling individual work orders for a given
+   *        query.
+   *
+   * TODO(harshad) - Add the name of the operator to the output.
+   * TODO(harshad) - Add the CPU core ID of the operator to the output. This
+   * will require modifying the WorkerDirectory to remember worker affinities.
+   * Until then, the users can refer to the worker_affinities provided to the
+   * cli to infer the CPU core ID where a given worker is pinned.
+   *
+   * @param query_id The ID of the query for which the results are to be printed.
+   * @param out The file stream.
+   **/
+  void printWorkOrderProfilingResults(const std::size_t query_id,
+                                      std::FILE *out) const;
 
  protected:
   void run() override;

--- a/query_execution/PolicyEnforcer.cpp
+++ b/query_execution/PolicyEnforcer.cpp
@@ -76,6 +76,9 @@ void PolicyEnforcer::processMessage(const TaggedMessage &tagged_message) {
       query_id = proto.query_id();
       worker_directory_->decrementNumQueuedWorkOrders(
           proto.worker_thread_index());
+      if (profile_individual_workorders_) {
+        recordTimeForWorkOrder(proto);
+      }
       break;
     }
     case kRebuildWorkOrderCompleteMessage: {
@@ -195,6 +198,18 @@ bool PolicyEnforcer::admitQueries(
     }
   }
   return true;
+}
+
+void PolicyEnforcer::recordTimeForWorkOrder(
+    const serialization::NormalWorkOrderCompletionMessage &proto) {
+  const std::size_t query_id = proto.query_id();
+  if (workorder_time_recorder_.find(query_id) == workorder_time_recorder_.end()) {
+    workorder_time_recorder_[query_id];
+  }
+  workorder_time_recorder_[query_id].emplace_back(
+      proto.worker_thread_index(),
+      proto.operator_index(),
+      proto.execution_time_in_microseconds());
 }
 
 }  // namespace quickstep

--- a/query_execution/PolicyEnforcer.hpp
+++ b/query_execution/PolicyEnforcer.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <memory>
 #include <queue>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -62,13 +63,15 @@ class PolicyEnforcer {
                  CatalogDatabaseLite *catalog_database,
                  StorageManager *storage_manager,
                  WorkerDirectory *worker_directory,
-                 tmb::MessageBus *bus)
+                 tmb::MessageBus *bus,
+                 const bool profile_individual_workorders = false)
       : foreman_client_id_(foreman_client_id),
         num_numa_nodes_(num_numa_nodes),
         catalog_database_(catalog_database),
         storage_manager_(storage_manager),
         worker_directory_(worker_directory),
-        bus_(bus) {}
+        bus_(bus),
+        profile_individual_workorders_(profile_individual_workorders) {}
 
   /**
    * @brief Destructor.
@@ -143,8 +146,39 @@ class PolicyEnforcer {
     return !(admitted_queries_.empty() && waiting_queries_.empty());
   }
 
+  /**
+   * @brief Get the profiling results for individual work order execution for a
+   *        given query.
+   *
+   * @note This function should only be called if profiling individual work
+   *       orders option is enabled.
+   *
+   * @param query_id The ID of the query for which the profiling results are
+   *        requested.
+   *
+   * @return A vector of tuples, each being a single profiling entry.
+   **/
+  inline const std::vector<std::tuple<std::size_t, std::size_t, std::size_t>>&
+      getProfilingResults(const std::size_t query_id) const {
+    DCHECK(profile_individual_workorders_);
+    DCHECK(workorder_time_recorder_.find(query_id) !=
+           workorder_time_recorder_.end());
+    return workorder_time_recorder_.at(query_id);
+  }
+
  private:
   static constexpr std::size_t kMaxConcurrentQueries = 1;
+
+  /**
+   * @brief Record the execution time for a finished WorkOrder.
+   *
+   * TODO(harshad) - Extend the functionality to rebuild work orders.
+   *
+   * @param proto The completion message proto sent after the WorkOrder
+   *        execution.
+   **/
+  void recordTimeForWorkOrder(
+      const serialization::NormalWorkOrderCompletionMessage &proto);
 
   const tmb::client_id foreman_client_id_;
   const std::size_t num_numa_nodes_;
@@ -154,12 +188,24 @@ class PolicyEnforcer {
   WorkerDirectory *worker_directory_;
 
   tmb::MessageBus *bus_;
+  const bool profile_individual_workorders_;
 
   // Key = query ID, value = QueryManager* for the key query.
   std::unordered_map<std::size_t, std::unique_ptr<QueryManager>> admitted_queries_;
 
   // The queries which haven't been admitted yet.
   std::queue<QueryHandle*> waiting_queries_;
+
+  // Key = Query ID.
+  // Value = A tuple indicating a record of executing a work order.
+  // Within a tuple ...
+  // 1st element: Logical worker ID.
+  // 2nd element: Operator ID.
+  // 3rd element: Time in microseconds to execute the work order.
+  std::unordered_map<
+      std::size_t,
+      std::vector<std::tuple<std::size_t, std::size_t, std::size_t>>>
+      workorder_time_recorder_;
 
   DISALLOW_COPY_AND_ASSIGN(PolicyEnforcer);
 };


### PR DESCRIPTION
This PR provides an initial version of the support required to report individual work order execution performance. Some highlights are described below: 

- A flag to enable work order profiling report generation.
- At the end of each query, a report is generated which includes worker
  ID, its NUMA socket, the query ID, the operator that produced the WorkOrder and the
  execution time in microseconds.
- The output is printed on stdout in CSV format as of now.

As this is a rudimentary support for the functionality, there is a lot of future work in this regards, which includes printing of CPU core information, printing operator name, allowing user to specify a file where the output can be written, extend the support for rebuild WorkOrder statistics etc.

Edit: Added query ID. 