### PR TITLE
DO NOT MERGE: QUICKSTEP-6: Decimal type

### DIFF
--- a/parser/SqlParser.ypp
+++ b/parser/SqlParser.ypp
@@ -774,7 +774,7 @@ data_type:
     $$ = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDatetime));
   }
   | TOKEN_DECIMAL {
-    $$ = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDouble));
+    $$ = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDecimal));
   }
   | TOKEN_REAL {
     $$ = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDouble));

--- a/parser/preprocessed/SqlParser_gen.cpp
+++ b/parser/preprocessed/SqlParser_gen.cpp
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.7.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2012 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,7 +26,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.7"
+#define YYBISON_VERSION "3.0.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -63,15 +63,12 @@
 #define yyparse         quickstep_yyparse
 #define yylex           quickstep_yylex
 #define yyerror         quickstep_yyerror
-#define yylval          quickstep_yylval
-#define yychar          quickstep_yychar
 #define yydebug         quickstep_yydebug
 #define yynerrs         quickstep_yynerrs
-#define yylloc          quickstep_yylloc
+
 
 /* Copy the first part of user declarations.  */
-/* Line 371 of yacc.c  */
-#line 35 "../SqlParser.ypp"
+#line 35 "../SqlParser.ypp" /* yacc.c:339  */
 
 
 /* Override the default definition, as we only need <first_line> and <first_column>. */
@@ -99,8 +96,7 @@ typedef struct YYLTYPE {
     }                                                           \
   } while (0)
 
-/* Line 371 of yacc.c  */
-#line 64 "../SqlParser.ypp"
+#line 64 "../SqlParser.ypp" /* yacc.c:339  */
 
 #include <cstdlib>
 #include <string>
@@ -156,14 +152,13 @@ typedef struct YYLTYPE {
 // Needed for Bison 2.6 and higher, which do not automatically provide this typedef.
 typedef void* yyscan_t;
 
-/* Line 371 of yacc.c  */
-#line 161 "SqlParser_gen.cpp"
+#line 156 "SqlParser_gen.cpp" /* yacc.c:339  */
 
-# ifndef YY_NULL
+# ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULL nullptr
+#   define YY_NULLPTR nullptr
 #  else
-#   define YY_NULL 0
+#   define YY_NULLPTR 0
 #  endif
 # endif
 
@@ -179,7 +174,7 @@ typedef void* yyscan_t;
    by #include "SqlParser_gen.hpp".  */
 #ifndef YY_QUICKSTEP_YY_SQLPARSER_GEN_HPP_INCLUDED
 # define YY_QUICKSTEP_YY_SQLPARSER_GEN_HPP_INCLUDED
-/* Enabling traces.  */
+/* Debug traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
 #endif
@@ -187,152 +182,151 @@ typedef void* yyscan_t;
 extern int quickstep_yydebug;
 #endif
 
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     TOKEN_COMMAND = 258,
-     TOKEN_NAME = 259,
-     TOKEN_STRING_SINGLE_QUOTED = 260,
-     TOKEN_STRING_DOUBLE_QUOTED = 261,
-     TOKEN_UNSIGNED_NUMVAL = 262,
-     TOKEN_OR = 263,
-     TOKEN_AND = 264,
-     TOKEN_NOT = 265,
-     TOKEN_EQ = 266,
-     TOKEN_NEQ = 267,
-     TOKEN_GEQ = 268,
-     TOKEN_GT = 269,
-     TOKEN_LEQ = 270,
-     TOKEN_LT = 271,
-     TOKEN_REGEXP = 272,
-     TOKEN_LIKE = 273,
-     TOKEN_BETWEEN = 274,
-     TOKEN_IS = 275,
-     UNARY_MINUS = 276,
-     UNARY_PLUS = 277,
-     TOKEN_ADD = 278,
-     TOKEN_ALL = 279,
-     TOKEN_ALTER = 280,
-     TOKEN_AS = 281,
-     TOKEN_ASC = 282,
-     TOKEN_BIGINT = 283,
-     TOKEN_BIT = 284,
-     TOKEN_BITWEAVING = 285,
-     TOKEN_BLOCKPROPERTIES = 286,
-     TOKEN_BLOCKSAMPLE = 287,
-     TOKEN_BLOOM_FILTER = 288,
-     TOKEN_CSB_TREE = 289,
-     TOKEN_BY = 290,
-     TOKEN_CASE = 291,
-     TOKEN_CHARACTER = 292,
-     TOKEN_CHECK = 293,
-     TOKEN_COLUMN = 294,
-     TOKEN_CONSTRAINT = 295,
-     TOKEN_COPY = 296,
-     TOKEN_CREATE = 297,
-     TOKEN_CURRENT = 298,
-     TOKEN_DATE = 299,
-     TOKEN_DATETIME = 300,
-     TOKEN_DAY = 301,
-     TOKEN_DECIMAL = 302,
-     TOKEN_DEFAULT = 303,
-     TOKEN_DELETE = 304,
-     TOKEN_DELIMITER = 305,
-     TOKEN_DESC = 306,
-     TOKEN_DISTINCT = 307,
-     TOKEN_DOUBLE = 308,
-     TOKEN_DROP = 309,
-     TOKEN_ELSE = 310,
-     TOKEN_END = 311,
-     TOKEN_ESCAPE_STRINGS = 312,
-     TOKEN_EXISTS = 313,
-     TOKEN_EXTRACT = 314,
-     TOKEN_FALSE = 315,
-     TOKEN_FIRST = 316,
-     TOKEN_FLOAT = 317,
-     TOKEN_FOLLOWING = 318,
-     TOKEN_FOR = 319,
-     TOKEN_FOREIGN = 320,
-     TOKEN_FROM = 321,
-     TOKEN_FULL = 322,
-     TOKEN_GROUP = 323,
-     TOKEN_HASH = 324,
-     TOKEN_HAVING = 325,
-     TOKEN_HOUR = 326,
-     TOKEN_IN = 327,
-     TOKEN_INDEX = 328,
-     TOKEN_INNER = 329,
-     TOKEN_INSERT = 330,
-     TOKEN_INTEGER = 331,
-     TOKEN_INTERVAL = 332,
-     TOKEN_INTO = 333,
-     TOKEN_JOIN = 334,
-     TOKEN_KEY = 335,
-     TOKEN_LAST = 336,
-     TOKEN_LEFT = 337,
-     TOKEN_LIMIT = 338,
-     TOKEN_LONG = 339,
-     TOKEN_MINUTE = 340,
-     TOKEN_MONTH = 341,
-     TOKEN_NULL = 342,
-     TOKEN_NULLS = 343,
-     TOKEN_OFF = 344,
-     TOKEN_ON = 345,
-     TOKEN_ORDER = 346,
-     TOKEN_OUTER = 347,
-     TOKEN_OVER = 348,
-     TOKEN_PARTITION = 349,
-     TOKEN_PARTITIONS = 350,
-     TOKEN_PERCENT = 351,
-     TOKEN_PRECEDING = 352,
-     TOKEN_PRIMARY = 353,
-     TOKEN_PRIORITY = 354,
-     TOKEN_QUIT = 355,
-     TOKEN_RANGE = 356,
-     TOKEN_REAL = 357,
-     TOKEN_REFERENCES = 358,
-     TOKEN_RIGHT = 359,
-     TOKEN_ROW = 360,
-     TOKEN_ROW_DELIMITER = 361,
-     TOKEN_ROWS = 362,
-     TOKEN_SECOND = 363,
-     TOKEN_SELECT = 364,
-     TOKEN_SET = 365,
-     TOKEN_SMA = 366,
-     TOKEN_SMALLINT = 367,
-     TOKEN_SUBSTRING = 368,
-     TOKEN_TABLE = 369,
-     TOKEN_THEN = 370,
-     TOKEN_TIME = 371,
-     TOKEN_TIMESTAMP = 372,
-     TOKEN_TRUE = 373,
-     TOKEN_TUPLESAMPLE = 374,
-     TOKEN_UNBOUNDED = 375,
-     TOKEN_UNIQUE = 376,
-     TOKEN_UPDATE = 377,
-     TOKEN_USING = 378,
-     TOKEN_VALUES = 379,
-     TOKEN_VARCHAR = 380,
-     TOKEN_WHEN = 381,
-     TOKEN_WHERE = 382,
-     TOKEN_WINDOW = 383,
-     TOKEN_WITH = 384,
-     TOKEN_YEAR = 385,
-     TOKEN_YEARMONTH = 386,
-     TOKEN_EOF = 387,
-     TOKEN_LEX_ERROR = 388
-   };
+  enum yytokentype
+  {
+    TOKEN_COMMAND = 258,
+    TOKEN_NAME = 259,
+    TOKEN_STRING_SINGLE_QUOTED = 260,
+    TOKEN_STRING_DOUBLE_QUOTED = 261,
+    TOKEN_UNSIGNED_NUMVAL = 262,
+    TOKEN_OR = 263,
+    TOKEN_AND = 264,
+    TOKEN_NOT = 265,
+    TOKEN_EQ = 266,
+    TOKEN_LT = 267,
+    TOKEN_LEQ = 268,
+    TOKEN_GT = 269,
+    TOKEN_GEQ = 270,
+    TOKEN_NEQ = 271,
+    TOKEN_LIKE = 272,
+    TOKEN_REGEXP = 273,
+    TOKEN_BETWEEN = 274,
+    TOKEN_IS = 275,
+    UNARY_PLUS = 276,
+    UNARY_MINUS = 277,
+    TOKEN_ADD = 278,
+    TOKEN_ALL = 279,
+    TOKEN_ALTER = 280,
+    TOKEN_AS = 281,
+    TOKEN_ASC = 282,
+    TOKEN_BIGINT = 283,
+    TOKEN_BIT = 284,
+    TOKEN_BITWEAVING = 285,
+    TOKEN_BLOCKPROPERTIES = 286,
+    TOKEN_BLOCKSAMPLE = 287,
+    TOKEN_BLOOM_FILTER = 288,
+    TOKEN_CSB_TREE = 289,
+    TOKEN_BY = 290,
+    TOKEN_CASE = 291,
+    TOKEN_CHARACTER = 292,
+    TOKEN_CHECK = 293,
+    TOKEN_COLUMN = 294,
+    TOKEN_CONSTRAINT = 295,
+    TOKEN_COPY = 296,
+    TOKEN_CREATE = 297,
+    TOKEN_CURRENT = 298,
+    TOKEN_DATE = 299,
+    TOKEN_DATETIME = 300,
+    TOKEN_DAY = 301,
+    TOKEN_DECIMAL = 302,
+    TOKEN_DEFAULT = 303,
+    TOKEN_DELETE = 304,
+    TOKEN_DELIMITER = 305,
+    TOKEN_DESC = 306,
+    TOKEN_DISTINCT = 307,
+    TOKEN_DOUBLE = 308,
+    TOKEN_DROP = 309,
+    TOKEN_ELSE = 310,
+    TOKEN_END = 311,
+    TOKEN_ESCAPE_STRINGS = 312,
+    TOKEN_EXISTS = 313,
+    TOKEN_EXTRACT = 314,
+    TOKEN_FALSE = 315,
+    TOKEN_FIRST = 316,
+    TOKEN_FLOAT = 317,
+    TOKEN_FOLLOWING = 318,
+    TOKEN_FOR = 319,
+    TOKEN_FOREIGN = 320,
+    TOKEN_FROM = 321,
+    TOKEN_FULL = 322,
+    TOKEN_GROUP = 323,
+    TOKEN_HASH = 324,
+    TOKEN_HAVING = 325,
+    TOKEN_HOUR = 326,
+    TOKEN_IN = 327,
+    TOKEN_INDEX = 328,
+    TOKEN_INNER = 329,
+    TOKEN_INSERT = 330,
+    TOKEN_INTEGER = 331,
+    TOKEN_INTERVAL = 332,
+    TOKEN_INTO = 333,
+    TOKEN_JOIN = 334,
+    TOKEN_KEY = 335,
+    TOKEN_LAST = 336,
+    TOKEN_LEFT = 337,
+    TOKEN_LIMIT = 338,
+    TOKEN_LONG = 339,
+    TOKEN_MINUTE = 340,
+    TOKEN_MONTH = 341,
+    TOKEN_NULL = 342,
+    TOKEN_NULLS = 343,
+    TOKEN_OFF = 344,
+    TOKEN_ON = 345,
+    TOKEN_ORDER = 346,
+    TOKEN_OUTER = 347,
+    TOKEN_OVER = 348,
+    TOKEN_PARTITION = 349,
+    TOKEN_PARTITIONS = 350,
+    TOKEN_PERCENT = 351,
+    TOKEN_PRECEDING = 352,
+    TOKEN_PRIMARY = 353,
+    TOKEN_PRIORITY = 354,
+    TOKEN_QUIT = 355,
+    TOKEN_RANGE = 356,
+    TOKEN_REAL = 357,
+    TOKEN_REFERENCES = 358,
+    TOKEN_RIGHT = 359,
+    TOKEN_ROW = 360,
+    TOKEN_ROW_DELIMITER = 361,
+    TOKEN_ROWS = 362,
+    TOKEN_SECOND = 363,
+    TOKEN_SELECT = 364,
+    TOKEN_SET = 365,
+    TOKEN_SMA = 366,
+    TOKEN_SMALLINT = 367,
+    TOKEN_SUBSTRING = 368,
+    TOKEN_TABLE = 369,
+    TOKEN_THEN = 370,
+    TOKEN_TIME = 371,
+    TOKEN_TIMESTAMP = 372,
+    TOKEN_TRUE = 373,
+    TOKEN_TUPLESAMPLE = 374,
+    TOKEN_UNBOUNDED = 375,
+    TOKEN_UNIQUE = 376,
+    TOKEN_UPDATE = 377,
+    TOKEN_USING = 378,
+    TOKEN_VALUES = 379,
+    TOKEN_VARCHAR = 380,
+    TOKEN_WHEN = 381,
+    TOKEN_WHERE = 382,
+    TOKEN_WINDOW = 383,
+    TOKEN_WITH = 384,
+    TOKEN_YEAR = 385,
+    TOKEN_YEARMONTH = 386,
+    TOKEN_EOF = 387,
+    TOKEN_LEX_ERROR = 388
+  };
 #endif
 
-
+/* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
+
+union YYSTYPE
 {
-/* Line 387 of yacc.c  */
-#line 120 "../SqlParser.ypp"
+#line 120 "../SqlParser.ypp" /* yacc.c:355  */
 
   quickstep::ParseString *string_value_;
 
@@ -432,55 +426,42 @@ typedef union YYSTYPE
 
   quickstep::ParsePriority *opt_priority_clause_;
 
+#line 430 "SqlParser_gen.cpp" /* yacc.c:355  */
+};
 
-/* Line 387 of yacc.c  */
-#line 438 "SqlParser_gen.cpp"
-} YYSTYPE;
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
 # define YYSTYPE_IS_DECLARED 1
 #endif
 
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
 
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int quickstep_yyparse (void *YYPARSE_PARAM);
-#else
-int quickstep_yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
+
 int quickstep_yyparse (yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement);
-#else
-int quickstep_yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 #endif /* !YY_QUICKSTEP_YY_SQLPARSER_GEN_HPP_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
-/* Line 390 of yacc.c  */
-#line 220 "../SqlParser.ypp"
+#line 220 "../SqlParser.ypp" /* yacc.c:358  */
 
 /* This header needs YYSTYPE, which is defined by the %union directive above */
 #include "SqlLexer_gen.hpp"
 void NotSupported(const YYLTYPE *location, yyscan_t yyscanner, const std::string &feature);
 
-/* Line 390 of yacc.c  */
-#line 484 "SqlParser_gen.cpp"
+#line 465 "SqlParser_gen.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -494,11 +475,8 @@ typedef unsigned char yytype_uint8;
 
 #ifdef YYTYPE_INT8
 typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-typedef signed char yytype_int8;
 #else
-typedef short int yytype_int8;
+typedef signed char yytype_int8;
 #endif
 
 #ifdef YYTYPE_UINT16
@@ -518,8 +496,7 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif ! defined YYSIZE_T
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
@@ -541,6 +518,33 @@ typedef short int yytype_int16;
 # endif
 #endif
 
+#ifndef YY_ATTRIBUTE
+# if (defined __GNUC__                                               \
+      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
+     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
+#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+# else
+#  define YY_ATTRIBUTE(Spec) /* empty */
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_PURE
+# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
+#endif
+
+#if !defined _Noreturn \
+     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
+# if defined _MSC_VER && 1200 <= _MSC_VER
+#  define _Noreturn __declspec (noreturn)
+# else
+#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+# endif
+#endif
+
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
 # define YYUSE(E) ((void) (E))
@@ -548,23 +552,25 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(N) (N)
+#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int yyi)
-#else
-static int
-YYID (yyi)
-    int yyi;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return yyi;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -583,8 +589,7 @@ YYID (yyi)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
       /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
 #     ifndef EXIT_SUCCESS
@@ -596,8 +601,8 @@ YYID (yyi)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -613,7 +618,7 @@ YYID (yyi)
 #  endif
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
@@ -621,15 +626,13 @@ YYID (yyi)
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
@@ -639,8 +642,8 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-	     && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
+             && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
@@ -666,16 +669,16 @@ union yyalloc
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYSIZE_T yynewbytes;                                            \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / sizeof (*yyptr);                          \
+      }                                                                 \
+    while (0)
 
 #endif
 
@@ -694,7 +697,7 @@ union yyalloc
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
-      while (YYID (0))
+      while (0)
 #  endif
 # endif
 #endif /* !YYCOPY_NEEDED */
@@ -710,17 +713,19 @@ union yyalloc
 #define YYNNTS  107
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  289
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  536
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
+   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   388
 
-#define YYTRANSLATE(YYX)						\
+#define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, without out-of-bounds checking.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -765,139 +770,7 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint16 yyprhs[] =
-{
-       0,     0,     3,     6,     9,    12,    15,    17,    19,    21,
-      23,    25,    27,    29,    31,    33,    35,    37,    39,    41,
-      48,    55,    62,    69,    79,    89,    93,    97,    99,   103,
-     105,   107,   109,   111,   113,   115,   117,   119,   121,   123,
-     125,   127,   129,   131,   134,   137,   142,   147,   149,   152,
-     154,   157,   160,   165,   171,   174,   176,   177,   179,   184,
-     190,   201,   206,   210,   212,   213,   215,   216,   220,   221,
-     227,   228,   237,   239,   241,   243,   247,   249,   251,   253,
-     256,   259,   264,   267,   269,   271,   273,   275,   276,   280,
-     291,   299,   304,   310,   316,   317,   322,   325,   328,   333,
-     338,   344,   349,   353,   355,   359,   362,   366,   367,   371,
-     374,   376,   380,   384,   395,   396,   398,   400,   402,   404,
-     406,   410,   414,   417,   419,   422,   426,   427,   431,   435,
-     436,   438,   440,   443,   445,   448,   450,   453,   460,   462,
-     465,   469,   472,   475,   477,   481,   483,   486,   488,   493,
-     495,   499,   500,   504,   505,   508,   509,   513,   514,   517,
-     518,   520,   522,   525,   532,   536,   537,   541,   542,   546,
-     547,   553,   555,   557,   560,   563,   566,   569,   572,   575,
-     577,   581,   585,   586,   588,   590,   591,   594,   597,   598,
-     600,   603,   607,   609,   613,   615,   618,   620,   626,   633,
-     638,   642,   646,   650,   653,   657,   663,   668,   675,   679,
-     681,   685,   687,   690,   692,   694,   696,   698,   702,   708,
-     710,   712,   714,   718,   720,   724,   729,   734,   740,   747,
-     754,   763,   769,   774,   776,   779,   784,   786,   789,   794,
-     795,   798,   800,   804,   806,   808,   811,   814,   816,   819,
-     823,   826,   828,   830,   832,   834,   836,   838,   840,   844,
-     846,   850,   852,   856,   858,   860,   862,   864,   866,   868,
-     870,   873,   875,   878,   880,   882,   884,   886,   888,   890,
-     892,   896,   898,   900,   902,   904,   906,   908,   911,   914
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int16 yyrhs[] =
-{
-     146,     0,    -1,   147,   139,    -1,   147,   137,    -1,   250,
-     140,    -1,   250,   137,    -1,     1,    -1,   137,    -1,   149,
-      -1,   174,    -1,   150,    -1,   151,    -1,   178,    -1,   152,
-      -1,   173,    -1,   148,    -1,   181,    -1,   177,    -1,   105,
-      -1,    30,   119,   248,    28,    44,   153,    -1,    30,   119,
-     248,    28,    45,   159,    -1,    30,   119,   248,    59,    44,
-     248,    -1,    30,   119,   248,    59,    45,   248,    -1,    47,
-     119,   248,   141,   154,   142,   161,   163,   164,    -1,    47,
-      78,   248,    95,   248,   162,   128,   171,   172,    -1,    59,
-     119,   248,    -1,   248,   155,   158,    -1,   153,    -1,   154,
-     143,   153,    -1,    34,    -1,    49,    -1,    50,    -1,   121,
-      -1,   122,    -1,    52,    -1,   107,    -1,    58,    -1,    67,
-      -1,   117,    -1,    81,    -1,    33,    -1,    89,    -1,    82,
-      -1,    50,    82,    -1,   136,    82,    -1,    42,   141,     7,
-     142,    -1,   130,   141,     7,   142,    -1,    92,    -1,    10,
-      92,    -1,   126,    -1,   103,    85,    -1,    53,   238,    -1,
-      43,   141,   220,   142,    -1,   108,   248,   141,   248,   142,
-      -1,   157,   156,    -1,   156,    -1,    -1,   157,    -1,   126,
-     141,   247,   142,    -1,   103,    85,   141,   247,   142,    -1,
-      70,    85,   141,   247,   142,   108,   248,   141,   247,   142,
-      -1,    43,   141,   220,   142,    -1,   160,   143,   159,    -1,
-     159,    -1,    -1,   160,    -1,    -1,   141,   242,   142,    -1,
-      -1,   134,    36,   141,   166,   142,    -1,    -1,    99,    40,
-     165,   141,   247,   142,   100,     7,    -1,    74,    -1,   106,
-      -1,   167,    -1,   166,   143,   167,    -1,   168,    -1,   169,
-      -1,   170,    -1,   248,   248,    -1,   248,    29,    -1,   248,
-     141,   247,   142,    -1,   248,     7,    -1,    35,    -1,    38,
-      -1,    39,    -1,   116,    -1,    -1,   141,   166,   142,    -1,
-      80,    83,   248,   141,   247,   142,   129,   141,   240,   142,
-      -1,    80,    83,   248,   129,   141,   240,   142,    -1,    80,
-      83,   248,   186,    -1,   183,    80,    83,   248,   186,    -1,
-      46,   248,    71,     5,   175,    -1,    -1,   134,   141,   176,
-     142,    -1,    55,     5,    -1,    62,   249,    -1,   176,   143,
-      55,     5,    -1,   176,   143,    62,   249,    -1,   127,   248,
-     115,   179,   218,    -1,    54,    71,   248,   218,    -1,   179,
-     143,   180,    -1,   180,    -1,   248,    11,   224,    -1,   186,
-     182,    -1,   183,   186,   182,    -1,    -1,   134,   104,     7,
-      -1,   134,   184,    -1,   185,    -1,   184,   143,   185,    -1,
-     198,    31,   192,    -1,   114,   187,   188,   191,   218,   200,
-     201,   202,   203,   204,    -1,    -1,    29,    -1,    57,    -1,
-      23,    -1,   189,    -1,   190,    -1,   189,   143,   190,    -1,
-     224,    31,   248,    -1,   224,   248,    -1,   224,    -1,    71,
-     199,    -1,   141,   186,   142,    -1,    -1,    37,     7,   101,
-      -1,   124,     7,   101,    -1,    -1,    79,    -1,    87,    -1,
-      87,    97,    -1,   109,    -1,   109,    97,    -1,    72,    -1,
-      72,    97,    -1,   195,   194,    84,   196,    95,   220,    -1,
-     196,    -1,   192,   197,    -1,   248,   193,   197,    -1,   248,
-     193,    -1,   228,   197,    -1,   228,    -1,   141,   195,   142,
-      -1,   198,    -1,    31,   198,    -1,   248,    -1,   248,   141,
-     247,   142,    -1,   195,    -1,   199,   143,   195,    -1,    -1,
-      73,    40,   237,    -1,    -1,    75,   220,    -1,    -1,    96,
-      40,   214,    -1,    -1,    88,     7,    -1,    -1,   205,    -1,
-     206,    -1,   205,   206,    -1,   133,   248,    31,   141,   207,
-     142,    -1,   208,   209,   210,    -1,    -1,    99,    40,   237,
-      -1,    -1,    96,    40,   214,    -1,    -1,   211,    19,   212,
-       9,   213,    -1,   112,    -1,   106,    -1,     7,   102,    -1,
-     125,   102,    -1,    48,   110,    -1,     7,    68,    -1,   125,
-      68,    -1,    48,   110,    -1,   215,    -1,   214,   143,   215,
-      -1,   224,   216,   217,    -1,    -1,    32,    -1,    56,    -1,
-      -1,    93,    66,    -1,    93,    86,    -1,    -1,   219,    -1,
-     132,   220,    -1,   220,     8,   221,    -1,   221,    -1,   221,
-       9,   222,    -1,   222,    -1,    10,   223,    -1,   223,    -1,
-     224,    19,   224,     9,   224,    -1,   224,    10,    19,   224,
-       9,   224,    -1,   241,    20,    10,    92,    -1,   241,    20,
-      92,    -1,   224,   243,   224,    -1,   141,   220,   142,    -1,
-      63,   192,    -1,   224,    77,   192,    -1,   224,    77,   141,
-     237,   142,    -1,   224,    10,    77,   192,    -1,   224,    10,
-      77,   141,   237,   142,    -1,   224,   245,   225,    -1,   225,
-      -1,   225,   246,   226,    -1,   226,    -1,   244,   227,    -1,
-     227,    -1,   241,    -1,   238,    -1,   228,    -1,   228,    98,
-     248,    -1,   228,    98,   141,   207,   142,    -1,   229,    -1,
-     230,    -1,   231,    -1,   141,   224,   142,    -1,   192,    -1,
-     248,   141,   142,    -1,   248,   141,    23,   142,    -1,   248,
-     141,   237,   142,    -1,   248,   141,    57,   237,   142,    -1,
-      64,   141,   239,    71,   224,   142,    -1,   118,   141,   224,
-      71,     7,   142,    -1,   118,   141,   224,    71,     7,    69,
-       7,   142,    -1,    41,   224,   232,   236,    61,    -1,    41,
-     234,   236,    61,    -1,   233,    -1,   232,   233,    -1,   131,
-     224,   120,   224,    -1,   235,    -1,   234,   235,    -1,   131,
-     220,   120,   224,    -1,    -1,    60,   224,    -1,   224,    -1,
-     237,   143,   224,    -1,    92,    -1,     7,    -1,    21,     7,
-      -1,    22,     7,    -1,     5,    -1,    82,     5,    -1,    82,
-       5,   239,    -1,   155,     5,    -1,   135,    -1,    91,    -1,
-      51,    -1,    76,    -1,    90,    -1,   113,    -1,   238,    -1,
-     240,   143,   238,    -1,   248,    -1,   248,    27,   248,    -1,
-     241,    -1,   242,   143,   241,    -1,    11,    -1,    12,    -1,
-      16,    -1,    15,    -1,    14,    -1,    13,    -1,    18,    -1,
-      10,    18,    -1,    17,    -1,    10,    17,    -1,    22,    -1,
-      21,    -1,    22,    -1,   144,    -1,    23,    -1,    24,    -1,
-     248,    -1,   247,   143,   248,    -1,     4,    -1,     6,    -1,
-     123,    -1,    95,    -1,    65,    -1,    94,    -1,     3,   251,
-      -1,   251,     3,    -1,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
+  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
        0,   629,   629,   633,   637,   641,   645,   648,   655,   658,
@@ -940,9 +813,9 @@ static const char *const yytname[] =
   "$end", "error", "$undefined", "TOKEN_COMMAND", "TOKEN_NAME",
   "TOKEN_STRING_SINGLE_QUOTED", "TOKEN_STRING_DOUBLE_QUOTED",
   "TOKEN_UNSIGNED_NUMVAL", "TOKEN_OR", "TOKEN_AND", "TOKEN_NOT",
-  "TOKEN_EQ", "TOKEN_NEQ", "TOKEN_GEQ", "TOKEN_GT", "TOKEN_LEQ",
-  "TOKEN_LT", "TOKEN_REGEXP", "TOKEN_LIKE", "TOKEN_BETWEEN", "TOKEN_IS",
-  "'+'", "'-'", "'*'", "'/'", "UNARY_MINUS", "UNARY_PLUS", "'.'",
+  "TOKEN_EQ", "TOKEN_LT", "TOKEN_LEQ", "TOKEN_GT", "TOKEN_GEQ",
+  "TOKEN_NEQ", "TOKEN_LIKE", "TOKEN_REGEXP", "TOKEN_BETWEEN", "TOKEN_IS",
+  "'+'", "'-'", "'*'", "'/'", "UNARY_PLUS", "UNARY_MINUS", "'.'",
   "TOKEN_ADD", "TOKEN_ALL", "TOKEN_ALTER", "TOKEN_AS", "TOKEN_ASC",
   "TOKEN_BIGINT", "TOKEN_BIT", "TOKEN_BITWEAVING", "TOKEN_BLOCKPROPERTIES",
   "TOKEN_BLOCKSAMPLE", "TOKEN_BLOOM_FILTER", "TOKEN_CSB_TREE", "TOKEN_BY",
@@ -1004,13 +877,13 @@ static const char *const yytname[] =
   "literal_value_commalist", "attribute_ref", "attribute_ref_list",
   "comparison_operation", "unary_operation", "add_operation",
   "multiply_operation", "name_commalist", "any_name", "boolean_value",
-  "command", "command_argument_list", YY_NULL
+  "command", "command_argument_list", YY_NULLPTR
 };
 #endif
 
 # ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
+/* YYTOKNUM[NUM] -- (External) token number corresponding to the
+   (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
@@ -1031,154 +904,18 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,   145,   146,   146,   146,   146,   146,   146,   147,   147,
-     147,   147,   147,   147,   147,   147,   147,   147,   148,   149,
-     149,   149,   149,   150,   151,   152,   153,   154,   154,   155,
-     155,   155,   155,   155,   155,   155,   155,   155,   155,   155,
-     155,   155,   155,   155,   155,   155,   155,   156,   156,   156,
-     156,   156,   156,   156,   157,   157,   158,   158,   159,   159,
-     159,   159,   160,   160,   161,   161,   162,   162,   163,   163,
-     164,   164,   165,   165,   166,   166,   167,   167,   167,   168,
-     168,   169,   170,   171,   171,   171,   171,   172,   172,   173,
-     173,   173,   173,   174,   175,   175,   176,   176,   176,   176,
-     177,   178,   179,   179,   180,   181,   181,   182,   182,   183,
-     184,   184,   185,   186,   187,   187,   187,   188,   188,   189,
-     189,   190,   190,   190,   191,   192,   193,   193,   193,   194,
-     194,   194,   194,   194,   194,   194,   194,   195,   195,   196,
-     196,   196,   196,   196,   196,   197,   197,   198,   198,   199,
-     199,   200,   200,   201,   201,   202,   202,   203,   203,   204,
-     204,   205,   205,   206,   207,   208,   208,   209,   209,   210,
-     210,   211,   211,   212,   212,   212,   213,   213,   213,   214,
-     214,   215,   216,   216,   216,   217,   217,   217,   218,   218,
-     219,   220,   220,   221,   221,   222,   222,   223,   223,   223,
-     223,   223,   223,   223,   223,   223,   223,   223,   224,   224,
-     225,   225,   226,   226,   227,   227,   227,   227,   227,   227,
-     227,   227,   227,   227,   228,   228,   228,   228,   229,   230,
-     230,   231,   231,   232,   232,   233,   234,   234,   235,   236,
-     236,   237,   237,   238,   238,   238,   238,   238,   238,   238,
-     238,   239,   239,   239,   239,   239,   239,   240,   240,   241,
-     241,   242,   242,   243,   243,   243,   243,   243,   243,   243,
-     243,   243,   243,   244,   245,   245,   246,   246,   246,   247,
-     247,   248,   248,   249,   249,   249,   249,   250,   251,   251
-};
-
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     2,     2,     2,     2,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     6,
-       6,     6,     6,     9,     9,     3,     3,     1,     3,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     2,     2,     4,     4,     1,     2,     1,
-       2,     2,     4,     5,     2,     1,     0,     1,     4,     5,
-      10,     4,     3,     1,     0,     1,     0,     3,     0,     5,
-       0,     8,     1,     1,     1,     3,     1,     1,     1,     2,
-       2,     4,     2,     1,     1,     1,     1,     0,     3,    10,
-       7,     4,     5,     5,     0,     4,     2,     2,     4,     4,
-       5,     4,     3,     1,     3,     2,     3,     0,     3,     2,
-       1,     3,     3,    10,     0,     1,     1,     1,     1,     1,
-       3,     3,     2,     1,     2,     3,     0,     3,     3,     0,
-       1,     1,     2,     1,     2,     1,     2,     6,     1,     2,
-       3,     2,     2,     1,     3,     1,     2,     1,     4,     1,
-       3,     0,     3,     0,     2,     0,     3,     0,     2,     0,
-       1,     1,     2,     6,     3,     0,     3,     0,     3,     0,
-       5,     1,     1,     2,     2,     2,     2,     2,     2,     1,
-       3,     3,     0,     1,     1,     0,     2,     2,     0,     1,
-       2,     3,     1,     3,     1,     2,     1,     5,     6,     4,
-       3,     3,     3,     2,     3,     5,     4,     6,     3,     1,
-       3,     1,     2,     1,     1,     1,     1,     3,     5,     1,
-       1,     1,     3,     1,     3,     4,     4,     5,     6,     6,
-       8,     5,     4,     1,     2,     4,     1,     2,     4,     0,
-       2,     1,     3,     1,     1,     2,     2,     1,     2,     3,
-       2,     1,     1,     1,     1,     1,     1,     1,     3,     1,
-       3,     1,     3,     1,     1,     1,     1,     1,     1,     1,
-       2,     1,     2,     1,     1,     1,     1,     1,     1,     1,
-       3,     1,     1,     1,     1,     1,     1,     2,     2,     0
-};
-
-/* YYDEFACT[STATE-NAME] -- Default reduction number in state STATE-NUM.
-   Performed when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint16 yydefact[] =
-{
-       0,     6,   289,     0,     0,     0,     0,     0,     0,    18,
-     114,     0,     0,     7,     0,     0,    15,     8,    10,    11,
-      13,    14,     9,    17,    12,    16,     0,   107,     0,   287,
-       0,   281,   282,     0,     0,     0,     0,     0,     0,   115,
-     116,     0,     0,   109,   110,     0,   147,     1,     3,     2,
-       0,   107,     0,   105,     5,     4,   288,     0,     0,     0,
-       0,   188,    25,     0,   247,   244,     0,   273,   117,    40,
-      29,     0,     0,    30,    31,    34,    36,     0,    37,    39,
-       0,    41,   243,    35,    38,     0,    32,    33,     0,     0,
-       0,     0,     0,   118,   119,   223,   123,   209,   211,   213,
-     216,   219,   220,   221,   215,   214,     0,   259,     0,     0,
-       0,     0,     0,   106,     0,     0,     0,    94,     0,     0,
-       0,   101,   189,     0,     0,    91,   245,   246,     0,     0,
-     239,   236,     0,    43,     0,   248,     0,     0,    44,     0,
-       0,   250,     0,   188,     0,   274,   275,     0,     0,   122,
-     277,   278,   276,     0,     0,     0,   212,     0,     0,   188,
-     103,     0,   111,     0,   112,     0,   279,     0,   108,     0,
-       0,     0,     0,     0,    93,    66,    27,     0,     0,     0,
-       0,     0,   190,   192,   194,   196,     0,   214,     0,     0,
-       0,     0,   239,   233,     0,   237,     0,     0,   253,   254,
-     255,   252,   256,   251,     0,   249,     0,     0,   125,   222,
-       0,     0,   149,   138,   124,   143,   126,   151,   120,   121,
-     208,   210,   165,   217,   260,     0,     0,   224,   241,     0,
-       0,   100,     0,   148,     0,    92,    19,     0,     0,     0,
-       0,    20,    21,    22,     0,     0,     0,    64,     0,    42,
-      56,   195,   203,     0,     0,     0,     0,     0,   263,   264,
-     268,   267,   266,   265,   271,   269,     0,     0,     0,     0,
-     257,     0,     0,     0,     0,   234,     0,   240,   232,    45,
-       0,     0,    46,   129,     0,   139,   145,   135,   130,   131,
-     133,     0,     0,   142,     0,     0,   141,     0,   153,     0,
-       0,   167,   225,     0,   226,     0,   102,   104,   280,     0,
-       0,     0,     0,     0,     0,     0,   261,     0,   259,     0,
-      63,    65,    68,    28,     0,     0,     0,    47,     0,     0,
-      49,    55,    57,    26,   202,   191,   193,   272,   270,     0,
-       0,     0,     0,   204,   201,     0,   200,    90,     0,     0,
-     238,     0,   231,     0,     0,   144,   146,   136,   132,   134,
-       0,   150,     0,     0,   140,     0,     0,   155,     0,   218,
-       0,   169,   227,   242,     0,     0,     0,     0,    96,   285,
-     286,   284,   283,    97,    95,     0,    67,     0,    83,    84,
-      85,    86,    87,     0,     0,    70,    48,     0,    51,    50,
-       0,    54,     0,     0,   206,     0,     0,   199,   258,     0,
-     235,   228,     0,   229,     0,   127,   128,   152,   154,     0,
-     157,   166,     0,   172,   171,   164,     0,    61,     0,     0,
-      58,     0,     0,   262,     0,    24,    62,     0,     0,    23,
-       0,     0,     0,     0,   197,   205,     0,     0,     0,     0,
-       0,   159,   168,   179,   182,     0,     0,    59,    98,    99,
-       0,    74,    76,    77,    78,     0,     0,     0,    52,     0,
-     198,   207,    89,   230,   137,   156,   158,     0,   113,   160,
-     161,     0,   183,   184,   185,     0,     0,     0,     0,     0,
-      88,     0,    82,    80,     0,    79,     0,    72,    73,     0,
-      53,     0,   162,   180,     0,   181,   173,   175,   174,     0,
-       0,    75,     0,    69,     0,     0,   186,   187,     0,     0,
-       0,   170,     0,    81,     0,   165,   176,   178,   177,     0,
-       0,     0,    60,     0,   163,    71
-};
-
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
-{
-      -1,    14,    15,    16,    17,    18,    19,    20,   176,   177,
-      91,   331,   332,   333,   241,   321,   322,   246,   395,   439,
-     499,   460,   461,   462,   463,   464,   392,   435,    21,    22,
-     174,   315,    23,    24,   159,   160,    25,    53,    26,    43,
-      44,   139,    41,    92,    93,    94,   143,    95,   296,   291,
-     212,   213,   285,   286,   214,   298,   367,   420,   451,   478,
-     479,   480,   300,   301,   371,   425,   426,   488,   521,   452,
-     453,   484,   505,   121,   122,   182,   183,   184,   185,   186,
-      97,    98,    99,   100,   101,   102,   103,   192,   193,   130,
-     131,   196,   229,   104,   204,   271,   105,   317,   268,   106,
-     148,   153,   165,   107,   383,    28,    29
-};
-
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
 #define YYPACT_NINF -234
+
+#define yypact_value_is_default(Yystate) \
+  (!!((Yystate) == (-234)))
+
+#define YYTABLE_NINF -130
+
+#define yytable_value_is_error(Yytable_value) \
+  0
+
+  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+     STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
      168,  -234,  -234,   -58,   181,   -19,    40,   -37,    59,  -234,
@@ -1237,7 +974,68 @@ static const yytype_int16 yypact[] =
      411,   377,  -234,   505,  -234,  -234
 };
 
-/* YYPGOTO[NTERM-NUM].  */
+  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+     Performed when YYTABLE does not specify something else to do.  Zero
+     means the default is an error.  */
+static const yytype_uint16 yydefact[] =
+{
+       0,     6,   289,     0,     0,     0,     0,     0,     0,    18,
+     114,     0,     0,     7,     0,     0,    15,     8,    10,    11,
+      13,    14,     9,    17,    12,    16,     0,   107,     0,   287,
+       0,   281,   282,     0,     0,     0,     0,     0,     0,   115,
+     116,     0,     0,   109,   110,     0,   147,     1,     3,     2,
+       0,   107,     0,   105,     5,     4,   288,     0,     0,     0,
+       0,   188,    25,     0,   247,   244,     0,   273,   117,    40,
+      29,     0,     0,    30,    31,    34,    36,     0,    37,    39,
+       0,    41,   243,    35,    38,     0,    32,    33,     0,     0,
+       0,     0,     0,   118,   119,   223,   123,   209,   211,   213,
+     216,   219,   220,   221,   215,   214,     0,   259,     0,     0,
+       0,     0,     0,   106,     0,     0,     0,    94,     0,     0,
+       0,   101,   189,     0,     0,    91,   245,   246,     0,     0,
+     239,   236,     0,    43,     0,   248,     0,     0,    44,     0,
+       0,   250,     0,   188,     0,   274,   275,     0,     0,   122,
+     277,   278,   276,     0,     0,     0,   212,     0,     0,   188,
+     103,     0,   111,     0,   112,     0,   279,     0,   108,     0,
+       0,     0,     0,     0,    93,    66,    27,     0,     0,     0,
+       0,     0,   190,   192,   194,   196,     0,   214,     0,     0,
+       0,     0,   239,   233,     0,   237,     0,     0,   253,   254,
+     255,   252,   256,   251,     0,   249,     0,     0,   125,   222,
+       0,     0,   149,   138,   124,   143,   126,   151,   120,   121,
+     208,   210,   165,   217,   260,     0,     0,   224,   241,     0,
+       0,   100,     0,   148,     0,    92,    19,     0,     0,     0,
+       0,    20,    21,    22,     0,     0,     0,    64,     0,    42,
+      56,   195,   203,     0,     0,     0,     0,     0,   263,   265,
+     266,   267,   268,   264,   269,   271,     0,     0,     0,     0,
+     257,     0,     0,     0,     0,   234,     0,   240,   232,    45,
+       0,     0,    46,   129,     0,   139,   145,   135,   130,   131,
+     133,     0,     0,   142,     0,     0,   141,     0,   153,     0,
+       0,   167,   225,     0,   226,     0,   102,   104,   280,     0,
+       0,     0,     0,     0,     0,     0,   261,     0,   259,     0,
+      63,    65,    68,    28,     0,     0,     0,    47,     0,     0,
+      49,    55,    57,    26,   202,   191,   193,   270,   272,     0,
+       0,     0,     0,   204,   201,     0,   200,    90,     0,     0,
+     238,     0,   231,     0,     0,   144,   146,   136,   132,   134,
+       0,   150,     0,     0,   140,     0,     0,   155,     0,   218,
+       0,   169,   227,   242,     0,     0,     0,     0,    96,   285,
+     286,   284,   283,    97,    95,     0,    67,     0,    83,    84,
+      85,    86,    87,     0,     0,    70,    48,     0,    51,    50,
+       0,    54,     0,     0,   206,     0,     0,   199,   258,     0,
+     235,   228,     0,   229,     0,   127,   128,   152,   154,     0,
+     157,   166,     0,   172,   171,   164,     0,    61,     0,     0,
+      58,     0,     0,   262,     0,    24,    62,     0,     0,    23,
+       0,     0,     0,     0,   197,   205,     0,     0,     0,     0,
+       0,   159,   168,   179,   182,     0,     0,    59,    98,    99,
+       0,    74,    76,    77,    78,     0,     0,     0,    52,     0,
+     198,   207,    89,   230,   137,   156,   158,     0,   113,   160,
+     161,     0,   183,   184,   185,     0,     0,     0,     0,     0,
+      88,     0,    82,    80,     0,    79,     0,    72,    73,     0,
+      53,     0,   162,   180,     0,   181,   173,   175,   174,     0,
+       0,    75,     0,    69,     0,     0,   186,   187,     0,     0,
+       0,   170,     0,    81,     0,   165,   176,   178,   177,     0,
+       0,     0,    60,     0,   163,    71
+};
+
+  /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
     -234,  -234,  -234,  -234,  -234,  -234,  -234,  -234,   -94,  -234,
@@ -1253,10 +1051,25 @@ static const yytype_int16 yypgoto[] =
     -234,  -234,  -120,    -4,   120,  -234,  -234
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -130
+  /* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int16 yydefgoto[] =
+{
+      -1,    14,    15,    16,    17,    18,    19,    20,   176,   177,
+      91,   331,   332,   333,   241,   321,   322,   246,   395,   439,
+     499,   460,   461,   462,   463,   464,   392,   435,    21,    22,
+     174,   315,    23,    24,   159,   160,    25,    53,    26,    43,
+      44,   139,    41,    92,    93,    94,   143,    95,   296,   291,
+     212,   213,   285,   286,   214,   298,   367,   420,   451,   478,
+     479,   480,   300,   301,   371,   425,   426,   488,   521,   452,
+     453,   484,   505,   121,   122,   182,   183,   184,   185,   186,
+      97,    98,    99,   100,   101,   102,   103,   192,   193,   130,
+     131,   196,   229,   104,   204,   271,   105,   317,   268,   106,
+     148,   153,   165,   107,   383,    28,    29
+};
+
+  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+     positive, shift that token.  If negative, reduce the rule whose
+     number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
       33,   187,    45,   270,   189,   215,    96,    42,    46,   187,
@@ -1395,12 +1208,6 @@ static const yytype_int16 yytable[] =
        0,    86,    87,     0,     0,     0,     0,     0,     0,     0,
       88,     0,     0,     0,     0,     0,    89
 };
-
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-234)))
-
-#define yytable_value_is_error(Yytable_value) \
-  YYID (0)
 
 static const yytype_int16 yycheck[] =
 {
@@ -1541,8 +1348,8 @@ static const yytype_int16 yycheck[] =
      130,    -1,    -1,    -1,    -1,    -1,   136
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
+  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+     symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
        0,     1,     3,    30,    46,    47,    54,    59,    80,   105,
@@ -1601,30 +1408,84 @@ static const yytype_uint8 yystos[] =
      142,   207,   142,   100,   142,     7
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+static const yytype_uint8 yyr1[] =
+{
+       0,   145,   146,   146,   146,   146,   146,   146,   147,   147,
+     147,   147,   147,   147,   147,   147,   147,   147,   148,   149,
+     149,   149,   149,   150,   151,   152,   153,   154,   154,   155,
+     155,   155,   155,   155,   155,   155,   155,   155,   155,   155,
+     155,   155,   155,   155,   155,   155,   155,   156,   156,   156,
+     156,   156,   156,   156,   157,   157,   158,   158,   159,   159,
+     159,   159,   160,   160,   161,   161,   162,   162,   163,   163,
+     164,   164,   165,   165,   166,   166,   167,   167,   167,   168,
+     168,   169,   170,   171,   171,   171,   171,   172,   172,   173,
+     173,   173,   173,   174,   175,   175,   176,   176,   176,   176,
+     177,   178,   179,   179,   180,   181,   181,   182,   182,   183,
+     184,   184,   185,   186,   187,   187,   187,   188,   188,   189,
+     189,   190,   190,   190,   191,   192,   193,   193,   193,   194,
+     194,   194,   194,   194,   194,   194,   194,   195,   195,   196,
+     196,   196,   196,   196,   196,   197,   197,   198,   198,   199,
+     199,   200,   200,   201,   201,   202,   202,   203,   203,   204,
+     204,   205,   205,   206,   207,   208,   208,   209,   209,   210,
+     210,   211,   211,   212,   212,   212,   213,   213,   213,   214,
+     214,   215,   216,   216,   216,   217,   217,   217,   218,   218,
+     219,   220,   220,   221,   221,   222,   222,   223,   223,   223,
+     223,   223,   223,   223,   223,   223,   223,   223,   224,   224,
+     225,   225,   226,   226,   227,   227,   227,   227,   227,   227,
+     227,   227,   227,   227,   228,   228,   228,   228,   229,   230,
+     230,   231,   231,   232,   232,   233,   234,   234,   235,   236,
+     236,   237,   237,   238,   238,   238,   238,   238,   238,   238,
+     238,   239,   239,   239,   239,   239,   239,   240,   240,   241,
+     241,   242,   242,   243,   243,   243,   243,   243,   243,   243,
+     243,   243,   243,   244,   245,   245,   246,   246,   246,   247,
+     247,   248,   248,   249,   249,   249,   249,   250,   251,   251
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+static const yytype_uint8 yyr2[] =
+{
+       0,     2,     2,     2,     2,     2,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     6,
+       6,     6,     6,     9,     9,     3,     3,     1,     3,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     2,     2,     4,     4,     1,     2,     1,
+       2,     2,     4,     5,     2,     1,     0,     1,     4,     5,
+      10,     4,     3,     1,     0,     1,     0,     3,     0,     5,
+       0,     8,     1,     1,     1,     3,     1,     1,     1,     2,
+       2,     4,     2,     1,     1,     1,     1,     0,     3,    10,
+       7,     4,     5,     5,     0,     4,     2,     2,     4,     4,
+       5,     4,     3,     1,     3,     2,     3,     0,     3,     2,
+       1,     3,     3,    10,     0,     1,     1,     1,     1,     1,
+       3,     3,     2,     1,     2,     3,     0,     3,     3,     0,
+       1,     1,     2,     1,     2,     1,     2,     6,     1,     2,
+       3,     2,     2,     1,     3,     1,     2,     1,     4,     1,
+       3,     0,     3,     0,     2,     0,     3,     0,     2,     0,
+       1,     1,     2,     6,     3,     0,     3,     0,     3,     0,
+       5,     1,     1,     2,     2,     2,     2,     2,     2,     1,
+       3,     3,     0,     1,     1,     0,     2,     2,     0,     1,
+       2,     3,     1,     3,     1,     2,     1,     5,     6,     4,
+       3,     3,     3,     2,     3,     5,     4,     6,     3,     1,
+       3,     1,     2,     1,     1,     1,     1,     3,     5,     1,
+       1,     1,     3,     1,     3,     4,     4,     5,     6,     6,
+       8,     5,     4,     1,     2,     4,     1,     2,     4,     0,
+       2,     1,     3,     1,     1,     2,     2,     1,     2,     3,
+       2,     1,     1,     1,     1,     1,     1,     1,     3,     1,
+       3,     1,     3,     1,     1,     1,     1,     1,     1,     1,
+       2,     1,     2,     1,     1,     1,     1,     1,     1,     1,
+       3,     1,     1,     1,     1,     1,     1,     2,     2,     0
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+#define YYEMPTY         (-2)
+#define YYEOF           0
 
-#define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
@@ -1641,13 +1502,13 @@ do                                                              \
   else                                                          \
     {                                                           \
       yyerror (&yylloc, yyscanner, parsedStatement, YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+      YYERROR;                                                  \
+    }                                                           \
+while (0)
 
 /* Error token number */
-#define YYTERROR	1
-#define YYERRCODE	256
+#define YYTERROR        1
+#define YYERRCODE       256
 
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
@@ -1657,7 +1518,7 @@ while (YYID (0))
 #ifndef YYLLOC_DEFAULT
 # define YYLLOC_DEFAULT(Current, Rhs, N)                                \
     do                                                                  \
-      if (YYID (N))                                                     \
+      if (N)                                                            \
         {                                                               \
           (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
           (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
@@ -1671,10 +1532,25 @@ while (YYID (0))
           (Current).first_column = (Current).last_column =              \
             YYRHSLOC (Rhs, 0).last_column;                              \
         }                                                               \
-    while (YYID (0))
+    while (0)
 #endif
 
 #define YYRHSLOC(Rhs, K) ((Rhs)[K])
+
+
+/* Enable debugging if requested.  */
+#if YYDEBUG
+
+# ifndef YYFPRINTF
+#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYFPRINTF fprintf
+# endif
+
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
 /* YY_LOCATION_PRINT -- Print the location on the stream.
@@ -1686,36 +1562,28 @@ while (YYID (0))
 
 /* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
 
-__attribute__((__unused__))
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+YY_ATTRIBUTE_UNUSED
 static unsigned
 yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
-#else
-static unsigned
-yy_location_print_ (yyo, yylocp)
-    FILE *yyo;
-    YYLTYPE const * const yylocp;
-#endif
 {
   unsigned res = 0;
   int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
   if (0 <= yylocp->first_line)
     {
-      res += fprintf (yyo, "%d", yylocp->first_line);
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
       if (0 <= yylocp->first_column)
-        res += fprintf (yyo, ".%d", yylocp->first_column);
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
     }
   if (0 <= yylocp->last_line)
     {
       if (yylocp->first_line < yylocp->last_line)
         {
-          res += fprintf (yyo, "-%d", yylocp->last_line);
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
           if (0 <= end_col)
-            res += fprintf (yyo, ".%d", end_col);
+            res += YYFPRINTF (yyo, ".%d", end_col);
         }
       else if (0 <= end_col && yylocp->first_column < end_col)
-        res += fprintf (yyo, "-%d", end_col);
+        res += YYFPRINTF (yyo, "-%d", end_col);
     }
   return res;
  }
@@ -1729,77 +1597,37 @@ yy_location_print_ (yyo, yylocp)
 #endif
 
 
-/* YYLEX -- calling `yylex' with the right arguments.  */
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (&yylval, &yylloc, YYLEX_PARAM)
-#else
-# define YYLEX yylex (&yylval, &yylloc, yyscanner)
-#endif
-
-/* Enable debugging if requested.  */
-#if YYDEBUG
-
-# ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
-#  define YYFPRINTF fprintf
-# endif
-
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value, Location, yyscanner, parsedStatement); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Type, Value, Location, yyscanner, parsedStatement); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*----------------------------------------.
+| Print this symbol's value on YYOUTPUT.  |
+`----------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, yyscanner, parsedStatement)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-    yyscan_t yyscanner;
-    quickstep::ParseStatement **parsedStatement;
-#endif
 {
   FILE *yyo = yyoutput;
   YYUSE (yyo);
-  if (!yyvaluep)
-    return;
   YYUSE (yylocationp);
   YYUSE (yyscanner);
   YYUSE (parsedStatement);
+  if (!yyvaluep)
+    return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
     YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
 # endif
-  switch (yytype)
-    {
-      default:
-        break;
-    }
+  YYUSE (yytype);
 }
 
 
@@ -1807,25 +1635,11 @@ yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, yyscanner, parse
 | Print this symbol on YYOUTPUT.  |
 `--------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp, yyscanner, parsedStatement)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-    yyscan_t yyscanner;
-    quickstep::ParseStatement **parsedStatement;
-#endif
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyoutput, "%s %s (",
+             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyoutput, *yylocationp);
   YYFPRINTF (yyoutput, ": ");
@@ -1838,16 +1652,8 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp, yyscanner, parsedState
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
-#else
-static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
-#endif
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -1858,52 +1664,42 @@ yy_stack_print (yybottom, yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement)
-#else
-static void
-yy_reduce_print (yyvsp, yylsp, yyrule, yyscanner, parsedStatement)
-    YYSTYPE *yyvsp;
-    YYLTYPE *yylsp;
-    int yyrule;
-    yyscan_t yyscanner;
-    quickstep::ParseStatement **parsedStatement;
-#endif
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement)
 {
+  unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       , &(yylsp[(yyi + 1) - (yynrhs)])		       , yyscanner, parsedStatement);
+      yy_symbol_print (stderr,
+                       yystos[yyssp[yyi + 1 - yynrhs]],
+                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , yyscanner, parsedStatement);
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, yylsp, Rule, yyscanner, parsedStatement); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, yyscanner, parsedStatement); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
@@ -1917,7 +1713,7 @@ int yydebug;
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1940,15 +1736,8 @@ int yydebug;
 #   define yystrlen strlen
 #  else
 /* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static YYSIZE_T
 yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
 {
   YYSIZE_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
@@ -1964,16 +1753,8 @@ yystrlen (yystr)
 #  else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -2003,27 +1784,27 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            /* Fall through.  */
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
@@ -2046,11 +1827,11 @@ static int
 yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yytype_int16 *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULL, yytname[yytoken]);
+  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
   YYSIZE_T yysize = yysize0;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
-  const char *yyformat = YY_NULL;
+  const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat. */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Number of reported tokens (one for the "unexpected", one per
@@ -2058,10 +1839,6 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   int yycount = 0;
 
   /* There are many possibilities here to consider:
-     - Assume YYFAIL is not used.  It's too flawed to consider.  See
-       <http://lists.gnu.org/archive/html/bison-patches/2009-12/msg00024.html>
-       for details.  YYERROR is fine as it does not invoke this
-       function.
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
        is an error action.  In that case, don't check for expected
@@ -2111,7 +1888,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                   }
                 yyarg[yycount++] = yytname[yyx];
                 {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULL, yytname[yyx]);
+                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
                   if (! (yysize <= yysize1
                          && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
                     return 2;
@@ -2178,1175 +1955,1057 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep, yylocationp, yyscanner, parsedStatement)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-    YYLTYPE *yylocationp;
-    yyscan_t yyscanner;
-    quickstep::ParseStatement **parsedStatement;
-#endif
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
   YYUSE (yyscanner);
   YYUSE (parsedStatement);
-
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   switch (yytype)
     {
-      case 3: /* TOKEN_COMMAND */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+          case 3: /* TOKEN_COMMAND  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2218 "SqlParser_gen.cpp"
+}
+#line 1980 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 4: /* TOKEN_NAME */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 4: /* TOKEN_NAME  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2229 "SqlParser_gen.cpp"
+}
+#line 1990 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 5: /* TOKEN_STRING_SINGLE_QUOTED */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 5: /* TOKEN_STRING_SINGLE_QUOTED  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2240 "SqlParser_gen.cpp"
+}
+#line 2000 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 6: /* TOKEN_STRING_DOUBLE_QUOTED */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 6: /* TOKEN_STRING_DOUBLE_QUOTED  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2251 "SqlParser_gen.cpp"
+}
+#line 2010 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 7: /* TOKEN_UNSIGNED_NUMVAL */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 7: /* TOKEN_UNSIGNED_NUMVAL  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).numeric_literal_value_) != nullptr) {
     delete ((*yyvaluep).numeric_literal_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2262 "SqlParser_gen.cpp"
+}
+#line 2020 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 147: /* sql_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 147: /* sql_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).statement_) != nullptr) {
     delete ((*yyvaluep).statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2273 "SqlParser_gen.cpp"
+}
+#line 2030 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 148: /* quit_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 148: /* quit_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).quit_statement_) != nullptr) {
     delete ((*yyvaluep).quit_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2284 "SqlParser_gen.cpp"
+}
+#line 2040 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 149: /* alter_table_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 149: /* alter_table_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).statement_) != nullptr) {
     delete ((*yyvaluep).statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2295 "SqlParser_gen.cpp"
+}
+#line 2050 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 150: /* create_table_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 150: /* create_table_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).create_table_statement_) != nullptr) {
     delete ((*yyvaluep).create_table_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2306 "SqlParser_gen.cpp"
+}
+#line 2060 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 151: /* create_index_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 151: /* create_index_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).statement_) != nullptr) {
     delete ((*yyvaluep).statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2317 "SqlParser_gen.cpp"
+}
+#line 2070 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 152: /* drop_table_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 152: /* drop_table_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).drop_table_statement_) != nullptr) {
     delete ((*yyvaluep).drop_table_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2328 "SqlParser_gen.cpp"
+}
+#line 2080 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 153: /* column_def */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 153: /* column_def  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).attribute_definition_) != nullptr) {
     delete ((*yyvaluep).attribute_definition_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2339 "SqlParser_gen.cpp"
+}
+#line 2090 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 154: /* column_def_commalist */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 154: /* column_def_commalist  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).attribute_definition_list_) != nullptr) {
     delete ((*yyvaluep).attribute_definition_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2350 "SqlParser_gen.cpp"
+}
+#line 2100 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 155: /* data_type */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 155: /* data_type  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).data_type_) != nullptr) {
     delete ((*yyvaluep).data_type_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2361 "SqlParser_gen.cpp"
+}
+#line 2110 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 156: /* column_constraint_def */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 156: /* column_constraint_def  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).column_constraint_) != nullptr) {
     delete ((*yyvaluep).column_constraint_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2372 "SqlParser_gen.cpp"
+}
+#line 2120 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 157: /* column_constraint_def_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 157: /* column_constraint_def_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).column_constraint_list_) != nullptr) {
     delete ((*yyvaluep).column_constraint_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2383 "SqlParser_gen.cpp"
+}
+#line 2130 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 158: /* opt_column_constraint_def_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 158: /* opt_column_constraint_def_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).column_constraint_list_) != nullptr) {
     delete ((*yyvaluep).column_constraint_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2394 "SqlParser_gen.cpp"
+}
+#line 2140 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 162: /* opt_column_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 162: /* opt_column_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).attribute_list_) != nullptr) {
     delete ((*yyvaluep).attribute_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2405 "SqlParser_gen.cpp"
+}
+#line 2150 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 163: /* opt_block_properties */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 163: /* opt_block_properties  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).block_properties_) != nullptr) {
     delete ((*yyvaluep).block_properties_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2416 "SqlParser_gen.cpp"
+}
+#line 2160 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 164: /* opt_partition_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 164: /* opt_partition_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).partition_clause_) != nullptr) {
     delete ((*yyvaluep).partition_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2427 "SqlParser_gen.cpp"
+}
+#line 2170 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 165: /* partition_type */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 165: /* partition_type  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2438 "SqlParser_gen.cpp"
+}
+#line 2180 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 166: /* key_value_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 166: /* key_value_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).key_value_list_) != nullptr) {
     delete ((*yyvaluep).key_value_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2449 "SqlParser_gen.cpp"
+}
+#line 2190 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 167: /* key_value */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 167: /* key_value  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).key_value_) != nullptr) {
     delete ((*yyvaluep).key_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2460 "SqlParser_gen.cpp"
+}
+#line 2200 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 168: /* key_string_value */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 168: /* key_string_value  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).key_string_value_) != nullptr) {
     delete ((*yyvaluep).key_string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2471 "SqlParser_gen.cpp"
+}
+#line 2210 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 169: /* key_string_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 169: /* key_string_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).key_string_list_) != nullptr) {
     delete ((*yyvaluep).key_string_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2482 "SqlParser_gen.cpp"
+}
+#line 2220 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 170: /* key_integer_value */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 170: /* key_integer_value  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).key_integer_value_) != nullptr) {
     delete ((*yyvaluep).key_integer_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2493 "SqlParser_gen.cpp"
+}
+#line 2230 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 171: /* index_type */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 171: /* index_type  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2504 "SqlParser_gen.cpp"
+}
+#line 2240 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 172: /* opt_index_properties */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 172: /* opt_index_properties  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).key_value_list_) != nullptr) {
     delete ((*yyvaluep).key_value_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2515 "SqlParser_gen.cpp"
+}
+#line 2250 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 173: /* insert_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 173: /* insert_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).insert_statement_) != nullptr) {
     delete ((*yyvaluep).insert_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2526 "SqlParser_gen.cpp"
+}
+#line 2260 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 174: /* copy_from_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 174: /* copy_from_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).copy_from_statement_) != nullptr) {
     delete ((*yyvaluep).copy_from_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2537 "SqlParser_gen.cpp"
+}
+#line 2270 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 175: /* opt_copy_from_params */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 175: /* opt_copy_from_params  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).copy_from_params_) != nullptr) {
     delete ((*yyvaluep).copy_from_params_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2548 "SqlParser_gen.cpp"
+}
+#line 2280 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 176: /* copy_from_params */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 176: /* copy_from_params  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).copy_from_params_) != nullptr) {
     delete ((*yyvaluep).copy_from_params_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2559 "SqlParser_gen.cpp"
+}
+#line 2290 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 177: /* update_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 177: /* update_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).update_statement_) != nullptr) {
     delete ((*yyvaluep).update_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2570 "SqlParser_gen.cpp"
+}
+#line 2300 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 178: /* delete_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 178: /* delete_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).delete_statement_) != nullptr) {
     delete ((*yyvaluep).delete_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2581 "SqlParser_gen.cpp"
+}
+#line 2310 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 179: /* assignment_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 179: /* assignment_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).assignment_list_) != nullptr) {
     delete ((*yyvaluep).assignment_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2592 "SqlParser_gen.cpp"
+}
+#line 2320 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 180: /* assignment_item */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 180: /* assignment_item  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).assignment_) != nullptr) {
     delete ((*yyvaluep).assignment_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2603 "SqlParser_gen.cpp"
+}
+#line 2330 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 181: /* select_statement */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 181: /* select_statement  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).select_statement_) != nullptr) {
     delete ((*yyvaluep).select_statement_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2614 "SqlParser_gen.cpp"
+}
+#line 2340 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 182: /* opt_priority_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 182: /* opt_priority_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_priority_clause_) != nullptr) {
     delete ((*yyvaluep).opt_priority_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2625 "SqlParser_gen.cpp"
+}
+#line 2350 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 183: /* with_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 183: /* with_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).with_list_) != nullptr) {
     delete ((*yyvaluep).with_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2636 "SqlParser_gen.cpp"
+}
+#line 2360 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 184: /* with_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 184: /* with_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).with_list_) != nullptr) {
     delete ((*yyvaluep).with_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2647 "SqlParser_gen.cpp"
+}
+#line 2370 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 185: /* with_list_element */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 185: /* with_list_element  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).with_list_element_) != nullptr) {
     delete ((*yyvaluep).with_list_element_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2658 "SqlParser_gen.cpp"
+}
+#line 2380 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 186: /* select_query */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 186: /* select_query  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).select_query_) != nullptr) {
     delete ((*yyvaluep).select_query_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2669 "SqlParser_gen.cpp"
+}
+#line 2390 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 188: /* selection */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 188: /* selection  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).selection_) != nullptr) {
     delete ((*yyvaluep).selection_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2680 "SqlParser_gen.cpp"
+}
+#line 2400 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 189: /* selection_item_commalist */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 189: /* selection_item_commalist  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).selection_list_) != nullptr) {
     delete ((*yyvaluep).selection_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2691 "SqlParser_gen.cpp"
+}
+#line 2410 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 190: /* selection_item */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 190: /* selection_item  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).selection_item_) != nullptr) {
     delete ((*yyvaluep).selection_item_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2702 "SqlParser_gen.cpp"
+}
+#line 2420 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 191: /* from_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 191: /* from_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).table_reference_list_) != nullptr) {
     delete ((*yyvaluep).table_reference_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2713 "SqlParser_gen.cpp"
+}
+#line 2430 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 192: /* subquery_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 192: /* subquery_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).subquery_expression_) != nullptr) {
     delete ((*yyvaluep).subquery_expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2724 "SqlParser_gen.cpp"
+}
+#line 2440 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 193: /* opt_sample_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 193: /* opt_sample_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_sample_clause_) != nullptr) {
     delete ((*yyvaluep).opt_sample_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2735 "SqlParser_gen.cpp"
+}
+#line 2450 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 194: /* join_type */
-/* Line 1398 of yacc.c  */
-#line 618 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 2742 "SqlParser_gen.cpp"
+
+    case 194: /* join_type  */
+#line 618 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2456 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 195: /* joined_table_reference */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 195: /* joined_table_reference  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).table_reference_) != nullptr) {
     delete ((*yyvaluep).table_reference_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2753 "SqlParser_gen.cpp"
+}
+#line 2466 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 196: /* table_reference */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 196: /* table_reference  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).table_reference_) != nullptr) {
     delete ((*yyvaluep).table_reference_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2764 "SqlParser_gen.cpp"
+}
+#line 2476 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 197: /* table_reference_signature */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 197: /* table_reference_signature  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).table_reference_signature_) != nullptr) {
     delete ((*yyvaluep).table_reference_signature_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2775 "SqlParser_gen.cpp"
+}
+#line 2486 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 198: /* table_reference_signature_primary */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 198: /* table_reference_signature_primary  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).table_reference_signature_) != nullptr) {
     delete ((*yyvaluep).table_reference_signature_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2786 "SqlParser_gen.cpp"
+}
+#line 2496 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 199: /* joined_table_reference_commalist */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 199: /* joined_table_reference_commalist  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).table_reference_list_) != nullptr) {
     delete ((*yyvaluep).table_reference_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2797 "SqlParser_gen.cpp"
+}
+#line 2506 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 200: /* opt_group_by_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 200: /* opt_group_by_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_group_by_clause_) != nullptr) {
     delete ((*yyvaluep).opt_group_by_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2808 "SqlParser_gen.cpp"
+}
+#line 2516 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 201: /* opt_having_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 201: /* opt_having_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_having_clause_) != nullptr) {
     delete ((*yyvaluep).opt_having_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2819 "SqlParser_gen.cpp"
+}
+#line 2526 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 202: /* opt_order_by_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 202: /* opt_order_by_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_order_by_clause_) != nullptr) {
     delete ((*yyvaluep).opt_order_by_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2830 "SqlParser_gen.cpp"
+}
+#line 2536 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 203: /* opt_limit_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 203: /* opt_limit_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_limit_clause_) != nullptr) {
     delete ((*yyvaluep).opt_limit_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2841 "SqlParser_gen.cpp"
+}
+#line 2546 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 204: /* opt_window_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 204: /* opt_window_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_window_clause_) != nullptr) {
     delete ((*yyvaluep).opt_window_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2852 "SqlParser_gen.cpp"
+}
+#line 2556 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 205: /* window_declaration_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 205: /* window_declaration_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).opt_window_clause_) != nullptr) {
     delete ((*yyvaluep).opt_window_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2863 "SqlParser_gen.cpp"
+}
+#line 2566 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 206: /* window_declaration */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 206: /* window_declaration  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).window_definition_) != nullptr) {
     delete ((*yyvaluep).window_definition_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2874 "SqlParser_gen.cpp"
+}
+#line 2576 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 207: /* window_definition */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 207: /* window_definition  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).window_definition_) != nullptr) {
     delete ((*yyvaluep).window_definition_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2885 "SqlParser_gen.cpp"
+}
+#line 2586 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 208: /* opt_window_partition */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 208: /* opt_window_partition  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).window_partition_by_list_) != nullptr) {
     delete ((*yyvaluep).window_partition_by_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2896 "SqlParser_gen.cpp"
+}
+#line 2596 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 209: /* opt_window_order */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 209: /* opt_window_order  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).window_order_by_list_) != nullptr) {
     delete ((*yyvaluep).window_order_by_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2907 "SqlParser_gen.cpp"
+}
+#line 2606 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 210: /* opt_window_frame */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 210: /* opt_window_frame  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).window_frame_info_) != nullptr) {
     delete ((*yyvaluep).window_frame_info_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2918 "SqlParser_gen.cpp"
+}
+#line 2616 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 211: /* frame_mode */
-/* Line 1398 of yacc.c  */
-#line 614 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 2925 "SqlParser_gen.cpp"
+
+    case 211: /* frame_mode  */
+#line 614 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2622 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 212: /* frame_preceding */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 212: /* frame_preceding  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).numeric_literal_value_) != nullptr) {
     delete ((*yyvaluep).numeric_literal_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2936 "SqlParser_gen.cpp"
+}
+#line 2632 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 213: /* frame_following */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 213: /* frame_following  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).numeric_literal_value_) != nullptr) {
     delete ((*yyvaluep).numeric_literal_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2947 "SqlParser_gen.cpp"
+}
+#line 2642 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 214: /* order_commalist */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 214: /* order_commalist  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).order_commalist_) != nullptr) {
     delete ((*yyvaluep).order_commalist_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2958 "SqlParser_gen.cpp"
+}
+#line 2652 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 215: /* order_item */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 215: /* order_item  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).order_item_) != nullptr) {
     delete ((*yyvaluep).order_item_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2969 "SqlParser_gen.cpp"
+}
+#line 2662 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 216: /* opt_order_direction */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 216: /* opt_order_direction  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).order_direction_) != nullptr) {
     delete ((*yyvaluep).order_direction_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2980 "SqlParser_gen.cpp"
+}
+#line 2672 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 217: /* opt_nulls_first */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 217: /* opt_nulls_first  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).order_direction_) != nullptr) {
     delete ((*yyvaluep).order_direction_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 2991 "SqlParser_gen.cpp"
+}
+#line 2682 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 218: /* opt_where_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 218: /* opt_where_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).predicate_) != nullptr) {
     delete ((*yyvaluep).predicate_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3002 "SqlParser_gen.cpp"
+}
+#line 2692 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 219: /* where_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 219: /* where_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).predicate_) != nullptr) {
     delete ((*yyvaluep).predicate_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3013 "SqlParser_gen.cpp"
+}
+#line 2702 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 220: /* or_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 220: /* or_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).predicate_) != nullptr) {
     delete ((*yyvaluep).predicate_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3024 "SqlParser_gen.cpp"
+}
+#line 2712 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 221: /* and_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 221: /* and_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).predicate_) != nullptr) {
     delete ((*yyvaluep).predicate_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3035 "SqlParser_gen.cpp"
+}
+#line 2722 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 222: /* not_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 222: /* not_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).predicate_) != nullptr) {
     delete ((*yyvaluep).predicate_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3046 "SqlParser_gen.cpp"
+}
+#line 2732 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 223: /* predicate_expression_base */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 223: /* predicate_expression_base  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).predicate_) != nullptr) {
     delete ((*yyvaluep).predicate_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3057 "SqlParser_gen.cpp"
+}
+#line 2742 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 224: /* add_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 224: /* add_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3068 "SqlParser_gen.cpp"
+}
+#line 2752 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 225: /* multiply_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 225: /* multiply_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3079 "SqlParser_gen.cpp"
+}
+#line 2762 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 226: /* unary_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 226: /* unary_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3090 "SqlParser_gen.cpp"
+}
+#line 2772 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 227: /* expression_base */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 227: /* expression_base  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3101 "SqlParser_gen.cpp"
+}
+#line 2782 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 228: /* function_call */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 228: /* function_call  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).function_call_) != nullptr) {
     delete ((*yyvaluep).function_call_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3112 "SqlParser_gen.cpp"
+}
+#line 2792 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 229: /* extract_function */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 229: /* extract_function  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3123 "SqlParser_gen.cpp"
+}
+#line 2802 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 230: /* substr_function */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 230: /* substr_function  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3134 "SqlParser_gen.cpp"
+}
+#line 2812 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 231: /* case_expression */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 231: /* case_expression  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3145 "SqlParser_gen.cpp"
+}
+#line 2822 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 232: /* simple_when_clause_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 232: /* simple_when_clause_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).simple_when_clause_list_) != nullptr) {
     delete ((*yyvaluep).simple_when_clause_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3156 "SqlParser_gen.cpp"
+}
+#line 2832 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 233: /* simple_when_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 233: /* simple_when_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).simple_when_clause_) != nullptr) {
     delete ((*yyvaluep).simple_when_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3167 "SqlParser_gen.cpp"
+}
+#line 2842 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 234: /* searched_when_clause_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 234: /* searched_when_clause_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).searched_when_clause_list_) != nullptr) {
     delete ((*yyvaluep).searched_when_clause_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3178 "SqlParser_gen.cpp"
+}
+#line 2852 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 235: /* searched_when_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 235: /* searched_when_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).searched_when_clause_) != nullptr) {
     delete ((*yyvaluep).searched_when_clause_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3189 "SqlParser_gen.cpp"
+}
+#line 2862 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 236: /* opt_else_clause */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 236: /* opt_else_clause  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_) != nullptr) {
     delete ((*yyvaluep).expression_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3200 "SqlParser_gen.cpp"
+}
+#line 2872 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 237: /* expression_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 237: /* expression_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).expression_list_) != nullptr) {
     delete ((*yyvaluep).expression_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3211 "SqlParser_gen.cpp"
+}
+#line 2882 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 238: /* literal_value */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 238: /* literal_value  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).literal_value_) != nullptr) {
     delete ((*yyvaluep).literal_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3222 "SqlParser_gen.cpp"
+}
+#line 2892 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 239: /* datetime_unit */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 239: /* datetime_unit  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3233 "SqlParser_gen.cpp"
+}
+#line 2902 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 240: /* literal_value_commalist */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 240: /* literal_value_commalist  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).literal_value_list_) != nullptr) {
     delete ((*yyvaluep).literal_value_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3244 "SqlParser_gen.cpp"
+}
+#line 2912 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 241: /* attribute_ref */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 241: /* attribute_ref  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).attribute_) != nullptr) {
     delete ((*yyvaluep).attribute_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3255 "SqlParser_gen.cpp"
+}
+#line 2922 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 242: /* attribute_ref_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 242: /* attribute_ref_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).attribute_list_) != nullptr) {
     delete ((*yyvaluep).attribute_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3266 "SqlParser_gen.cpp"
+}
+#line 2932 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 243: /* comparison_operation */
-/* Line 1398 of yacc.c  */
-#line 615 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 3273 "SqlParser_gen.cpp"
+
+    case 243: /* comparison_operation  */
+#line 615 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2938 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 244: /* unary_operation */
-/* Line 1398 of yacc.c  */
-#line 616 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 3280 "SqlParser_gen.cpp"
+
+    case 244: /* unary_operation  */
+#line 616 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2944 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 245: /* add_operation */
-/* Line 1398 of yacc.c  */
-#line 617 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 3287 "SqlParser_gen.cpp"
+
+    case 245: /* add_operation  */
+#line 617 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2950 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 246: /* multiply_operation */
-/* Line 1398 of yacc.c  */
-#line 617 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 3294 "SqlParser_gen.cpp"
+
+    case 246: /* multiply_operation  */
+#line 617 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2956 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 247: /* name_commalist */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 247: /* name_commalist  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_list_) != nullptr) {
     delete ((*yyvaluep).string_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3305 "SqlParser_gen.cpp"
+}
+#line 2966 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 248: /* any_name */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 248: /* any_name  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).string_value_) != nullptr) {
     delete ((*yyvaluep).string_value_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3316 "SqlParser_gen.cpp"
+}
+#line 2976 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 249: /* boolean_value */
-/* Line 1398 of yacc.c  */
-#line 614 "../SqlParser.ypp"
-        { };
-/* Line 1398 of yacc.c  */
-#line 3323 "SqlParser_gen.cpp"
+
+    case 249: /* boolean_value  */
+#line 614 "../SqlParser.ypp" /* yacc.c:1257  */
+      { }
+#line 2982 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 250: /* command */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 250: /* command  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).command_) != nullptr) {
     delete ((*yyvaluep).command_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3334 "SqlParser_gen.cpp"
+}
+#line 2992 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
-      case 251: /* command_argument_list */
-/* Line 1398 of yacc.c  */
-#line 620 "../SqlParser.ypp"
-        {
+
+    case 251: /* command_argument_list  */
+#line 620 "../SqlParser.ypp" /* yacc.c:1257  */
+      {
   if (((*yyvaluep).command_argument_list_) != nullptr) {
     delete ((*yyvaluep).command_argument_list_);
   }
-};
-/* Line 1398 of yacc.c  */
-#line 3345 "SqlParser_gen.cpp"
+}
+#line 3002 "SqlParser_gen.cpp" /* yacc.c:1257  */
         break;
+
 
       default:
         break;
     }
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
@@ -3356,66 +3015,26 @@ yydestruct (yymsg, yytype, yyvaluep, yylocationp, yyscanner, parsedStatement)
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement)
-#else
-int
-yyparse (yyscanner, parsedStatement)
-    yyscan_t yyscanner;
-    quickstep::ParseStatement **parsedStatement;
-#endif
-#endif
 {
 /* The lookahead symbol.  */
 int yychar;
 
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
-/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
-    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
-    _Pragma ("GCC diagnostic pop")
-#else
+/* The semantic value of the lookahead symbol.  */
 /* Default value used for initialization, for pacifying older GCCs
    or non-GCC compilers.  */
-static YYSTYPE yyval_default;
-# define YY_INITIAL_VALUE(Value) = Value
-#endif
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
+
+/* Location data for the lookahead symbol.  */
 static YYLTYPE yyloc_default
 # if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
   = { 1, 1, 1, 1 }
 # endif
 ;
-#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END
-#endif
-#ifndef YY_INITIAL_VALUE
-# define YY_INITIAL_VALUE(Value) /* Nothing. */
-#endif
-
-/* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval YY_INITIAL_VALUE(yyval_default);
-
-/* Location data for the lookahead symbol.  */
 YYLTYPE yylloc = yyloc_default;
-
 
     /* Number of syntax errors so far.  */
     int yynerrs;
@@ -3425,9 +3044,9 @@ YYLTYPE yylloc = yyloc_default;
     int yyerrstatus;
 
     /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
-       `yyls': related to locations.
+       'yyss': related to states.
+       'yyvs': related to semantic values.
+       'yyls': related to locations.
 
        Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
@@ -3506,26 +3125,26 @@ YYLTYPE yylloc = yyloc_default;
 
 #ifdef yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
-	YYLTYPE *yyls1 = yyls;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        YYSTYPE *yyvs1 = yyvs;
+        yytype_int16 *yyss1 = yyss;
+        YYLTYPE *yyls1 = yyls;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yyls1, yysize * sizeof (*yylsp),
-		    &yystacksize);
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * sizeof (*yyssp),
+                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyls1, yysize * sizeof (*yylsp),
+                    &yystacksize);
 
-	yyls = yyls1;
-	yyss = yyss1;
-	yyvs = yyvs1;
+        yyls = yyls1;
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
 #else /* no yyoverflow */
 # ifndef YYSTACK_RELOCATE
@@ -3533,23 +3152,23 @@ YYLTYPE yylloc = yyloc_default;
 # else
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        goto yyexhaustedlab;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-	YYSTACK_RELOCATE (yyls_alloc, yyls);
+        yytype_int16 *yyss1 = yyss;
+        union yyalloc *yyptr =
+          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+        if (! yyptr)
+          goto yyexhaustedlab;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        YYSTACK_RELOCATE (yyls_alloc, yyls);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
 #endif /* no yyoverflow */
@@ -3559,10 +3178,10 @@ YYLTYPE yylloc = yyloc_default;
       yylsp = yyls + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+                  (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
@@ -3591,7 +3210,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      yychar = yylex (&yylval, &yylloc, yyscanner);
     }
 
   if (yychar <= YYEOF)
@@ -3656,7 +3275,7 @@ yyreduce:
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -3671,358 +3290,357 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-/* Line 1792 of yacc.c  */
-#line 629 "../SqlParser.ypp"
+#line 629 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    *parsedStatement = (yyvsp[(1) - (2)].statement_);
+    *parsedStatement = (yyvsp[-1].statement_);
     YYACCEPT;
   }
+#line 3299 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 3:
-/* Line 1792 of yacc.c  */
-#line 633 "../SqlParser.ypp"
+#line 633 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    *parsedStatement = (yyvsp[(1) - (2)].statement_);
+    *parsedStatement = (yyvsp[-1].statement_);
     YYACCEPT;
   }
+#line 3308 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 4:
-/* Line 1792 of yacc.c  */
-#line 637 "../SqlParser.ypp"
+#line 637 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    *parsedStatement = (yyvsp[(1) - (2)].command_);
+    *parsedStatement = (yyvsp[-1].command_);
     YYACCEPT;
   }
+#line 3317 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 5:
-/* Line 1792 of yacc.c  */
-#line 641 "../SqlParser.ypp"
+#line 641 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    *parsedStatement = (yyvsp[(1) - (2)].command_);
+    *parsedStatement = (yyvsp[-1].command_);
     YYACCEPT;
   }
+#line 3326 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 6:
-/* Line 1792 of yacc.c  */
-#line 645 "../SqlParser.ypp"
+#line 645 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     YYABORT;
   }
+#line 3334 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 7:
-/* Line 1792 of yacc.c  */
-#line 648 "../SqlParser.ypp"
+#line 648 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     // Regular yyparse() return codes are non-negative, so use a negative one here.
     return -1;
   }
+#line 3343 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 8:
-/* Line 1792 of yacc.c  */
-#line 655 "../SqlParser.ypp"
+#line 655 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].statement_);
+    (yyval.statement_) = (yyvsp[0].statement_);
   }
+#line 3351 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 9:
-/* Line 1792 of yacc.c  */
-#line 658 "../SqlParser.ypp"
+#line 658 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].copy_from_statement_);
+    (yyval.statement_) = (yyvsp[0].copy_from_statement_);
   }
+#line 3359 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 10:
-/* Line 1792 of yacc.c  */
-#line 661 "../SqlParser.ypp"
+#line 661 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].create_table_statement_);
+    (yyval.statement_) = (yyvsp[0].create_table_statement_);
   }
+#line 3367 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 11:
-/* Line 1792 of yacc.c  */
-#line 664 "../SqlParser.ypp"
+#line 664 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].statement_);
+    (yyval.statement_) = (yyvsp[0].statement_);
   }
+#line 3375 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 12:
-/* Line 1792 of yacc.c  */
-#line 667 "../SqlParser.ypp"
+#line 667 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].delete_statement_);
+    (yyval.statement_) = (yyvsp[0].delete_statement_);
   }
+#line 3383 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 13:
-/* Line 1792 of yacc.c  */
-#line 670 "../SqlParser.ypp"
+#line 670 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].drop_table_statement_);
+    (yyval.statement_) = (yyvsp[0].drop_table_statement_);
   }
+#line 3391 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 14:
-/* Line 1792 of yacc.c  */
-#line 673 "../SqlParser.ypp"
+#line 673 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].insert_statement_);
+    (yyval.statement_) = (yyvsp[0].insert_statement_);
   }
+#line 3399 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 15:
-/* Line 1792 of yacc.c  */
-#line 676 "../SqlParser.ypp"
+#line 676 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].quit_statement_);
+    (yyval.statement_) = (yyvsp[0].quit_statement_);
   }
+#line 3407 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 16:
-/* Line 1792 of yacc.c  */
-#line 679 "../SqlParser.ypp"
+#line 679 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].select_statement_);
+    (yyval.statement_) = (yyvsp[0].select_statement_);
   }
+#line 3415 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 17:
-/* Line 1792 of yacc.c  */
-#line 682 "../SqlParser.ypp"
+#line 682 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.statement_) = (yyvsp[(1) - (1)].update_statement_);
+    (yyval.statement_) = (yyvsp[0].update_statement_);
   }
+#line 3423 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 18:
-/* Line 1792 of yacc.c  */
-#line 688 "../SqlParser.ypp"
+#line 688 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.quit_statement_) = new quickstep::ParseStatementQuit((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column);
+    (yyval.quit_statement_) = new quickstep::ParseStatementQuit((yylsp[0]).first_line, (yylsp[0]).first_column);
   }
+#line 3431 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 19:
-/* Line 1792 of yacc.c  */
-#line 694 "../SqlParser.ypp"
+#line 694 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (6)].string_value_);
-    delete (yyvsp[(6) - (6)].attribute_definition_);
+    delete (yyvsp[-3].string_value_);
+    delete (yyvsp[0].attribute_definition_);
     (yyval.statement_) = nullptr;
-    NotSupported(&(yylsp[(1) - (6)]), yyscanner, "ALTER statements");
+    NotSupported(&(yylsp[-5]), yyscanner, "ALTER statements");
     YYERROR;
   }
+#line 3443 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 20:
-/* Line 1792 of yacc.c  */
-#line 701 "../SqlParser.ypp"
+#line 701 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (6)].string_value_);
+    delete (yyvsp[-3].string_value_);
     (yyval.statement_) = nullptr;
-    NotSupported(&(yylsp[(1) - (6)]), yyscanner, "ALTER statements");
+    NotSupported(&(yylsp[-5]), yyscanner, "ALTER statements");
     YYERROR;
   }
+#line 3454 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 21:
-/* Line 1792 of yacc.c  */
-#line 707 "../SqlParser.ypp"
+#line 707 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (6)].string_value_);
-    delete (yyvsp[(6) - (6)].string_value_);
+    delete (yyvsp[-3].string_value_);
+    delete (yyvsp[0].string_value_);
     (yyval.statement_) = nullptr;
-    NotSupported(&(yylsp[(1) - (6)]), yyscanner, "ALTER statements");
+    NotSupported(&(yylsp[-5]), yyscanner, "ALTER statements");
     YYERROR;
   }
+#line 3466 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 22:
-/* Line 1792 of yacc.c  */
-#line 714 "../SqlParser.ypp"
+#line 714 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (6)].string_value_);
-    delete (yyvsp[(6) - (6)].string_value_);
+    delete (yyvsp[-3].string_value_);
+    delete (yyvsp[0].string_value_);
     (yyval.statement_) = nullptr;
-    NotSupported(&(yylsp[(1) - (6)]), yyscanner, "ALTER statements");
+    NotSupported(&(yylsp[-5]), yyscanner, "ALTER statements");
     YYERROR;
   }
+#line 3478 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 23:
-/* Line 1792 of yacc.c  */
-#line 723 "../SqlParser.ypp"
+#line 723 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.create_table_statement_) = new quickstep::ParseStatementCreateTable((yylsp[(1) - (9)]).first_line, (yylsp[(1) - (9)]).first_column, (yyvsp[(3) - (9)].string_value_), (yyvsp[(5) - (9)].attribute_definition_list_), (yyvsp[(8) - (9)].block_properties_), (yyvsp[(9) - (9)].partition_clause_));
+    (yyval.create_table_statement_) = new quickstep::ParseStatementCreateTable((yylsp[-8]).first_line, (yylsp[-8]).first_column, (yyvsp[-6].string_value_), (yyvsp[-4].attribute_definition_list_), (yyvsp[-1].block_properties_), (yyvsp[0].partition_clause_));
   }
+#line 3486 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 24:
-/* Line 1792 of yacc.c  */
-#line 728 "../SqlParser.ypp"
+#line 728 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(9) - (9)].key_value_list_)) {
-      (yyval.statement_) = new quickstep::ParseStatementCreateIndex((yylsp[(1) - (9)]).first_line, (yylsp[(1) - (9)]).first_column, (yyvsp[(3) - (9)].string_value_), (yyvsp[(5) - (9)].string_value_), (yyvsp[(6) - (9)].attribute_list_), (yyvsp[(8) - (9)].string_value_), (yylsp[(9) - (9)]).first_line, (yylsp[(9) - (9)]).first_column, (yyvsp[(9) - (9)].key_value_list_));
+    if ((yyvsp[0].key_value_list_)) {
+      (yyval.statement_) = new quickstep::ParseStatementCreateIndex((yylsp[-8]).first_line, (yylsp[-8]).first_column, (yyvsp[-6].string_value_), (yyvsp[-4].string_value_), (yyvsp[-3].attribute_list_), (yyvsp[-1].string_value_), (yylsp[0]).first_line, (yylsp[0]).first_column, (yyvsp[0].key_value_list_));
     } else {
-      (yyval.statement_) = new quickstep::ParseStatementCreateIndex((yylsp[(1) - (9)]).first_line, (yylsp[(1) - (9)]).first_column, (yyvsp[(3) - (9)].string_value_), (yyvsp[(5) - (9)].string_value_), (yyvsp[(6) - (9)].attribute_list_), (yyvsp[(8) - (9)].string_value_));
+      (yyval.statement_) = new quickstep::ParseStatementCreateIndex((yylsp[-8]).first_line, (yylsp[-8]).first_column, (yyvsp[-6].string_value_), (yyvsp[-4].string_value_), (yyvsp[-3].attribute_list_), (yyvsp[-1].string_value_));
     }
   }
+#line 3498 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 25:
-/* Line 1792 of yacc.c  */
-#line 737 "../SqlParser.ypp"
+#line 737 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.drop_table_statement_) = new quickstep::ParseStatementDropTable((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(3) - (3)].string_value_));
+    (yyval.drop_table_statement_) = new quickstep::ParseStatementDropTable((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[0].string_value_));
   }
+#line 3506 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 26:
-/* Line 1792 of yacc.c  */
-#line 742 "../SqlParser.ypp"
+#line 742 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.attribute_definition_) = new quickstep::ParseAttributeDefinition((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(1) - (3)].string_value_), (yyvsp[(2) - (3)].data_type_), (yyvsp[(3) - (3)].column_constraint_list_));
+    (yyval.attribute_definition_) = new quickstep::ParseAttributeDefinition((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-2].string_value_), (yyvsp[-1].data_type_), (yyvsp[0].column_constraint_list_));
   }
+#line 3514 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 27:
-/* Line 1792 of yacc.c  */
-#line 747 "../SqlParser.ypp"
+#line 747 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.attribute_definition_list_) = new quickstep::PtrList<quickstep::ParseAttributeDefinition>();
-    (yyval.attribute_definition_list_)->push_back((yyvsp[(1) - (1)].attribute_definition_));
+    (yyval.attribute_definition_list_)->push_back((yyvsp[0].attribute_definition_));
   }
+#line 3523 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 28:
-/* Line 1792 of yacc.c  */
-#line 751 "../SqlParser.ypp"
+#line 751 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.attribute_definition_list_) = (yyvsp[(1) - (3)].attribute_definition_list_);
-    (yyval.attribute_definition_list_)->push_back((yyvsp[(3) - (3)].attribute_definition_));
+    (yyval.attribute_definition_list_) = (yyvsp[-2].attribute_definition_list_);
+    (yyval.attribute_definition_list_)->push_back((yyvsp[0].attribute_definition_));
   }
+#line 3532 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 29:
-/* Line 1792 of yacc.c  */
-#line 757 "../SqlParser.ypp"
+#line 757 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = nullptr;
-    NotSupported(&(yylsp[(1) - (1)]), yyscanner, "BIT data type");
+    NotSupported(&(yylsp[0]), yyscanner, "BIT data type");
     YYERROR;
   }
+#line 3542 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 30:
-/* Line 1792 of yacc.c  */
-#line 762 "../SqlParser.ypp"
+#line 762 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDatetime));
   }
+#line 3550 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 31:
-/* Line 1792 of yacc.c  */
-#line 765 "../SqlParser.ypp"
+#line 765 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDatetime));
   }
+#line 3558 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 32:
-/* Line 1792 of yacc.c  */
-#line 768 "../SqlParser.ypp"
+#line 768 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = nullptr;
-    NotSupported(&(yylsp[(1) - (1)]), yyscanner, "TIME data type");
+    NotSupported(&(yylsp[0]), yyscanner, "TIME data type");
     YYERROR;
   }
+#line 3568 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 33:
-/* Line 1792 of yacc.c  */
-#line 773 "../SqlParser.ypp"
+#line 773 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDatetime));
   }
+#line 3576 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 34:
-/* Line 1792 of yacc.c  */
-#line 776 "../SqlParser.ypp"
+#line 776 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDouble));
+    (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDecimal));
   }
+#line 3584 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 35:
-/* Line 1792 of yacc.c  */
-#line 779 "../SqlParser.ypp"
+#line 779 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDouble));
   }
+#line 3592 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 36:
-/* Line 1792 of yacc.c  */
-#line 782 "../SqlParser.ypp"
+#line 782 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDouble));
   }
+#line 3600 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 37:
-/* Line 1792 of yacc.c  */
-#line 785 "../SqlParser.ypp"
+#line 785 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kFloat));
   }
+#line 3608 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 38:
-/* Line 1792 of yacc.c  */
-#line 788 "../SqlParser.ypp"
+#line 788 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kInt));
   }
+#line 3616 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 39:
-/* Line 1792 of yacc.c  */
-#line 791 "../SqlParser.ypp"
+#line 791 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kInt));
   }
+#line 3624 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 40:
-/* Line 1792 of yacc.c  */
-#line 794 "../SqlParser.ypp"
+#line 794 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kLong));
   }
+#line 3632 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 41:
-/* Line 1792 of yacc.c  */
-#line 797 "../SqlParser.ypp"
+#line 797 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kLong));
   }
+#line 3640 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 42:
-/* Line 1792 of yacc.c  */
-#line 800 "../SqlParser.ypp"
+#line 800 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /**
      * NOTE(chasseur): This pattern exhibits a shift/reduce conflict with the
@@ -4030,1809 +3648,1809 @@ yyreduce:
      * than reduce, so the case in 'literal_value' has precedence over this.
      **/
     (yyval.data_type_) = nullptr;
-    quickstep_yyerror(&(yylsp[(1) - (1)]), yyscanner, nullptr,
+    quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr,
         "INTERVAL is ambiguous as a column type. Specify either DATETIME INTERVAL "
         "or YEARMONTH INTERVAL");
     YYERROR;
   }
+#line 3657 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 43:
-/* Line 1792 of yacc.c  */
-#line 812 "../SqlParser.ypp"
+#line 812 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kDatetimeInterval));
   }
+#line 3665 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 44:
-/* Line 1792 of yacc.c  */
-#line 815 "../SqlParser.ypp"
+#line 815 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kYearMonthInterval));
   }
+#line 3673 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 45:
-/* Line 1792 of yacc.c  */
-#line 818 "../SqlParser.ypp"
+#line 818 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(3) - (4)].numeric_literal_value_)->float_like()) {
-      delete (yyvsp[(3) - (4)].numeric_literal_value_);
+    if ((yyvsp[-1].numeric_literal_value_)->float_like()) {
+      delete (yyvsp[-1].numeric_literal_value_);
       (yyval.data_type_) = NULL;
-      quickstep_yyerror(&(yylsp[(3) - (4)]), yyscanner, nullptr, "Non-integer length supplied for CHAR type");
+      quickstep_yyerror(&(yylsp[-1]), yyscanner, nullptr, "Non-integer length supplied for CHAR type");
       YYERROR;
     } else {
-      if ((yyvsp[(3) - (4)].numeric_literal_value_)->long_value() <= 0) {
-        delete (yyvsp[(3) - (4)].numeric_literal_value_);
+      if ((yyvsp[-1].numeric_literal_value_)->long_value() <= 0) {
+        delete (yyvsp[-1].numeric_literal_value_);
         (yyval.data_type_) = NULL;
-        quickstep_yyerror(&(yylsp[(3) - (4)]), yyscanner, nullptr, "Length for CHAR type must be at least 1");
+        quickstep_yyerror(&(yylsp[-1]), yyscanner, nullptr, "Length for CHAR type must be at least 1");
         YYERROR;
       } else {
-        (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kChar, (yyvsp[(3) - (4)].numeric_literal_value_)->long_value(), false));
-        delete (yyvsp[(3) - (4)].numeric_literal_value_);
+        (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kChar, (yyvsp[-1].numeric_literal_value_)->long_value(), false));
+        delete (yyvsp[-1].numeric_literal_value_);
       }
     }
   }
+#line 3696 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 46:
-/* Line 1792 of yacc.c  */
-#line 836 "../SqlParser.ypp"
+#line 836 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(3) - (4)].numeric_literal_value_)->float_like()) {
-      delete (yyvsp[(3) - (4)].numeric_literal_value_);
+    if ((yyvsp[-1].numeric_literal_value_)->float_like()) {
+      delete (yyvsp[-1].numeric_literal_value_);
       (yyval.data_type_) = NULL;
-      quickstep_yyerror(&(yylsp[(3) - (4)]), yyscanner, nullptr, "Non-integer length supplied for VARCHAR type");
+      quickstep_yyerror(&(yylsp[-1]), yyscanner, nullptr, "Non-integer length supplied for VARCHAR type");
       YYERROR;
     } else {
-      if ((yyvsp[(3) - (4)].numeric_literal_value_)->long_value() < 0) {
-        delete (yyvsp[(3) - (4)].numeric_literal_value_);
+      if ((yyvsp[-1].numeric_literal_value_)->long_value() < 0) {
+        delete (yyvsp[-1].numeric_literal_value_);
         (yyval.data_type_) = NULL;
-        quickstep_yyerror(&(yylsp[(3) - (4)]), yyscanner, nullptr, "Negative length supplied for VARCHAR type");
+        quickstep_yyerror(&(yylsp[-1]), yyscanner, nullptr, "Negative length supplied for VARCHAR type");
         YYERROR;
       } else {
-        (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kVarChar, (yyvsp[(3) - (4)].numeric_literal_value_)->long_value(), false));
-        delete (yyvsp[(3) - (4)].numeric_literal_value_);
+        (yyval.data_type_) = new quickstep::ParseDataType(quickstep::TypeFactory::GetType(quickstep::kVarChar, (yyvsp[-1].numeric_literal_value_)->long_value(), false));
+        delete (yyvsp[-1].numeric_literal_value_);
       }
     }
   }
+#line 3719 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 47:
-/* Line 1792 of yacc.c  */
-#line 856 "../SqlParser.ypp"
+#line 856 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.column_constraint_) = new quickstep::ParseColumnConstraintNull((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column);
+    (yyval.column_constraint_) = new quickstep::ParseColumnConstraintNull((yylsp[0]).first_line, (yylsp[0]).first_column);
   }
+#line 3727 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 48:
-/* Line 1792 of yacc.c  */
-#line 859 "../SqlParser.ypp"
+#line 859 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.column_constraint_) = new quickstep::ParseColumnConstraintNotNull((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column);
+    (yyval.column_constraint_) = new quickstep::ParseColumnConstraintNotNull((yylsp[-1]).first_line, (yylsp[-1]).first_column);
   }
+#line 3735 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 49:
-/* Line 1792 of yacc.c  */
-#line 862 "../SqlParser.ypp"
+#line 862 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_) = nullptr;
-    NotSupported(&(yylsp[(1) - (1)]), yyscanner, "Column Constraints (UNIQUE)");
+    NotSupported(&(yylsp[0]), yyscanner, "Column Constraints (UNIQUE)");
     YYERROR;
   }
+#line 3745 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 50:
-/* Line 1792 of yacc.c  */
-#line 867 "../SqlParser.ypp"
+#line 867 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_) = nullptr;
-    NotSupported(&(yylsp[(1) - (2)]), yyscanner, "Column Constraints (PRIMARY KEY)");
+    NotSupported(&(yylsp[-1]), yyscanner, "Column Constraints (PRIMARY KEY)");
     YYERROR;
   }
+#line 3755 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 51:
-/* Line 1792 of yacc.c  */
-#line 872 "../SqlParser.ypp"
+#line 872 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_) = nullptr;
-    delete (yyvsp[(2) - (2)].literal_value_);
-    NotSupported(&(yylsp[(1) - (2)]), yyscanner, "Column Constraints (DEFAULT)");
+    delete (yyvsp[0].literal_value_);
+    NotSupported(&(yylsp[-1]), yyscanner, "Column Constraints (DEFAULT)");
     YYERROR;
   }
+#line 3766 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 52:
-/* Line 1792 of yacc.c  */
-#line 878 "../SqlParser.ypp"
+#line 878 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_) = nullptr;
-    delete (yyvsp[(3) - (4)].predicate_);
-    NotSupported(&(yylsp[(1) - (4)]), yyscanner, "Column Constraints (CHECK)");
+    delete (yyvsp[-1].predicate_);
+    NotSupported(&(yylsp[-3]), yyscanner, "Column Constraints (CHECK)");
     YYERROR;
   }
+#line 3777 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 53:
-/* Line 1792 of yacc.c  */
-#line 884 "../SqlParser.ypp"
+#line 884 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_) = nullptr;
-    delete (yyvsp[(2) - (5)].string_value_);
-    delete (yyvsp[(4) - (5)].string_value_);
-    NotSupported(&(yylsp[(1) - (5)]), yyscanner, "Foreign Keys");
+    delete (yyvsp[-3].string_value_);
+    delete (yyvsp[-1].string_value_);
+    NotSupported(&(yylsp[-4]), yyscanner, "Foreign Keys");
     YYERROR;
   }
+#line 3789 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 54:
-/* Line 1792 of yacc.c  */
-#line 893 "../SqlParser.ypp"
+#line 893 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.column_constraint_list_) = (yyvsp[(1) - (2)].column_constraint_list_);
-    (yyval.column_constraint_list_)->push_back((yyvsp[(2) - (2)].column_constraint_));
+    (yyval.column_constraint_list_) = (yyvsp[-1].column_constraint_list_);
+    (yyval.column_constraint_list_)->push_back((yyvsp[0].column_constraint_));
   }
+#line 3798 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 55:
-/* Line 1792 of yacc.c  */
-#line 897 "../SqlParser.ypp"
+#line 897 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_list_) = new quickstep::PtrList<quickstep::ParseColumnConstraint>();
-    (yyval.column_constraint_list_)->push_back((yyvsp[(1) - (1)].column_constraint_));
+    (yyval.column_constraint_list_)->push_back((yyvsp[0].column_constraint_));
   }
+#line 3807 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 56:
-/* Line 1792 of yacc.c  */
-#line 903 "../SqlParser.ypp"
+#line 903 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.column_constraint_list_) = nullptr;
   }
+#line 3815 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 57:
-/* Line 1792 of yacc.c  */
-#line 906 "../SqlParser.ypp"
+#line 906 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.column_constraint_list_) = (yyvsp[(1) - (1)].column_constraint_list_);
+    (yyval.column_constraint_list_) = (yyvsp[0].column_constraint_list_);
   }
+#line 3823 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 58:
-/* Line 1792 of yacc.c  */
-#line 911 "../SqlParser.ypp"
+#line 911 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (4)].string_list_);
-    NotSupported(&(yylsp[(1) - (4)]), yyscanner, "Table Constraints (UNIQUE)");
+    delete (yyvsp[-1].string_list_);
+    NotSupported(&(yylsp[-3]), yyscanner, "Table Constraints (UNIQUE)");
     YYERROR;
   }
+#line 3833 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 59:
-/* Line 1792 of yacc.c  */
-#line 916 "../SqlParser.ypp"
+#line 916 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(4) - (5)].string_list_);
-    NotSupported(&(yylsp[(1) - (5)]), yyscanner, "Table Constraints (PRIMARY KEY)");
+    delete (yyvsp[-1].string_list_);
+    NotSupported(&(yylsp[-4]), yyscanner, "Table Constraints (PRIMARY KEY)");
     YYERROR;
   }
+#line 3843 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 60:
-/* Line 1792 of yacc.c  */
-#line 921 "../SqlParser.ypp"
+#line 921 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(4) - (10)].string_list_);
-    delete (yyvsp[(7) - (10)].string_value_);
-    delete (yyvsp[(9) - (10)].string_list_);
-    NotSupported(&(yylsp[(1) - (10)]), yyscanner, "Table Constraints (FOREIGN KEY)");
+    delete (yyvsp[-6].string_list_);
+    delete (yyvsp[-3].string_value_);
+    delete (yyvsp[-1].string_list_);
+    NotSupported(&(yylsp[-9]), yyscanner, "Table Constraints (FOREIGN KEY)");
     YYERROR;
   }
+#line 3855 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 61:
-/* Line 1792 of yacc.c  */
-#line 928 "../SqlParser.ypp"
+#line 928 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (4)].predicate_);
-    NotSupported(&(yylsp[(1) - (4)]), yyscanner, "Table Constraints (CHECK)");
+    delete (yyvsp[-1].predicate_);
+    NotSupported(&(yylsp[-3]), yyscanner, "Table Constraints (CHECK)");
     YYERROR;
   }
+#line 3865 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 62:
-/* Line 1792 of yacc.c  */
-#line 935 "../SqlParser.ypp"
+#line 935 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    NotSupported(&(yylsp[(1) - (3)]), yyscanner, "Table Constraints");
+    NotSupported(&(yylsp[-2]), yyscanner, "Table Constraints");
     YYERROR;
   }
+#line 3874 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 63:
-/* Line 1792 of yacc.c  */
-#line 939 "../SqlParser.ypp"
+#line 939 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    NotSupported(&(yylsp[(1) - (1)]), yyscanner, "Table Constraints");
+    NotSupported(&(yylsp[0]), yyscanner, "Table Constraints");
     YYERROR;
   }
+#line 3883 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 64:
-/* Line 1792 of yacc.c  */
-#line 945 "../SqlParser.ypp"
+#line 945 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /* $$ = nullptr; */
   }
+#line 3891 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 65:
-/* Line 1792 of yacc.c  */
-#line 948 "../SqlParser.ypp"
+#line 948 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /* $$ = $1; */
   }
+#line 3899 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 66:
-/* Line 1792 of yacc.c  */
-#line 953 "../SqlParser.ypp"
+#line 953 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.attribute_list_) = nullptr;
   }
+#line 3907 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 67:
-/* Line 1792 of yacc.c  */
-#line 956 "../SqlParser.ypp"
+#line 956 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.attribute_list_) = (yyvsp[(2) - (3)].attribute_list_);
+    (yyval.attribute_list_) = (yyvsp[-1].attribute_list_);
   }
+#line 3915 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 68:
-/* Line 1792 of yacc.c  */
-#line 961 "../SqlParser.ypp"
+#line 961 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.block_properties_) = nullptr;
   }
+#line 3923 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 69:
-/* Line 1792 of yacc.c  */
-#line 964 "../SqlParser.ypp"
+#line 964 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.block_properties_) = new quickstep::ParseBlockProperties((yylsp[(2) - (5)]).first_line, (yylsp[(2) - (5)]).first_column, (yyvsp[(4) - (5)].key_value_list_));
+    (yyval.block_properties_) = new quickstep::ParseBlockProperties((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-1].key_value_list_));
   }
+#line 3931 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 70:
-/* Line 1792 of yacc.c  */
-#line 969 "../SqlParser.ypp"
+#line 969 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.partition_clause_) = nullptr;
   }
+#line 3939 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 71:
-/* Line 1792 of yacc.c  */
-#line 972 "../SqlParser.ypp"
+#line 972 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(8) - (8)].numeric_literal_value_)->float_like()) {
-      delete (yyvsp[(8) - (8)].numeric_literal_value_);
+    if ((yyvsp[0].numeric_literal_value_)->float_like()) {
+      delete (yyvsp[0].numeric_literal_value_);
       (yyval.partition_clause_) = NULL;
-      quickstep_yyerror(&(yylsp[(8) - (8)]), yyscanner, NULL, "NUMBER OF PARTITIONS must be an integer");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, NULL, "NUMBER OF PARTITIONS must be an integer");
       YYERROR;
     } else {
-      if ((yyvsp[(8) - (8)].numeric_literal_value_)->long_value() <= 0 || (yyvsp[(8) - (8)].numeric_literal_value_)->long_value() > 64) {
-        delete (yyvsp[(8) - (8)].numeric_literal_value_);
+      if ((yyvsp[0].numeric_literal_value_)->long_value() <= 0 || (yyvsp[0].numeric_literal_value_)->long_value() > 64) {
+        delete (yyvsp[0].numeric_literal_value_);
         (yyval.partition_clause_) = NULL;
-        quickstep_yyerror(&(yylsp[(8) - (8)]), yyscanner, NULL, "NUMBER OF PARITIONS must be between 1 and 64");
+        quickstep_yyerror(&(yylsp[0]), yyscanner, NULL, "NUMBER OF PARITIONS must be between 1 and 64");
         YYERROR;
       } else {
-        (yyval.partition_clause_) = new quickstep::ParsePartitionClause((yylsp[(1) - (8)]).first_line, (yylsp[(1) - (8)]).first_column, (yyvsp[(3) - (8)].string_value_), (yyvsp[(5) - (8)].string_list_), (yyvsp[(8) - (8)].numeric_literal_value_));
+        (yyval.partition_clause_) = new quickstep::ParsePartitionClause((yylsp[-7]).first_line, (yylsp[-7]).first_column, (yyvsp[-5].string_value_), (yyvsp[-3].string_list_), (yyvsp[0].numeric_literal_value_));
       }
     }
   }
+#line 3961 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 72:
-/* Line 1792 of yacc.c  */
-#line 991 "../SqlParser.ypp"
+#line 991 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column,
+    (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column,
            std::to_string(quickstep::PartitionSchemeHeader::PartitionType::kHash));
   }
+#line 3970 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 73:
-/* Line 1792 of yacc.c  */
-#line 995 "../SqlParser.ypp"
+#line 995 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column,
+    (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column,
            std::to_string(quickstep::PartitionSchemeHeader::PartitionType::kRange));
   }
+#line 3979 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 74:
-/* Line 1792 of yacc.c  */
-#line 1001 "../SqlParser.ypp"
+#line 1001 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.key_value_list_) = new quickstep::PtrList<quickstep::ParseKeyValue>();
-    (yyval.key_value_list_)->push_back((yyvsp[(1) - (1)].key_value_));
+    (yyval.key_value_list_)->push_back((yyvsp[0].key_value_));
   }
+#line 3988 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 75:
-/* Line 1792 of yacc.c  */
-#line 1005 "../SqlParser.ypp"
+#line 1005 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_value_list_) = (yyvsp[(1) - (3)].key_value_list_);
-    (yyval.key_value_list_)->push_back((yyvsp[(3) - (3)].key_value_));
+    (yyval.key_value_list_) = (yyvsp[-2].key_value_list_);
+    (yyval.key_value_list_)->push_back((yyvsp[0].key_value_));
   }
+#line 3997 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 76:
-/* Line 1792 of yacc.c  */
-#line 1011 "../SqlParser.ypp"
+#line 1011 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_value_) = (yyvsp[(1) - (1)].key_string_value_);
+    (yyval.key_value_) = (yyvsp[0].key_string_value_);
   }
+#line 4005 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 77:
-/* Line 1792 of yacc.c  */
-#line 1014 "../SqlParser.ypp"
+#line 1014 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_value_) = (yyvsp[(1) - (1)].key_string_list_);
+    (yyval.key_value_) = (yyvsp[0].key_string_list_);
   }
+#line 4013 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 78:
-/* Line 1792 of yacc.c  */
-#line 1017 "../SqlParser.ypp"
+#line 1017 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_value_) = (yyvsp[(1) - (1)].key_integer_value_);
+    (yyval.key_value_) = (yyvsp[0].key_integer_value_);
   }
+#line 4021 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 79:
-/* Line 1792 of yacc.c  */
-#line 1022 "../SqlParser.ypp"
+#line 1022 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_string_value_) = new quickstep::ParseKeyStringValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].string_value_), (yyvsp[(2) - (2)].string_value_));
+    (yyval.key_string_value_) = new quickstep::ParseKeyStringValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].string_value_));
   }
+#line 4029 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 80:
-/* Line 1792 of yacc.c  */
-#line 1025 "../SqlParser.ypp"
+#line 1025 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     // This is a special case to handle the COMPRESS ALL option of the BLOCK PROPERTIES.
-    (yyval.key_string_value_) = new quickstep::ParseKeyStringValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].string_value_),
-        new quickstep::ParseString((yylsp[(2) - (2)]).first_line, (yylsp[(2) - (2)]).first_column, "ALL"));
+    (yyval.key_string_value_) = new quickstep::ParseKeyStringValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].string_value_),
+        new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, "ALL"));
   }
+#line 4039 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 81:
-/* Line 1792 of yacc.c  */
-#line 1032 "../SqlParser.ypp"
+#line 1032 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_string_list_) = new quickstep::ParseKeyStringList((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(1) - (4)].string_value_), (yyvsp[(3) - (4)].string_list_));
+    (yyval.key_string_list_) = new quickstep::ParseKeyStringList((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-3].string_value_), (yyvsp[-1].string_list_));
   }
+#line 4047 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 82:
-/* Line 1792 of yacc.c  */
-#line 1037 "../SqlParser.ypp"
+#line 1037 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(2) - (2)].numeric_literal_value_)->float_like()) {
-      delete (yyvsp[(2) - (2)].numeric_literal_value_);
+    if ((yyvsp[0].numeric_literal_value_)->float_like()) {
+      delete (yyvsp[0].numeric_literal_value_);
       (yyval.key_integer_value_) = nullptr;
-      quickstep_yyerror(&(yylsp[(2) - (2)]), yyscanner, nullptr, "Value must be an integer");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "Value must be an integer");
       YYERROR;
     }
-    (yyval.key_integer_value_) = new quickstep::ParseKeyIntegerValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].string_value_), (yyvsp[(2) - (2)].numeric_literal_value_));
+    (yyval.key_integer_value_) = new quickstep::ParseKeyIntegerValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].numeric_literal_value_));
   }
+#line 4061 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 83:
-/* Line 1792 of yacc.c  */
-#line 1048 "../SqlParser.ypp"
+#line 1048 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     // Defaults to BitWeavingV, but IndexProperties can change this to H.
-    (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column,
+    (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column,
            std::to_string(quickstep::IndexSubBlockType::kBitWeavingV));
   }
+#line 4071 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 84:
-/* Line 1792 of yacc.c  */
-#line 1053 "../SqlParser.ypp"
+#line 1053 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column,
+    (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column,
            std::to_string(quickstep::IndexSubBlockType::kBloomFilter));
   }
+#line 4080 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 85:
-/* Line 1792 of yacc.c  */
-#line 1057 "../SqlParser.ypp"
+#line 1057 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column,
+    (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column,
            std::to_string(quickstep::IndexSubBlockType::kCSBTree));
   }
+#line 4089 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 86:
-/* Line 1792 of yacc.c  */
-#line 1061 "../SqlParser.ypp"
+#line 1061 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column,
+    (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column,
            std::to_string(quickstep::IndexSubBlockType::kSMA));
   }
+#line 4098 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 87:
-/* Line 1792 of yacc.c  */
-#line 1067 "../SqlParser.ypp"
+#line 1067 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.key_value_list_) = nullptr;
   }
+#line 4106 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 88:
-/* Line 1792 of yacc.c  */
-#line 1070 "../SqlParser.ypp"
+#line 1070 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.key_value_list_) = (yyvsp[(2) - (3)].key_value_list_);
+    (yyval.key_value_list_) = (yyvsp[-1].key_value_list_);
   }
+#line 4114 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 89:
-/* Line 1792 of yacc.c  */
-#line 1076 "../SqlParser.ypp"
+#line 1076 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(3) - (10)].string_value_);
-    delete (yyvsp[(5) - (10)].string_list_);
-    delete (yyvsp[(9) - (10)].literal_value_list_);
+    delete (yyvsp[-7].string_value_);
+    delete (yyvsp[-5].string_list_);
+    delete (yyvsp[-1].literal_value_list_);
     (yyval.insert_statement_) = nullptr;
-    NotSupported(&(yylsp[(4) - (10)]), yyscanner, "list of column names in INSERT statement");
+    NotSupported(&(yylsp[-6]), yyscanner, "list of column names in INSERT statement");
     YYERROR;
   }
+#line 4127 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 90:
-/* Line 1792 of yacc.c  */
-#line 1084 "../SqlParser.ypp"
+#line 1084 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.insert_statement_) = new quickstep::ParseStatementInsertTuple((yylsp[(1) - (7)]).first_line, (yylsp[(1) - (7)]).first_column, (yyvsp[(3) - (7)].string_value_), (yyvsp[(6) - (7)].literal_value_list_));
+    (yyval.insert_statement_) = new quickstep::ParseStatementInsertTuple((yylsp[-6]).first_line, (yylsp[-6]).first_column, (yyvsp[-4].string_value_), (yyvsp[-1].literal_value_list_));
   }
+#line 4135 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 91:
-/* Line 1792 of yacc.c  */
-#line 1087 "../SqlParser.ypp"
+#line 1087 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.insert_statement_) = new quickstep::ParseStatementInsertSelection((yylsp[(1) - (4)]).first_line, (yylsp[(2) - (4)]).first_column, (yyvsp[(3) - (4)].string_value_), (yyvsp[(4) - (4)].select_query_), nullptr);
+    (yyval.insert_statement_) = new quickstep::ParseStatementInsertSelection((yylsp[-3]).first_line, (yylsp[-2]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].select_query_), nullptr);
   }
+#line 4143 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 92:
-/* Line 1792 of yacc.c  */
-#line 1090 "../SqlParser.ypp"
+#line 1090 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.insert_statement_) = new quickstep::ParseStatementInsertSelection((yylsp[(1) - (5)]).first_line, (yylsp[(2) - (5)]).first_column, (yyvsp[(4) - (5)].string_value_), (yyvsp[(5) - (5)].select_query_), (yyvsp[(1) - (5)].with_list_));
+    (yyval.insert_statement_) = new quickstep::ParseStatementInsertSelection((yylsp[-4]).first_line, (yylsp[-3]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].select_query_), (yyvsp[-4].with_list_));
   }
+#line 4151 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 93:
-/* Line 1792 of yacc.c  */
-#line 1096 "../SqlParser.ypp"
+#line 1096 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.copy_from_statement_) = new quickstep::ParseStatementCopyFrom((yylsp[(1) - (5)]).first_line, (yylsp[(1) - (5)]).first_column, (yyvsp[(2) - (5)].string_value_), (yyvsp[(4) - (5)].string_value_), (yyvsp[(5) - (5)].copy_from_params_));
+    (yyval.copy_from_statement_) = new quickstep::ParseStatementCopyFrom((yylsp[-4]).first_line, (yylsp[-4]).first_column, (yyvsp[-3].string_value_), (yyvsp[-1].string_value_), (yyvsp[0].copy_from_params_));
   }
+#line 4159 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 94:
-/* Line 1792 of yacc.c  */
-#line 1101 "../SqlParser.ypp"
+#line 1101 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.copy_from_params_) = nullptr;
   }
+#line 4167 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 95:
-/* Line 1792 of yacc.c  */
-#line 1104 "../SqlParser.ypp"
+#line 1104 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.copy_from_params_) = (yyvsp[(3) - (4)].copy_from_params_);
+    (yyval.copy_from_params_) = (yyvsp[-1].copy_from_params_);
   }
+#line 4175 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 96:
-/* Line 1792 of yacc.c  */
-#line 1109 "../SqlParser.ypp"
+#line 1109 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.copy_from_params_) = new quickstep::ParseCopyFromParams((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column);
-    (yyval.copy_from_params_)->set_delimiter((yyvsp[(2) - (2)].string_value_));
+    (yyval.copy_from_params_) = new quickstep::ParseCopyFromParams((yylsp[-1]).first_line, (yylsp[-1]).first_column);
+    (yyval.copy_from_params_)->set_delimiter((yyvsp[0].string_value_));
   }
+#line 4184 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 97:
-/* Line 1792 of yacc.c  */
-#line 1113 "../SqlParser.ypp"
+#line 1113 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.copy_from_params_) = new quickstep::ParseCopyFromParams((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column);
-    (yyval.copy_from_params_)->escape_strings = (yyvsp[(2) - (2)].boolean_value_);
+    (yyval.copy_from_params_) = new quickstep::ParseCopyFromParams((yylsp[-1]).first_line, (yylsp[-1]).first_column);
+    (yyval.copy_from_params_)->escape_strings = (yyvsp[0].boolean_value_);
   }
+#line 4193 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 98:
-/* Line 1792 of yacc.c  */
-#line 1117 "../SqlParser.ypp"
+#line 1117 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.copy_from_params_) = (yyvsp[(1) - (4)].copy_from_params_);
-    (yyval.copy_from_params_)->set_delimiter((yyvsp[(4) - (4)].string_value_));
+    (yyval.copy_from_params_) = (yyvsp[-3].copy_from_params_);
+    (yyval.copy_from_params_)->set_delimiter((yyvsp[0].string_value_));
   }
+#line 4202 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 99:
-/* Line 1792 of yacc.c  */
-#line 1121 "../SqlParser.ypp"
+#line 1121 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.copy_from_params_) = (yyvsp[(1) - (4)].copy_from_params_);
-    (yyval.copy_from_params_)->escape_strings = (yyvsp[(4) - (4)].boolean_value_);
+    (yyval.copy_from_params_) = (yyvsp[-3].copy_from_params_);
+    (yyval.copy_from_params_)->escape_strings = (yyvsp[0].boolean_value_);
   }
+#line 4211 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 100:
-/* Line 1792 of yacc.c  */
-#line 1127 "../SqlParser.ypp"
+#line 1127 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.update_statement_) = new quickstep::ParseStatementUpdate((yylsp[(1) - (5)]).first_line, (yylsp[(1) - (5)]).first_column, (yyvsp[(2) - (5)].string_value_), (yyvsp[(4) - (5)].assignment_list_), (yyvsp[(5) - (5)].predicate_));
+    (yyval.update_statement_) = new quickstep::ParseStatementUpdate((yylsp[-4]).first_line, (yylsp[-4]).first_column, (yyvsp[-3].string_value_), (yyvsp[-1].assignment_list_), (yyvsp[0].predicate_));
   }
+#line 4219 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 101:
-/* Line 1792 of yacc.c  */
-#line 1132 "../SqlParser.ypp"
+#line 1132 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.delete_statement_) = new quickstep::ParseStatementDelete((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(3) - (4)].string_value_), (yyvsp[(4) - (4)].predicate_));
+    (yyval.delete_statement_) = new quickstep::ParseStatementDelete((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].predicate_));
   }
+#line 4227 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 102:
-/* Line 1792 of yacc.c  */
-#line 1137 "../SqlParser.ypp"
+#line 1137 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.assignment_list_) = (yyvsp[(1) - (3)].assignment_list_);
-    (yyval.assignment_list_)->push_back((yyvsp[(3) - (3)].assignment_));
+    (yyval.assignment_list_) = (yyvsp[-2].assignment_list_);
+    (yyval.assignment_list_)->push_back((yyvsp[0].assignment_));
   }
+#line 4236 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 103:
-/* Line 1792 of yacc.c  */
-#line 1141 "../SqlParser.ypp"
+#line 1141 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.assignment_list_) = new quickstep::PtrList<quickstep::ParseAssignment>();
-    (yyval.assignment_list_)->push_back((yyvsp[(1) - (1)].assignment_));
+    (yyval.assignment_list_)->push_back((yyvsp[0].assignment_));
   }
+#line 4245 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 104:
-/* Line 1792 of yacc.c  */
-#line 1147 "../SqlParser.ypp"
+#line 1147 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.assignment_) = new quickstep::ParseAssignment((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(1) - (3)].string_value_), (yyvsp[(3) - (3)].expression_));
+    (yyval.assignment_) = new quickstep::ParseAssignment((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-2].string_value_), (yyvsp[0].expression_));
   }
+#line 4253 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 105:
-/* Line 1792 of yacc.c  */
-#line 1153 "../SqlParser.ypp"
+#line 1153 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.select_statement_) = new quickstep::ParseStatementSelect((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].select_query_), nullptr, (yyvsp[(2) - (2)].opt_priority_clause_));
+    (yyval.select_statement_) = new quickstep::ParseStatementSelect((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].select_query_), nullptr, (yyvsp[0].opt_priority_clause_));
   }
+#line 4261 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 106:
-/* Line 1792 of yacc.c  */
-#line 1156 "../SqlParser.ypp"
+#line 1156 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.select_statement_) = new quickstep::ParseStatementSelect((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(2) - (3)].select_query_), (yyvsp[(1) - (3)].with_list_), (yyvsp[(3) - (3)].opt_priority_clause_));
+    (yyval.select_statement_) = new quickstep::ParseStatementSelect((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-1].select_query_), (yyvsp[-2].with_list_), (yyvsp[0].opt_priority_clause_));
   }
+#line 4269 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 107:
-/* Line 1792 of yacc.c  */
-#line 1161 "../SqlParser.ypp"
+#line 1161 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_priority_clause_) = nullptr;
   }
+#line 4277 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 108:
-/* Line 1792 of yacc.c  */
-#line 1164 "../SqlParser.ypp"
+#line 1164 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(3) - (3)].numeric_literal_value_)->float_like()) {
-      delete (yyvsp[(3) - (3)].numeric_literal_value_);
+    if ((yyvsp[0].numeric_literal_value_)->float_like()) {
+      delete (yyvsp[0].numeric_literal_value_);
       (yyval.opt_priority_clause_) = nullptr;
-      quickstep_yyerror(&(yylsp[(3) - (3)]), yyscanner, nullptr, "PRIORITY value must be an integer");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "PRIORITY value must be an integer");
       YYERROR;
     } else {
-      if ((yyvsp[(3) - (3)].numeric_literal_value_)->long_value() <= 0) {
-        delete (yyvsp[(3) - (3)].numeric_literal_value_);
+      if ((yyvsp[0].numeric_literal_value_)->long_value() <= 0) {
+        delete (yyvsp[0].numeric_literal_value_);
         (yyval.opt_priority_clause_) = nullptr;
-        quickstep_yyerror(&(yylsp[(3) - (3)]), yyscanner, nullptr, "PRIORITY value must be positive");
+        quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "PRIORITY value must be positive");
         YYERROR;
       } else {
-        (yyval.opt_priority_clause_) = new quickstep::ParsePriority((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(3) - (3)].numeric_literal_value_));
+        (yyval.opt_priority_clause_) = new quickstep::ParsePriority((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[0].numeric_literal_value_));
       }
     }
   }
+#line 4299 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 109:
-/* Line 1792 of yacc.c  */
-#line 1183 "../SqlParser.ypp"
+#line 1183 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.with_list_) = (yyvsp[(2) - (2)].with_list_);
+    (yyval.with_list_) = (yyvsp[0].with_list_);
   }
+#line 4307 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 110:
-/* Line 1792 of yacc.c  */
-#line 1188 "../SqlParser.ypp"
+#line 1188 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.with_list_) = new quickstep::PtrVector<quickstep::ParseSubqueryTableReference>();
-    (yyval.with_list_)->push_back((yyvsp[(1) - (1)].with_list_element_));
+    (yyval.with_list_)->push_back((yyvsp[0].with_list_element_));
   }
+#line 4316 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 111:
-/* Line 1792 of yacc.c  */
-#line 1192 "../SqlParser.ypp"
+#line 1192 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.with_list_) = (yyvsp[(1) - (3)].with_list_);
-    (yyval.with_list_)->push_back((yyvsp[(3) - (3)].with_list_element_));
+    (yyval.with_list_) = (yyvsp[-2].with_list_);
+    (yyval.with_list_)->push_back((yyvsp[0].with_list_element_));
   }
+#line 4325 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 112:
-/* Line 1792 of yacc.c  */
-#line 1198 "../SqlParser.ypp"
+#line 1198 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.with_list_element_) = new quickstep::ParseSubqueryTableReference((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(3) - (3)].subquery_expression_));
-    (yyval.with_list_element_)->set_table_reference_signature((yyvsp[(1) - (3)].table_reference_signature_));
+    (yyval.with_list_element_) = new quickstep::ParseSubqueryTableReference((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[0].subquery_expression_));
+    (yyval.with_list_element_)->set_table_reference_signature((yyvsp[-2].table_reference_signature_));
   }
+#line 4334 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 113:
-/* Line 1792 of yacc.c  */
-#line 1205 "../SqlParser.ypp"
+#line 1205 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.select_query_) = new quickstep::ParseSelect((yylsp[(1) - (10)]).first_line, (yylsp[(1) - (10)]).first_column, (yyvsp[(3) - (10)].selection_), (yyvsp[(4) - (10)].table_reference_list_), (yyvsp[(5) - (10)].predicate_), (yyvsp[(6) - (10)].opt_group_by_clause_), (yyvsp[(7) - (10)].opt_having_clause_), (yyvsp[(8) - (10)].opt_order_by_clause_), (yyvsp[(9) - (10)].opt_limit_clause_), (yyvsp[(10) - (10)].opt_window_clause_));
+    (yyval.select_query_) = new quickstep::ParseSelect((yylsp[-9]).first_line, (yylsp[-9]).first_column, (yyvsp[-7].selection_), (yyvsp[-6].table_reference_list_), (yyvsp[-5].predicate_), (yyvsp[-4].opt_group_by_clause_), (yyvsp[-3].opt_having_clause_), (yyvsp[-2].opt_order_by_clause_), (yyvsp[-1].opt_limit_clause_), (yyvsp[0].opt_window_clause_));
   }
+#line 4342 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 114:
-/* Line 1792 of yacc.c  */
-#line 1210 "../SqlParser.ypp"
+#line 1210 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /* $$ = nullptr; */
   }
+#line 4350 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 115:
-/* Line 1792 of yacc.c  */
-#line 1213 "../SqlParser.ypp"
+#line 1213 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    NotSupported(&(yylsp[(1) - (1)]), yyscanner, "ALL in selection");
+    NotSupported(&(yylsp[0]), yyscanner, "ALL in selection");
     YYERROR;
   }
+#line 4359 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 116:
-/* Line 1792 of yacc.c  */
-#line 1217 "../SqlParser.ypp"
+#line 1217 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    NotSupported(&(yylsp[(1) - (1)]), yyscanner, "DISTINCT in selection");
+    NotSupported(&(yylsp[0]), yyscanner, "DISTINCT in selection");
     YYERROR;
   }
+#line 4368 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 117:
-/* Line 1792 of yacc.c  */
-#line 1223 "../SqlParser.ypp"
+#line 1223 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_) = new quickstep::ParseSelectionStar((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column);
+    (yyval.selection_) = new quickstep::ParseSelectionStar((yylsp[0]).first_line, (yylsp[0]).first_column);
   }
+#line 4376 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 118:
-/* Line 1792 of yacc.c  */
-#line 1226 "../SqlParser.ypp"
+#line 1226 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_) = (yyvsp[(1) - (1)].selection_list_);
+    (yyval.selection_) = (yyvsp[0].selection_list_);
   }
+#line 4384 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 119:
-/* Line 1792 of yacc.c  */
-#line 1231 "../SqlParser.ypp"
+#line 1231 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_list_) = new quickstep::ParseSelectionList((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column);
-    (yyval.selection_list_)->add((yyvsp[(1) - (1)].selection_item_));
+    (yyval.selection_list_) = new quickstep::ParseSelectionList((yylsp[0]).first_line, (yylsp[0]).first_column);
+    (yyval.selection_list_)->add((yyvsp[0].selection_item_));
   }
+#line 4393 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 120:
-/* Line 1792 of yacc.c  */
-#line 1235 "../SqlParser.ypp"
+#line 1235 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_list_) = (yyvsp[(1) - (3)].selection_list_);
-    (yyval.selection_list_)->add((yyvsp[(3) - (3)].selection_item_));
+    (yyval.selection_list_) = (yyvsp[-2].selection_list_);
+    (yyval.selection_list_)->add((yyvsp[0].selection_item_));
   }
+#line 4402 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 121:
-/* Line 1792 of yacc.c  */
-#line 1241 "../SqlParser.ypp"
+#line 1241 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_item_) = new quickstep::ParseSelectionItem((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(1) - (3)].expression_), (yyvsp[(3) - (3)].string_value_));
+    (yyval.selection_item_) = new quickstep::ParseSelectionItem((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-2].expression_), (yyvsp[0].string_value_));
   }
+#line 4410 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 122:
-/* Line 1792 of yacc.c  */
-#line 1244 "../SqlParser.ypp"
+#line 1244 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_item_) = new quickstep::ParseSelectionItem((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].expression_), (yyvsp[(2) - (2)].string_value_));
+    (yyval.selection_item_) = new quickstep::ParseSelectionItem((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].expression_), (yyvsp[0].string_value_));
   }
+#line 4418 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 123:
-/* Line 1792 of yacc.c  */
-#line 1247 "../SqlParser.ypp"
+#line 1247 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.selection_item_) = new quickstep::ParseSelectionItem((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, (yyvsp[(1) - (1)].expression_));
+    (yyval.selection_item_) = new quickstep::ParseSelectionItem((yylsp[0]).first_line, (yylsp[0]).first_column, (yyvsp[0].expression_));
   }
+#line 4426 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 124:
-/* Line 1792 of yacc.c  */
-#line 1252 "../SqlParser.ypp"
+#line 1252 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_list_) = (yyvsp[(2) - (2)].table_reference_list_);
+    (yyval.table_reference_list_) = (yyvsp[0].table_reference_list_);
   }
+#line 4434 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 125:
-/* Line 1792 of yacc.c  */
-#line 1257 "../SqlParser.ypp"
+#line 1257 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.subquery_expression_) = new quickstep::ParseSubqueryExpression((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(2) - (3)].select_query_));
+    (yyval.subquery_expression_) = new quickstep::ParseSubqueryExpression((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-1].select_query_));
   }
+#line 4442 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 126:
-/* Line 1792 of yacc.c  */
-#line 1262 "../SqlParser.ypp"
+#line 1262 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_sample_clause_) = NULL;
   }
+#line 4450 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 127:
-/* Line 1792 of yacc.c  */
-#line 1265 "../SqlParser.ypp"
+#line 1265 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_sample_clause_) = new quickstep::ParseSample((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, true, (yyvsp[(2) - (3)].numeric_literal_value_));
+    (yyval.opt_sample_clause_) = new quickstep::ParseSample((yylsp[-2]).first_line, (yylsp[-2]).first_column, true, (yyvsp[-1].numeric_literal_value_));
   }
+#line 4458 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 128:
-/* Line 1792 of yacc.c  */
-#line 1268 "../SqlParser.ypp"
+#line 1268 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_sample_clause_) = new quickstep::ParseSample((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, false, (yyvsp[(2) - (3)].numeric_literal_value_));
+    (yyval.opt_sample_clause_) = new quickstep::ParseSample((yylsp[-2]).first_line, (yylsp[-2]).first_column, false, (yyvsp[-1].numeric_literal_value_));
   }
+#line 4466 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 129:
-/* Line 1792 of yacc.c  */
-#line 1273 "../SqlParser.ypp"
+#line 1273 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kInnerJoin;
   }
+#line 4474 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 130:
-/* Line 1792 of yacc.c  */
-#line 1276 "../SqlParser.ypp"
+#line 1276 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kInnerJoin;
   }
+#line 4482 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 131:
-/* Line 1792 of yacc.c  */
-#line 1279 "../SqlParser.ypp"
+#line 1279 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kLeftOuterJoin;
   }
+#line 4490 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 132:
-/* Line 1792 of yacc.c  */
-#line 1282 "../SqlParser.ypp"
+#line 1282 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kLeftOuterJoin;
   }
+#line 4498 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 133:
-/* Line 1792 of yacc.c  */
-#line 1285 "../SqlParser.ypp"
+#line 1285 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kRightOuterJoin;
   }
+#line 4506 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 134:
-/* Line 1792 of yacc.c  */
-#line 1288 "../SqlParser.ypp"
+#line 1288 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kRightOuterJoin;
   }
+#line 4514 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 135:
-/* Line 1792 of yacc.c  */
-#line 1291 "../SqlParser.ypp"
+#line 1291 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kFullOuterJoin;
   }
+#line 4522 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 136:
-/* Line 1792 of yacc.c  */
-#line 1294 "../SqlParser.ypp"
+#line 1294 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.join_type_) = quickstep::ParseJoinedTableReference::JoinType::kFullOuterJoin;
   }
+#line 4530 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 137:
-/* Line 1792 of yacc.c  */
-#line 1299 "../SqlParser.ypp"
+#line 1299 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = new quickstep::ParseJoinedTableReference((yylsp[(3) - (6)]).first_line, (yylsp[(3) - (6)]).first_column, (yyvsp[(2) - (6)].join_type_), (yyvsp[(1) - (6)].table_reference_), (yyvsp[(4) - (6)].table_reference_), (yyvsp[(6) - (6)].predicate_));
+    (yyval.table_reference_) = new quickstep::ParseJoinedTableReference((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-4].join_type_), (yyvsp[-5].table_reference_), (yyvsp[-2].table_reference_), (yyvsp[0].predicate_));
   }
+#line 4538 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 138:
-/* Line 1792 of yacc.c  */
-#line 1302 "../SqlParser.ypp"
+#line 1302 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = (yyvsp[(1) - (1)].table_reference_);
+    (yyval.table_reference_) = (yyvsp[0].table_reference_);
   }
+#line 4546 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 139:
-/* Line 1792 of yacc.c  */
-#line 1307 "../SqlParser.ypp"
+#line 1307 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = new quickstep::ParseSubqueryTableReference((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].subquery_expression_));
-    (yyval.table_reference_)->set_table_reference_signature((yyvsp[(2) - (2)].table_reference_signature_));
+    (yyval.table_reference_) = new quickstep::ParseSubqueryTableReference((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].subquery_expression_));
+    (yyval.table_reference_)->set_table_reference_signature((yyvsp[0].table_reference_signature_));
   }
+#line 4555 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 140:
-/* Line 1792 of yacc.c  */
-#line 1311 "../SqlParser.ypp"
+#line 1311 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = new quickstep::ParseSimpleTableReference((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(1) - (3)].string_value_), (yyvsp[(2) - (3)].opt_sample_clause_));
-    (yyval.table_reference_)->set_table_reference_signature((yyvsp[(3) - (3)].table_reference_signature_));
+    (yyval.table_reference_) = new quickstep::ParseSimpleTableReference((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-2].string_value_), (yyvsp[-1].opt_sample_clause_));
+    (yyval.table_reference_)->set_table_reference_signature((yyvsp[0].table_reference_signature_));
   }
+#line 4564 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 141:
-/* Line 1792 of yacc.c  */
-#line 1315 "../SqlParser.ypp"
+#line 1315 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = new quickstep::ParseSimpleTableReference((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].string_value_), (yyvsp[(2) - (2)].opt_sample_clause_));
+    (yyval.table_reference_) = new quickstep::ParseSimpleTableReference((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].opt_sample_clause_));
   }
+#line 4572 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 142:
-/* Line 1792 of yacc.c  */
-#line 1318 "../SqlParser.ypp"
+#line 1318 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = new quickstep::ParseGeneratorTableReference((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].function_call_));
-    (yyval.table_reference_)->set_table_reference_signature((yyvsp[(2) - (2)].table_reference_signature_));
+    (yyval.table_reference_) = new quickstep::ParseGeneratorTableReference((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].function_call_));
+    (yyval.table_reference_)->set_table_reference_signature((yyvsp[0].table_reference_signature_));
   }
+#line 4581 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 143:
-/* Line 1792 of yacc.c  */
-#line 1322 "../SqlParser.ypp"
+#line 1322 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = new quickstep::ParseGeneratorTableReference((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, (yyvsp[(1) - (1)].function_call_));
+    (yyval.table_reference_) = new quickstep::ParseGeneratorTableReference((yylsp[0]).first_line, (yylsp[0]).first_column, (yyvsp[0].function_call_));
   }
+#line 4589 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 144:
-/* Line 1792 of yacc.c  */
-#line 1325 "../SqlParser.ypp"
+#line 1325 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_) = (yyvsp[(2) - (3)].table_reference_);
+    (yyval.table_reference_) = (yyvsp[-1].table_reference_);
   }
+#line 4597 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 145:
-/* Line 1792 of yacc.c  */
-#line 1330 "../SqlParser.ypp"
+#line 1330 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_signature_) = (yyvsp[(1) - (1)].table_reference_signature_);
+    (yyval.table_reference_signature_) = (yyvsp[0].table_reference_signature_);
   }
+#line 4605 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 146:
-/* Line 1792 of yacc.c  */
-#line 1333 "../SqlParser.ypp"
+#line 1333 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_signature_) = (yyvsp[(2) - (2)].table_reference_signature_);
+    (yyval.table_reference_signature_) = (yyvsp[0].table_reference_signature_);
   }
+#line 4613 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 147:
-/* Line 1792 of yacc.c  */
-#line 1338 "../SqlParser.ypp"
+#line 1338 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_signature_) = new ::quickstep::ParseTableReferenceSignature((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, (yyvsp[(1) - (1)].string_value_));
+    (yyval.table_reference_signature_) = new ::quickstep::ParseTableReferenceSignature((yylsp[0]).first_line, (yylsp[0]).first_column, (yyvsp[0].string_value_));
   }
+#line 4621 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 148:
-/* Line 1792 of yacc.c  */
-#line 1341 "../SqlParser.ypp"
+#line 1341 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_signature_) = new ::quickstep::ParseTableReferenceSignature((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(1) - (4)].string_value_), (yyvsp[(3) - (4)].string_list_));
+    (yyval.table_reference_signature_) = new ::quickstep::ParseTableReferenceSignature((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-3].string_value_), (yyvsp[-1].string_list_));
   }
+#line 4629 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 149:
-/* Line 1792 of yacc.c  */
-#line 1346 "../SqlParser.ypp"
+#line 1346 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.table_reference_list_) = new quickstep::PtrList<quickstep::ParseTableReference>();
-    (yyval.table_reference_list_)->push_back((yyvsp[(1) - (1)].table_reference_));
+    (yyval.table_reference_list_)->push_back((yyvsp[0].table_reference_));
   }
+#line 4638 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 150:
-/* Line 1792 of yacc.c  */
-#line 1350 "../SqlParser.ypp"
+#line 1350 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.table_reference_list_) = (yyvsp[(1) - (3)].table_reference_list_);
-    (yyval.table_reference_list_)->push_back((yyvsp[(3) - (3)].table_reference_));
+    (yyval.table_reference_list_) = (yyvsp[-2].table_reference_list_);
+    (yyval.table_reference_list_)->push_back((yyvsp[0].table_reference_));
   }
+#line 4647 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 151:
-/* Line 1792 of yacc.c  */
-#line 1356 "../SqlParser.ypp"
+#line 1356 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_group_by_clause_) = nullptr;
   }
+#line 4655 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 152:
-/* Line 1792 of yacc.c  */
-#line 1359 "../SqlParser.ypp"
+#line 1359 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_group_by_clause_) = new quickstep::ParseGroupBy((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(3) - (3)].expression_list_));
+    (yyval.opt_group_by_clause_) = new quickstep::ParseGroupBy((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[0].expression_list_));
   }
+#line 4663 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 153:
-/* Line 1792 of yacc.c  */
-#line 1364 "../SqlParser.ypp"
+#line 1364 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_having_clause_) = nullptr;
   }
+#line 4671 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 154:
-/* Line 1792 of yacc.c  */
-#line 1367 "../SqlParser.ypp"
+#line 1367 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_having_clause_) = new quickstep::ParseHaving((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(2) - (2)].predicate_));
+    (yyval.opt_having_clause_) = new quickstep::ParseHaving((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[0].predicate_));
   }
+#line 4679 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 155:
-/* Line 1792 of yacc.c  */
-#line 1372 "../SqlParser.ypp"
+#line 1372 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_order_by_clause_) = nullptr;
   }
+#line 4687 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 156:
-/* Line 1792 of yacc.c  */
-#line 1375 "../SqlParser.ypp"
+#line 1375 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_order_by_clause_) = new quickstep::ParseOrderBy((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(3) - (3)].order_commalist_));
+    (yyval.opt_order_by_clause_) = new quickstep::ParseOrderBy((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[0].order_commalist_));
   }
+#line 4695 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 157:
-/* Line 1792 of yacc.c  */
-#line 1380 "../SqlParser.ypp"
+#line 1380 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_limit_clause_) = nullptr;
   }
+#line 4703 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 158:
-/* Line 1792 of yacc.c  */
-#line 1383 "../SqlParser.ypp"
+#line 1383 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(2) - (2)].numeric_literal_value_)->float_like()) {
-      delete (yyvsp[(2) - (2)].numeric_literal_value_);
+    if ((yyvsp[0].numeric_literal_value_)->float_like()) {
+      delete (yyvsp[0].numeric_literal_value_);
       (yyval.opt_limit_clause_) = nullptr;
-      quickstep_yyerror(&(yylsp[(2) - (2)]), yyscanner, nullptr, "LIMIT value must be an integer");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "LIMIT value must be an integer");
       YYERROR;
     } else {
-      if ((yyvsp[(2) - (2)].numeric_literal_value_)->long_value() <= 0) {
-        delete (yyvsp[(2) - (2)].numeric_literal_value_);
+      if ((yyvsp[0].numeric_literal_value_)->long_value() <= 0) {
+        delete (yyvsp[0].numeric_literal_value_);
         (yyval.opt_limit_clause_) = nullptr;
-        quickstep_yyerror(&(yylsp[(2) - (2)]), yyscanner, nullptr, "LIMIT value must be positive");
+        quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "LIMIT value must be positive");
         YYERROR;
       } else {
-        (yyval.opt_limit_clause_) = new quickstep::ParseLimit((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(2) - (2)].numeric_literal_value_));
+        (yyval.opt_limit_clause_) = new quickstep::ParseLimit((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[0].numeric_literal_value_));
       }
     }
   }
+#line 4725 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 159:
-/* Line 1792 of yacc.c  */
-#line 1402 "../SqlParser.ypp"
+#line 1402 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_window_clause_) = nullptr;
   }
+#line 4733 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 160:
-/* Line 1792 of yacc.c  */
-#line 1405 "../SqlParser.ypp"
+#line 1405 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_window_clause_) = (yyvsp[(1) - (1)].opt_window_clause_);
+    (yyval.opt_window_clause_) = (yyvsp[0].opt_window_clause_);
   }
+#line 4741 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 161:
-/* Line 1792 of yacc.c  */
-#line 1410 "../SqlParser.ypp"
+#line 1410 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.opt_window_clause_) = new quickstep::PtrList<quickstep::ParseWindow>();
-    (yyval.opt_window_clause_)->push_back((yyvsp[(1) - (1)].window_definition_));
+    (yyval.opt_window_clause_)->push_back((yyvsp[0].window_definition_));
   }
+#line 4750 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 162:
-/* Line 1792 of yacc.c  */
-#line 1414 "../SqlParser.ypp"
+#line 1414 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.opt_window_clause_) = (yyvsp[(1) - (2)].opt_window_clause_);
-    (yyval.opt_window_clause_)->push_back((yyvsp[(2) - (2)].window_definition_));
+    (yyval.opt_window_clause_) = (yyvsp[-1].opt_window_clause_);
+    (yyval.opt_window_clause_)->push_back((yyvsp[0].window_definition_));
   }
+#line 4759 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 163:
-/* Line 1792 of yacc.c  */
-#line 1420 "../SqlParser.ypp"
+#line 1420 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.window_definition_) = (yyvsp[(5) - (6)].window_definition_);
-    (yyval.window_definition_)->setName((yyvsp[(2) - (6)].string_value_));
+    (yyval.window_definition_) = (yyvsp[-1].window_definition_);
+    (yyval.window_definition_)->setName((yyvsp[-4].string_value_));
   }
+#line 4768 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 164:
-/* Line 1792 of yacc.c  */
-#line 1426 "../SqlParser.ypp"
+#line 1426 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.window_definition_) = new quickstep::ParseWindow((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(1) - (3)].window_partition_by_list_), (yyvsp[(2) - (3)].window_order_by_list_), (yyvsp[(3) - (3)].window_frame_info_));
+    (yyval.window_definition_) = new quickstep::ParseWindow((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-2].window_partition_by_list_), (yyvsp[-1].window_order_by_list_), (yyvsp[0].window_frame_info_));
   }
+#line 4776 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 165:
-/* Line 1792 of yacc.c  */
-#line 1431 "../SqlParser.ypp"
+#line 1431 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.window_partition_by_list_) = nullptr;
   }
+#line 4784 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 166:
-/* Line 1792 of yacc.c  */
-#line 1434 "../SqlParser.ypp"
+#line 1434 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.window_partition_by_list_) = (yyvsp[(3) - (3)].expression_list_);
+    (yyval.window_partition_by_list_) = (yyvsp[0].expression_list_);
   }
+#line 4792 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 167:
-/* Line 1792 of yacc.c  */
-#line 1439 "../SqlParser.ypp"
+#line 1439 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.window_order_by_list_) = nullptr;
   }
+#line 4800 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 168:
-/* Line 1792 of yacc.c  */
-#line 1442 "../SqlParser.ypp"
+#line 1442 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.window_order_by_list_) = (yyvsp[(3) - (3)].order_commalist_);
+    (yyval.window_order_by_list_) = (yyvsp[0].order_commalist_);
   }
+#line 4808 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 169:
-/* Line 1792 of yacc.c  */
-#line 1447 "../SqlParser.ypp"
+#line 1447 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.window_frame_info_) = nullptr;
   }
+#line 4816 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 170:
-/* Line 1792 of yacc.c  */
-#line 1450 "../SqlParser.ypp"
+#line 1450 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.window_frame_info_) = new quickstep::ParseFrameInfo((yylsp[(1) - (5)]).first_line, (yylsp[(1) - (5)]).first_column, (yyvsp[(1) - (5)].boolean_value_), (yyvsp[(3) - (5)].numeric_literal_value_)->long_value(), (yyvsp[(5) - (5)].numeric_literal_value_)->long_value());
+    (yyval.window_frame_info_) = new quickstep::ParseFrameInfo((yylsp[-4]).first_line, (yylsp[-4]).first_column, (yyvsp[-4].boolean_value_), (yyvsp[-2].numeric_literal_value_)->long_value(), (yyvsp[0].numeric_literal_value_)->long_value());
   }
+#line 4824 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 171:
-/* Line 1792 of yacc.c  */
-#line 1455 "../SqlParser.ypp"
+#line 1455 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.boolean_value_) = true;
   }
+#line 4832 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 172:
-/* Line 1792 of yacc.c  */
-#line 1458 "../SqlParser.ypp"
+#line 1458 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.boolean_value_) = false;
   }
+#line 4840 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 174:
-/* Line 1792 of yacc.c  */
-#line 1464 "../SqlParser.ypp"
+#line 1464 "../SqlParser.ypp" /* yacc.c:1646  */
     { 
-    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, "-1");
+    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, "-1");
   }
+#line 4848 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 175:
-/* Line 1792 of yacc.c  */
-#line 1467 "../SqlParser.ypp"
+#line 1467 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, "0");
+    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, "0");
   }
+#line 4856 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 177:
-/* Line 1792 of yacc.c  */
-#line 1473 "../SqlParser.ypp"
+#line 1473 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, "-1");
+    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, "-1");
   }
+#line 4864 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 178:
-/* Line 1792 of yacc.c  */
-#line 1476 "../SqlParser.ypp"
+#line 1476 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, "0");
+    (yyval.numeric_literal_value_) = new quickstep::NumericParseLiteralValue((yylsp[-1]).first_line, (yylsp[-1]).first_column, "0");
   }
+#line 4872 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 179:
-/* Line 1792 of yacc.c  */
-#line 1481 "../SqlParser.ypp"
+#line 1481 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_commalist_) = new quickstep::PtrList<quickstep::ParseOrderByItem>();
-    (yyval.order_commalist_)->push_back((yyvsp[(1) - (1)].order_item_));
+    (yyval.order_commalist_)->push_back((yyvsp[0].order_item_));
   }
+#line 4881 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 180:
-/* Line 1792 of yacc.c  */
-#line 1485 "../SqlParser.ypp"
+#line 1485 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.order_commalist_) = (yyvsp[(1) - (3)].order_commalist_);
-    (yyval.order_commalist_)->push_back((yyvsp[(3) - (3)].order_item_));
+    (yyval.order_commalist_) = (yyvsp[-2].order_commalist_);
+    (yyval.order_commalist_)->push_back((yyvsp[0].order_item_));
   }
+#line 4890 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 181:
-/* Line 1792 of yacc.c  */
-#line 1491 "../SqlParser.ypp"
+#line 1491 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.order_item_) = new quickstep::ParseOrderByItem((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(1) - (3)].expression_), (yyvsp[(2) - (3)].order_direction_), (yyvsp[(3) - (3)].order_direction_));
-    delete (yyvsp[(2) - (3)].order_direction_);
-    delete (yyvsp[(3) - (3)].order_direction_);
+    (yyval.order_item_) = new quickstep::ParseOrderByItem((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[-2].expression_), (yyvsp[-1].order_direction_), (yyvsp[0].order_direction_));
+    delete (yyvsp[-1].order_direction_);
+    delete (yyvsp[0].order_direction_);
   }
+#line 4900 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 182:
-/* Line 1792 of yacc.c  */
-#line 1498 "../SqlParser.ypp"
+#line 1498 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_direction_) = nullptr;
   }
+#line 4908 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 183:
-/* Line 1792 of yacc.c  */
-#line 1501 "../SqlParser.ypp"
+#line 1501 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_direction_) = new bool(true);
   }
+#line 4916 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 184:
-/* Line 1792 of yacc.c  */
-#line 1504 "../SqlParser.ypp"
+#line 1504 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_direction_) = new bool(false);
   }
+#line 4924 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 185:
-/* Line 1792 of yacc.c  */
-#line 1509 "../SqlParser.ypp"
+#line 1509 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_direction_) = nullptr;
   }
+#line 4932 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 186:
-/* Line 1792 of yacc.c  */
-#line 1512 "../SqlParser.ypp"
+#line 1512 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_direction_) = new bool(true);
   }
+#line 4940 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 187:
-/* Line 1792 of yacc.c  */
-#line 1515 "../SqlParser.ypp"
+#line 1515 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.order_direction_) = new bool(false);
   }
+#line 4948 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 188:
-/* Line 1792 of yacc.c  */
-#line 1521 "../SqlParser.ypp"
+#line 1521 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.predicate_) = nullptr;
   }
+#line 4956 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 189:
-/* Line 1792 of yacc.c  */
-#line 1524 "../SqlParser.ypp"
+#line 1524 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = (yyvsp[(1) - (1)].predicate_);
+    (yyval.predicate_) = (yyvsp[0].predicate_);
   }
+#line 4964 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 190:
-/* Line 1792 of yacc.c  */
-#line 1529 "../SqlParser.ypp"
+#line 1529 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = (yyvsp[(2) - (2)].predicate_);
+    (yyval.predicate_) = (yyvsp[0].predicate_);
   }
+#line 4972 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 191:
-/* Line 1792 of yacc.c  */
-#line 1534 "../SqlParser.ypp"
+#line 1534 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(1) - (3)].predicate_)->getParsePredicateType() == quickstep::ParsePredicate::kDisjunction) {
-      (yyval.predicate_) = (yyvsp[(1) - (3)].predicate_);
+    if ((yyvsp[-2].predicate_)->getParsePredicateType() == quickstep::ParsePredicate::kDisjunction) {
+      (yyval.predicate_) = (yyvsp[-2].predicate_);
     } else {
-      (yyval.predicate_) = new quickstep::ParsePredicateDisjunction((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column);
-      static_cast<quickstep::ParsePredicateDisjunction *>((yyval.predicate_))->addPredicate((yyvsp[(1) - (3)].predicate_));
+      (yyval.predicate_) = new quickstep::ParsePredicateDisjunction((yylsp[-2]).first_line, (yylsp[-2]).first_column);
+      static_cast<quickstep::ParsePredicateDisjunction *>((yyval.predicate_))->addPredicate((yyvsp[-2].predicate_));
     }
-    static_cast<quickstep::ParsePredicateDisjunction *>((yyval.predicate_))->addPredicate((yyvsp[(3) - (3)].predicate_));
+    static_cast<quickstep::ParsePredicateDisjunction *>((yyval.predicate_))->addPredicate((yyvsp[0].predicate_));
   }
+#line 4986 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 192:
-/* Line 1792 of yacc.c  */
-#line 1543 "../SqlParser.ypp"
+#line 1543 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = (yyvsp[(1) - (1)].predicate_);
+    (yyval.predicate_) = (yyvsp[0].predicate_);
   }
+#line 4994 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 193:
-/* Line 1792 of yacc.c  */
-#line 1548 "../SqlParser.ypp"
+#line 1548 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(1) - (3)].predicate_)->getParsePredicateType() == quickstep::ParsePredicate::kConjunction) {
-      (yyval.predicate_) = (yyvsp[(1) - (3)].predicate_);
+    if ((yyvsp[-2].predicate_)->getParsePredicateType() == quickstep::ParsePredicate::kConjunction) {
+      (yyval.predicate_) = (yyvsp[-2].predicate_);
     } else {
-      (yyval.predicate_) = new quickstep::ParsePredicateConjunction((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column);
-      static_cast<quickstep::ParsePredicateConjunction *>((yyval.predicate_))->addPredicate((yyvsp[(1) - (3)].predicate_));
+      (yyval.predicate_) = new quickstep::ParsePredicateConjunction((yylsp[-2]).first_line, (yylsp[-2]).first_column);
+      static_cast<quickstep::ParsePredicateConjunction *>((yyval.predicate_))->addPredicate((yyvsp[-2].predicate_));
     }
-    static_cast<quickstep::ParsePredicateConjunction *>((yyval.predicate_))->addPredicate((yyvsp[(3) - (3)].predicate_));
+    static_cast<quickstep::ParsePredicateConjunction *>((yyval.predicate_))->addPredicate((yyvsp[0].predicate_));
   }
+#line 5008 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 194:
-/* Line 1792 of yacc.c  */
-#line 1557 "../SqlParser.ypp"
+#line 1557 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = (yyvsp[(1) - (1)].predicate_);
+    (yyval.predicate_) = (yyvsp[0].predicate_);
   }
+#line 5016 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 195:
-/* Line 1792 of yacc.c  */
-#line 1562 "../SqlParser.ypp"
+#line 1562 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = new quickstep::ParsePredicateNegation((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(2) - (2)].predicate_));
+    (yyval.predicate_) = new quickstep::ParsePredicateNegation((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[0].predicate_));
   }
+#line 5024 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 196:
-/* Line 1792 of yacc.c  */
-#line 1565 "../SqlParser.ypp"
+#line 1565 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = (yyvsp[(1) - (1)].predicate_);
+    (yyval.predicate_) = (yyvsp[0].predicate_);
   }
+#line 5032 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 197:
-/* Line 1792 of yacc.c  */
-#line 1570 "../SqlParser.ypp"
+#line 1570 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = new quickstep::ParsePredicateBetween((yylsp[(2) - (5)]).first_line, (yylsp[(2) - (5)]).first_column, (yyvsp[(1) - (5)].expression_), (yyvsp[(3) - (5)].expression_), (yyvsp[(5) - (5)].expression_));
+    (yyval.predicate_) = new quickstep::ParsePredicateBetween((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-4].expression_), (yyvsp[-2].expression_), (yyvsp[0].expression_));
   }
+#line 5040 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 198:
-/* Line 1792 of yacc.c  */
-#line 1573 "../SqlParser.ypp"
+#line 1573 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.predicate_) = new quickstep::ParsePredicateNegation(
-        (yylsp[(2) - (6)]).first_line, (yylsp[(2) - (6)]).first_column,
-        new quickstep::ParsePredicateBetween((yylsp[(3) - (6)]).first_line, (yylsp[(3) - (6)]).first_column, (yyvsp[(1) - (6)].expression_), (yyvsp[(4) - (6)].expression_), (yyvsp[(6) - (6)].expression_)));
+        (yylsp[-4]).first_line, (yylsp[-4]).first_column,
+        new quickstep::ParsePredicateBetween((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-5].expression_), (yyvsp[-2].expression_), (yyvsp[0].expression_)));
   }
+#line 5050 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 199:
-/* Line 1792 of yacc.c  */
-#line 1578 "../SqlParser.ypp"
+#line 1578 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(1) - (4)].attribute_);
+    delete (yyvsp[-3].attribute_);
     (yyval.predicate_) = nullptr;
-    NotSupported(&(yylsp[(2) - (4)]), yyscanner, "NULL comparison predicates");
+    NotSupported(&(yylsp[-2]), yyscanner, "NULL comparison predicates");
     YYERROR;
   }
+#line 5061 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 200:
-/* Line 1792 of yacc.c  */
-#line 1584 "../SqlParser.ypp"
+#line 1584 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    delete (yyvsp[(1) - (3)].attribute_);
+    delete (yyvsp[-2].attribute_);
     (yyval.predicate_) = nullptr;
-    NotSupported(&(yylsp[(2) - (3)]), yyscanner, "NULL comparison predicates");
+    NotSupported(&(yylsp[-1]), yyscanner, "NULL comparison predicates");
     YYERROR;
   }
+#line 5072 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 201:
-/* Line 1792 of yacc.c  */
-#line 1590 "../SqlParser.ypp"
+#line 1590 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = new quickstep::ParsePredicateComparison((yylsp[(2) - (3)]).first_line, (yylsp[(2) - (3)]).first_column, *(yyvsp[(2) - (3)].comparison_), (yyvsp[(1) - (3)].expression_), (yyvsp[(3) - (3)].expression_));
+    (yyval.predicate_) = new quickstep::ParsePredicateComparison((yylsp[-1]).first_line, (yylsp[-1]).first_column, *(yyvsp[-1].comparison_), (yyvsp[-2].expression_), (yyvsp[0].expression_));
   }
+#line 5080 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 202:
-/* Line 1792 of yacc.c  */
-#line 1593 "../SqlParser.ypp"
+#line 1593 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = (yyvsp[(2) - (3)].predicate_);
+    (yyval.predicate_) = (yyvsp[-1].predicate_);
   }
+#line 5088 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 203:
-/* Line 1792 of yacc.c  */
-#line 1596 "../SqlParser.ypp"
+#line 1596 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = new quickstep::ParsePredicateExists((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(2) - (2)].subquery_expression_));
+    (yyval.predicate_) = new quickstep::ParsePredicateExists((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[0].subquery_expression_));
   }
+#line 5096 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 204:
-/* Line 1792 of yacc.c  */
-#line 1599 "../SqlParser.ypp"
+#line 1599 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = new quickstep::ParsePredicateInTableQuery((yylsp[(2) - (3)]).first_line, (yylsp[(2) - (3)]).first_column, (yyvsp[(1) - (3)].expression_), (yyvsp[(3) - (3)].subquery_expression_));
+    (yyval.predicate_) = new quickstep::ParsePredicateInTableQuery((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-2].expression_), (yyvsp[0].subquery_expression_));
   }
+#line 5104 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 205:
-/* Line 1792 of yacc.c  */
-#line 1602 "../SqlParser.ypp"
+#line 1602 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.predicate_) = new quickstep::ParsePredicateInValueList((yylsp[(2) - (5)]).first_line, (yylsp[(2) - (5)]).first_column, (yyvsp[(1) - (5)].expression_), (yyvsp[(4) - (5)].expression_list_));
+    (yyval.predicate_) = new quickstep::ParsePredicateInValueList((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-4].expression_), (yyvsp[-1].expression_list_));
   }
+#line 5112 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 206:
-/* Line 1792 of yacc.c  */
-#line 1605 "../SqlParser.ypp"
+#line 1605 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.predicate_) = new quickstep::ParsePredicateNegation(
-        (yylsp[(2) - (4)]).first_line,
-        (yylsp[(2) - (4)]).first_column,
-        new quickstep::ParsePredicateInTableQuery((yylsp[(3) - (4)]).first_line, (yylsp[(3) - (4)]).first_column, (yyvsp[(1) - (4)].expression_), (yyvsp[(4) - (4)].subquery_expression_)));
+        (yylsp[-2]).first_line,
+        (yylsp[-2]).first_column,
+        new quickstep::ParsePredicateInTableQuery((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-3].expression_), (yyvsp[0].subquery_expression_)));
   }
+#line 5123 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 207:
-/* Line 1792 of yacc.c  */
-#line 1611 "../SqlParser.ypp"
+#line 1611 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.predicate_) = new quickstep::ParsePredicateNegation(
-        (yylsp[(2) - (6)]).first_line,
-        (yylsp[(2) - (6)]).first_column,
-        new quickstep::ParsePredicateInValueList((yylsp[(3) - (6)]).first_line, (yylsp[(3) - (6)]).first_column, (yyvsp[(1) - (6)].expression_), (yyvsp[(5) - (6)].expression_list_)));
+        (yylsp[-4]).first_line,
+        (yylsp[-4]).first_column,
+        new quickstep::ParsePredicateInValueList((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-5].expression_), (yyvsp[-1].expression_list_)));
   }
+#line 5134 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 208:
-/* Line 1792 of yacc.c  */
-#line 1620 "../SqlParser.ypp"
+#line 1620 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseBinaryExpression((yylsp[(2) - (3)]).first_line, (yylsp[(2) - (3)]).first_column, *(yyvsp[(2) - (3)].binary_operation_), (yyvsp[(1) - (3)].expression_), (yyvsp[(3) - (3)].expression_));
+    (yyval.expression_) = new quickstep::ParseBinaryExpression((yylsp[-1]).first_line, (yylsp[-1]).first_column, *(yyvsp[-1].binary_operation_), (yyvsp[-2].expression_), (yyvsp[0].expression_));
   }
+#line 5142 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 209:
-/* Line 1792 of yacc.c  */
-#line 1623 "../SqlParser.ypp"
+#line 1623 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5150 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 210:
-/* Line 1792 of yacc.c  */
-#line 1628 "../SqlParser.ypp"
+#line 1628 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseBinaryExpression((yylsp[(2) - (3)]).first_line, (yylsp[(2) - (3)]).first_column, *(yyvsp[(2) - (3)].binary_operation_), (yyvsp[(1) - (3)].expression_), (yyvsp[(3) - (3)].expression_));
+    (yyval.expression_) = new quickstep::ParseBinaryExpression((yylsp[-1]).first_line, (yylsp[-1]).first_column, *(yyvsp[-1].binary_operation_), (yyvsp[-2].expression_), (yyvsp[0].expression_));
   }
+#line 5158 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 211:
-/* Line 1792 of yacc.c  */
-#line 1631 "../SqlParser.ypp"
+#line 1631 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5166 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 212:
-/* Line 1792 of yacc.c  */
-#line 1636 "../SqlParser.ypp"
+#line 1636 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseUnaryExpression((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, *(yyvsp[(1) - (2)].unary_operation_), (yyvsp[(2) - (2)].expression_));
+    (yyval.expression_) = new quickstep::ParseUnaryExpression((yylsp[-1]).first_line, (yylsp[-1]).first_column, *(yyvsp[-1].unary_operation_), (yyvsp[0].expression_));
   }
+#line 5174 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 213:
-/* Line 1792 of yacc.c  */
-#line 1639 "../SqlParser.ypp"
+#line 1639 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5182 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 214:
-/* Line 1792 of yacc.c  */
-#line 1644 "../SqlParser.ypp"
+#line 1644 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].attribute_);
+    (yyval.expression_) = (yyvsp[0].attribute_);
   }
+#line 5190 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 215:
-/* Line 1792 of yacc.c  */
-#line 1647 "../SqlParser.ypp"
+#line 1647 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseScalarLiteral((yyvsp[(1) - (1)].literal_value_));
+    (yyval.expression_) = new quickstep::ParseScalarLiteral((yyvsp[0].literal_value_));
   }
+#line 5198 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 216:
-/* Line 1792 of yacc.c  */
-#line 1650 "../SqlParser.ypp"
+#line 1650 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].function_call_);
+    (yyval.expression_) = (yyvsp[0].function_call_);
   }
+#line 5206 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 217:
-/* Line 1792 of yacc.c  */
-#line 1653 "../SqlParser.ypp"
+#line 1653 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyvsp[(1) - (3)].function_call_)->setWindowName((yyvsp[(3) - (3)].string_value_));
-    (yyval.expression_) = (yyvsp[(1) - (3)].function_call_);
+    (yyvsp[-2].function_call_)->setWindowName((yyvsp[0].string_value_));
+    (yyval.expression_) = (yyvsp[-2].function_call_);
   }
+#line 5215 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 218:
-/* Line 1792 of yacc.c  */
-#line 1657 "../SqlParser.ypp"
+#line 1657 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyvsp[(1) - (5)].function_call_)->setWindow((yyvsp[(4) - (5)].window_definition_));
-    (yyval.expression_) = (yyvsp[(1) - (5)].function_call_);
+    (yyvsp[-4].function_call_)->setWindow((yyvsp[-1].window_definition_));
+    (yyval.expression_) = (yyvsp[-4].function_call_);
   }
+#line 5224 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 219:
-/* Line 1792 of yacc.c  */
-#line 1661 "../SqlParser.ypp"
+#line 1661 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5232 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 220:
-/* Line 1792 of yacc.c  */
-#line 1664 "../SqlParser.ypp"
+#line 1664 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5240 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 221:
-/* Line 1792 of yacc.c  */
-#line 1667 "../SqlParser.ypp"
+#line 1667 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5248 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 222:
-/* Line 1792 of yacc.c  */
-#line 1670 "../SqlParser.ypp"
+#line 1670 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(2) - (3)].expression_);
+    (yyval.expression_) = (yyvsp[-1].expression_);
   }
+#line 5256 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 223:
-/* Line 1792 of yacc.c  */
-#line 1673 "../SqlParser.ypp"
+#line 1673 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(1) - (1)].subquery_expression_);
+    (yyval.expression_) = (yyvsp[0].subquery_expression_);
   }
+#line 5264 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 224:
-/* Line 1792 of yacc.c  */
-#line 1678 "../SqlParser.ypp"
+#line 1678 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.function_call_) = new quickstep::ParseFunctionCall(
-        (yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, false, (yyvsp[(1) - (3)].string_value_), new quickstep::PtrList<quickstep::ParseExpression>());
+        (yylsp[-2]).first_line, (yylsp[-2]).first_column, false, (yyvsp[-2].string_value_), new quickstep::PtrList<quickstep::ParseExpression>());
   }
+#line 5273 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 225:
-/* Line 1792 of yacc.c  */
-#line 1682 "../SqlParser.ypp"
+#line 1682 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.function_call_) = new quickstep::ParseFunctionCall(
-        (yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(1) - (4)].string_value_), new quickstep::ParseStar((yylsp[(3) - (4)]).first_line, (yylsp[(3) - (4)]).first_column));
+        (yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-3].string_value_), new quickstep::ParseStar((yylsp[-1]).first_line, (yylsp[-1]).first_column));
   }
+#line 5282 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 226:
-/* Line 1792 of yacc.c  */
-#line 1686 "../SqlParser.ypp"
+#line 1686 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.function_call_) = new quickstep::ParseFunctionCall((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, false, (yyvsp[(1) - (4)].string_value_), (yyvsp[(3) - (4)].expression_list_));
+    (yyval.function_call_) = new quickstep::ParseFunctionCall((yylsp[-3]).first_line, (yylsp[-3]).first_column, false, (yyvsp[-3].string_value_), (yyvsp[-1].expression_list_));
   }
+#line 5290 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 227:
-/* Line 1792 of yacc.c  */
-#line 1689 "../SqlParser.ypp"
+#line 1689 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.function_call_) = new quickstep::ParseFunctionCall((yylsp[(1) - (5)]).first_line, (yylsp[(1) - (5)]).first_column, true, (yyvsp[(1) - (5)].string_value_), (yyvsp[(4) - (5)].expression_list_));
+    (yyval.function_call_) = new quickstep::ParseFunctionCall((yylsp[-4]).first_line, (yylsp[-4]).first_column, true, (yyvsp[-4].string_value_), (yyvsp[-1].expression_list_));
   }
+#line 5298 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 228:
-/* Line 1792 of yacc.c  */
-#line 1694 "../SqlParser.ypp"
+#line 1694 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseExtractFunction((yylsp[(1) - (6)]).first_line, (yylsp[(1) - (6)]).first_column, (yyvsp[(3) - (6)].string_value_), (yyvsp[(5) - (6)].expression_));
+    (yyval.expression_) = new quickstep::ParseExtractFunction((yylsp[-5]).first_line, (yylsp[-5]).first_column, (yyvsp[-3].string_value_), (yyvsp[-1].expression_));
   }
+#line 5306 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 229:
-/* Line 1792 of yacc.c  */
-#line 1699 "../SqlParser.ypp"
+#line 1699 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.expression_) = new quickstep::ParseSubstringFunction(
-        (yylsp[(1) - (6)]).first_line, (yylsp[(1) - (6)]).first_column, (yyvsp[(3) - (6)].expression_), (yyvsp[(5) - (6)].numeric_literal_value_)->long_value());
+        (yylsp[-5]).first_line, (yylsp[-5]).first_column, (yyvsp[-3].expression_), (yyvsp[-1].numeric_literal_value_)->long_value());
   }
+#line 5315 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 230:
-/* Line 1792 of yacc.c  */
-#line 1703 "../SqlParser.ypp"
+#line 1703 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.expression_) = new quickstep::ParseSubstringFunction(
-        (yylsp[(1) - (8)]).first_line, (yylsp[(1) - (8)]).first_column, (yyvsp[(3) - (8)].expression_), (yyvsp[(5) - (8)].numeric_literal_value_)->long_value(), (yyvsp[(7) - (8)].numeric_literal_value_)->long_value());
+        (yylsp[-7]).first_line, (yylsp[-7]).first_column, (yyvsp[-5].expression_), (yyvsp[-3].numeric_literal_value_)->long_value(), (yyvsp[-1].numeric_literal_value_)->long_value());
   }
+#line 5324 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 231:
-/* Line 1792 of yacc.c  */
-#line 1709 "../SqlParser.ypp"
+#line 1709 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseSimpleCaseExpression((yylsp[(1) - (5)]).first_line, (yylsp[(1) - (5)]).first_column, (yyvsp[(2) - (5)].expression_), (yyvsp[(3) - (5)].simple_when_clause_list_), (yyvsp[(4) - (5)].expression_));
+    (yyval.expression_) = new quickstep::ParseSimpleCaseExpression((yylsp[-4]).first_line, (yylsp[-4]).first_column, (yyvsp[-3].expression_), (yyvsp[-2].simple_when_clause_list_), (yyvsp[-1].expression_));
   }
+#line 5332 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 232:
-/* Line 1792 of yacc.c  */
-#line 1712 "../SqlParser.ypp"
+#line 1712 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = new quickstep::ParseSearchedCaseExpression((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(2) - (4)].searched_when_clause_list_), (yyvsp[(3) - (4)].expression_));
+    (yyval.expression_) = new quickstep::ParseSearchedCaseExpression((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-2].searched_when_clause_list_), (yyvsp[-1].expression_));
   }
+#line 5340 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 233:
-/* Line 1792 of yacc.c  */
-#line 1717 "../SqlParser.ypp"
+#line 1717 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.simple_when_clause_list_) = new quickstep::PtrVector<quickstep::ParseSimpleWhenClause>;
-    (yyval.simple_when_clause_list_)->push_back((yyvsp[(1) - (1)].simple_when_clause_));
+    (yyval.simple_when_clause_list_)->push_back((yyvsp[0].simple_when_clause_));
   }
+#line 5349 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 234:
-/* Line 1792 of yacc.c  */
-#line 1721 "../SqlParser.ypp"
+#line 1721 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.simple_when_clause_list_) = (yyvsp[(1) - (2)].simple_when_clause_list_);
-    (yyval.simple_when_clause_list_)->push_back((yyvsp[(2) - (2)].simple_when_clause_));
+    (yyval.simple_when_clause_list_) = (yyvsp[-1].simple_when_clause_list_);
+    (yyval.simple_when_clause_list_)->push_back((yyvsp[0].simple_when_clause_));
   }
+#line 5358 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 235:
-/* Line 1792 of yacc.c  */
-#line 1727 "../SqlParser.ypp"
+#line 1727 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.simple_when_clause_) = new quickstep::ParseSimpleWhenClause((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(2) - (4)].expression_), (yyvsp[(4) - (4)].expression_));
+    (yyval.simple_when_clause_) = new quickstep::ParseSimpleWhenClause((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-2].expression_), (yyvsp[0].expression_));
   }
+#line 5366 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 236:
-/* Line 1792 of yacc.c  */
-#line 1732 "../SqlParser.ypp"
+#line 1732 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.searched_when_clause_list_) = new quickstep::PtrVector<quickstep::ParseSearchedWhenClause>;
-    (yyval.searched_when_clause_list_)->push_back((yyvsp[(1) - (1)].searched_when_clause_));
+    (yyval.searched_when_clause_list_)->push_back((yyvsp[0].searched_when_clause_));
   }
+#line 5375 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 237:
-/* Line 1792 of yacc.c  */
-#line 1736 "../SqlParser.ypp"
+#line 1736 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.searched_when_clause_list_) = (yyvsp[(1) - (2)].searched_when_clause_list_);
-    (yyval.searched_when_clause_list_)->push_back((yyvsp[(2) - (2)].searched_when_clause_));
+    (yyval.searched_when_clause_list_) = (yyvsp[-1].searched_when_clause_list_);
+    (yyval.searched_when_clause_list_)->push_back((yyvsp[0].searched_when_clause_));
   }
+#line 5384 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 238:
-/* Line 1792 of yacc.c  */
-#line 1742 "../SqlParser.ypp"
+#line 1742 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.searched_when_clause_) = new quickstep::ParseSearchedWhenClause((yylsp[(1) - (4)]).first_line, (yylsp[(1) - (4)]).first_column, (yyvsp[(2) - (4)].predicate_), (yyvsp[(4) - (4)].expression_));
+    (yyval.searched_when_clause_) = new quickstep::ParseSearchedWhenClause((yylsp[-3]).first_line, (yylsp[-3]).first_column, (yyvsp[-2].predicate_), (yyvsp[0].expression_));
   }
+#line 5392 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 239:
-/* Line 1792 of yacc.c  */
-#line 1747 "../SqlParser.ypp"
+#line 1747 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.expression_) = NULL;
   }
+#line 5400 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 240:
-/* Line 1792 of yacc.c  */
-#line 1750 "../SqlParser.ypp"
+#line 1750 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_) = (yyvsp[(2) - (2)].expression_);
+    (yyval.expression_) = (yyvsp[0].expression_);
   }
+#line 5408 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 241:
-/* Line 1792 of yacc.c  */
-#line 1755 "../SqlParser.ypp"
+#line 1755 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.expression_list_) = new quickstep::PtrList<quickstep::ParseExpression>();
-    (yyval.expression_list_)->push_back((yyvsp[(1) - (1)].expression_));
+    (yyval.expression_list_)->push_back((yyvsp[0].expression_));
   }
+#line 5417 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 242:
-/* Line 1792 of yacc.c  */
-#line 1759 "../SqlParser.ypp"
+#line 1759 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.expression_list_) = (yyvsp[(1) - (3)].expression_list_);
-    (yyval.expression_list_)->push_back((yyvsp[(3) - (3)].expression_));
+    (yyval.expression_list_) = (yyvsp[-2].expression_list_);
+    (yyval.expression_list_)->push_back((yyvsp[0].expression_));
   }
+#line 5426 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 243:
-/* Line 1792 of yacc.c  */
-#line 1765 "../SqlParser.ypp"
+#line 1765 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.literal_value_) = new quickstep::NullParseLiteralValue((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column);
+    (yyval.literal_value_) = new quickstep::NullParseLiteralValue((yylsp[0]).first_line, (yylsp[0]).first_column);
   }
+#line 5434 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 244:
-/* Line 1792 of yacc.c  */
-#line 1768 "../SqlParser.ypp"
+#line 1768 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.literal_value_) = (yyvsp[(1) - (1)].numeric_literal_value_);
+    (yyval.literal_value_) = (yyvsp[0].numeric_literal_value_);
   }
+#line 5442 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 245:
-/* Line 1792 of yacc.c  */
-#line 1771 "../SqlParser.ypp"
+#line 1771 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.literal_value_) = (yyvsp[(2) - (2)].numeric_literal_value_);
+    (yyval.literal_value_) = (yyvsp[0].numeric_literal_value_);
   }
+#line 5450 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 246:
-/* Line 1792 of yacc.c  */
-#line 1774 "../SqlParser.ypp"
+#line 1774 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /**
      * NOTE(chasseur): This case exhibits a shift/reduce conflict with the
@@ -5842,23 +5460,23 @@ yyreduce:
      * pattern as a negative number literal rather than a unary minus operation
      * applied to a non-negative number literal).
      **/
-    (yyvsp[(2) - (2)].numeric_literal_value_)->prependMinus();
-    (yyval.literal_value_) = (yyvsp[(2) - (2)].numeric_literal_value_);
+    (yyvsp[0].numeric_literal_value_)->prependMinus();
+    (yyval.literal_value_) = (yyvsp[0].numeric_literal_value_);
   }
+#line 5467 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 247:
-/* Line 1792 of yacc.c  */
-#line 1786 "../SqlParser.ypp"
+#line 1786 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.literal_value_) = new quickstep::StringParseLiteralValue((yyvsp[(1) - (1)].string_value_),
+    (yyval.literal_value_) = new quickstep::StringParseLiteralValue((yyvsp[0].string_value_),
                                                 nullptr);  // No explicit type.
   }
+#line 5476 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 248:
-/* Line 1792 of yacc.c  */
-#line 1790 "../SqlParser.ypp"
+#line 1790 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /**
      * NOTE(chasseur): This case exhibits a shift/reduce conflict with the
@@ -5870,235 +5488,235 @@ yyreduce:
      * error being emitted because of an ambiguous type).
      **/
     quickstep::StringParseLiteralValue *parse_value;
-    if (quickstep::StringParseLiteralValue::ParseAmbiguousInterval((yyvsp[(2) - (2)].string_value_), &parse_value)) {
+    if (quickstep::StringParseLiteralValue::ParseAmbiguousInterval((yyvsp[0].string_value_), &parse_value)) {
       (yyval.literal_value_) = parse_value;
     } else {
       (yyval.literal_value_) = nullptr;
-      quickstep_yyerror(&(yylsp[(2) - (2)]), yyscanner, nullptr, "Failed to parse literal as specified type");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "Failed to parse literal as specified type");
       YYERROR;
     }
   }
+#line 5500 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 249:
-/* Line 1792 of yacc.c  */
-#line 1809 "../SqlParser.ypp"
+#line 1809 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     quickstep::StringParseLiteralValue *parse_value;
-    const std::string &datetime_type_value = (yyvsp[(3) - (3)].string_value_)->value();
+    const std::string &datetime_type_value = (yyvsp[0].string_value_)->value();
     if (quickstep::StringParseLiteralValue::ParseAmbiguousInterval(
-        &((yyvsp[(2) - (3)].string_value_)->append((" " + datetime_type_value).c_str(), datetime_type_value.length() + 1)),
+        &((yyvsp[-1].string_value_)->append((" " + datetime_type_value).c_str(), datetime_type_value.length() + 1)),
         &parse_value)) {
       (yyval.literal_value_) = parse_value;
     } else {
       (yyval.literal_value_) = nullptr;
-      quickstep_yyerror(&(yylsp[(3) - (3)]), yyscanner, nullptr, "Failed to parse literal as specified type");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "Failed to parse literal as specified type");
       YYERROR;
     }
   }
+#line 5518 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 250:
-/* Line 1792 of yacc.c  */
-#line 1822 "../SqlParser.ypp"
+#line 1822 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     quickstep::StringParseLiteralValue *parse_value
-        = new quickstep::StringParseLiteralValue((yyvsp[(2) - (2)].string_value_), &((yyvsp[(1) - (2)].data_type_)->getType()));
-    delete (yyvsp[(1) - (2)].data_type_);
+        = new quickstep::StringParseLiteralValue((yyvsp[0].string_value_), &((yyvsp[-1].data_type_)->getType()));
+    delete (yyvsp[-1].data_type_);
     if (!parse_value->tryExplicitTypeParse()) {
       delete parse_value;
       (yyval.literal_value_) = nullptr;
-      quickstep_yyerror(&(yylsp[(2) - (2)]), yyscanner, nullptr, "Failed to parse literal as specified type");
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "Failed to parse literal as specified type");
       YYERROR;
     } else {
       (yyval.literal_value_) = parse_value;
     }
   }
+#line 5536 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 251:
-/* Line 1792 of yacc.c  */
-#line 1837 "../SqlParser.ypp"
+#line 1837 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-     (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, std::string("YEAR"));
+     (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, std::string("YEAR"));
   }
+#line 5544 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 252:
-/* Line 1792 of yacc.c  */
-#line 1840 "../SqlParser.ypp"
+#line 1840 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-     (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, std::string("MONTH"));
+     (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, std::string("MONTH"));
   }
+#line 5552 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 253:
-/* Line 1792 of yacc.c  */
-#line 1843 "../SqlParser.ypp"
+#line 1843 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-     (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, std::string("DAY"));
+     (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, std::string("DAY"));
   }
+#line 5560 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 254:
-/* Line 1792 of yacc.c  */
-#line 1846 "../SqlParser.ypp"
+#line 1846 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-     (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, std::string("HOUR"));
+     (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, std::string("HOUR"));
   }
+#line 5568 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 255:
-/* Line 1792 of yacc.c  */
-#line 1849 "../SqlParser.ypp"
+#line 1849 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-     (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, std::string("MINUTE"));
+     (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, std::string("MINUTE"));
   }
+#line 5576 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 256:
-/* Line 1792 of yacc.c  */
-#line 1852 "../SqlParser.ypp"
+#line 1852 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-     (yyval.string_value_) = new quickstep::ParseString((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, std::string("SECOND"));
+     (yyval.string_value_) = new quickstep::ParseString((yylsp[0]).first_line, (yylsp[0]).first_column, std::string("SECOND"));
   }
+#line 5584 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 257:
-/* Line 1792 of yacc.c  */
-#line 1857 "../SqlParser.ypp"
+#line 1857 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.literal_value_list_) = new quickstep::PtrList<quickstep::ParseScalarLiteral>();
-    (yyval.literal_value_list_)->push_back(new quickstep::ParseScalarLiteral((yyvsp[(1) - (1)].literal_value_)));
+    (yyval.literal_value_list_)->push_back(new quickstep::ParseScalarLiteral((yyvsp[0].literal_value_)));
   }
+#line 5593 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 258:
-/* Line 1792 of yacc.c  */
-#line 1861 "../SqlParser.ypp"
+#line 1861 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.literal_value_list_) = (yyvsp[(1) - (3)].literal_value_list_);
-    (yyval.literal_value_list_)->push_back(new quickstep::ParseScalarLiteral((yyvsp[(3) - (3)].literal_value_)));
+    (yyval.literal_value_list_) = (yyvsp[-2].literal_value_list_);
+    (yyval.literal_value_list_)->push_back(new quickstep::ParseScalarLiteral((yyvsp[0].literal_value_)));
   }
+#line 5602 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 259:
-/* Line 1792 of yacc.c  */
-#line 1867 "../SqlParser.ypp"
+#line 1867 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.attribute_) = new quickstep::ParseAttribute((yylsp[(1) - (1)]).first_line, (yylsp[(1) - (1)]).first_column, (yyvsp[(1) - (1)].string_value_));
+    (yyval.attribute_) = new quickstep::ParseAttribute((yylsp[0]).first_line, (yylsp[0]).first_column, (yyvsp[0].string_value_));
   }
+#line 5610 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 260:
-/* Line 1792 of yacc.c  */
-#line 1870 "../SqlParser.ypp"
+#line 1870 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.attribute_) = new quickstep::ParseAttribute((yylsp[(1) - (3)]).first_line, (yylsp[(1) - (3)]).first_column, (yyvsp[(3) - (3)].string_value_), (yyvsp[(1) - (3)].string_value_));
+    (yyval.attribute_) = new quickstep::ParseAttribute((yylsp[-2]).first_line, (yylsp[-2]).first_column, (yyvsp[0].string_value_), (yyvsp[-2].string_value_));
   }
+#line 5618 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 261:
-/* Line 1792 of yacc.c  */
-#line 1875 "../SqlParser.ypp"
+#line 1875 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.attribute_list_) = new quickstep::PtrList<quickstep::ParseAttribute>();
-    (yyval.attribute_list_)->push_back((yyvsp[(1) - (1)].attribute_));
+    (yyval.attribute_list_)->push_back((yyvsp[0].attribute_));
   }
+#line 5627 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 262:
-/* Line 1792 of yacc.c  */
-#line 1879 "../SqlParser.ypp"
+#line 1879 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.attribute_list_) = (yyvsp[(1) - (3)].attribute_list_);
-    (yyval.attribute_list_)->push_back((yyvsp[(3) - (3)].attribute_));
+    (yyval.attribute_list_) = (yyvsp[-2].attribute_list_);
+    (yyval.attribute_list_)->push_back((yyvsp[0].attribute_));
   }
+#line 5636 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 263:
-/* Line 1792 of yacc.c  */
-#line 1886 "../SqlParser.ypp"
+#line 1886 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) = &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kEqual);
   }
+#line 5644 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 264:
-/* Line 1792 of yacc.c  */
-#line 1889 "../SqlParser.ypp"
+#line 1889 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) = &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kNotEqual);
   }
+#line 5652 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 265:
-/* Line 1792 of yacc.c  */
-#line 1892 "../SqlParser.ypp"
+#line 1892 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) = &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kLess);
   }
+#line 5660 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 266:
-/* Line 1792 of yacc.c  */
-#line 1895 "../SqlParser.ypp"
+#line 1895 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) = &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kLessOrEqual);
   }
+#line 5668 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 267:
-/* Line 1792 of yacc.c  */
-#line 1898 "../SqlParser.ypp"
+#line 1898 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) = &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kGreater);
   }
+#line 5676 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 268:
-/* Line 1792 of yacc.c  */
-#line 1901 "../SqlParser.ypp"
+#line 1901 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) = &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kGreaterOrEqual);
   }
+#line 5684 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 269:
-/* Line 1792 of yacc.c  */
-#line 1904 "../SqlParser.ypp"
+#line 1904 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) =  &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kLike);
   }
+#line 5692 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 270:
-/* Line 1792 of yacc.c  */
-#line 1907 "../SqlParser.ypp"
+#line 1907 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) =  &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kNotLike);
   }
+#line 5700 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 271:
-/* Line 1792 of yacc.c  */
-#line 1910 "../SqlParser.ypp"
+#line 1910 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) =  &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kRegexMatch);
   }
+#line 5708 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 272:
-/* Line 1792 of yacc.c  */
-#line 1913 "../SqlParser.ypp"
+#line 1913 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.comparison_) =  &quickstep::ComparisonFactory::GetComparison(quickstep::ComparisonID::kNotRegexMatch);
   }
+#line 5716 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 273:
-/* Line 1792 of yacc.c  */
-#line 1918 "../SqlParser.ypp"
+#line 1918 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     /**
      * NOTE(chasseur): This case exhibits a shift/reduce conflict with the
@@ -6108,146 +5726,146 @@ yyreduce:
      **/
     (yyval.unary_operation_) = &quickstep::UnaryOperationFactory::GetUnaryOperation(quickstep::UnaryOperationID::kNegate);
   }
+#line 5730 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 274:
-/* Line 1792 of yacc.c  */
-#line 1929 "../SqlParser.ypp"
+#line 1929 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.binary_operation_) = &quickstep::BinaryOperationFactory::GetBinaryOperation(quickstep::BinaryOperationID::kAdd);
   }
+#line 5738 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 275:
-/* Line 1792 of yacc.c  */
-#line 1932 "../SqlParser.ypp"
+#line 1932 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.binary_operation_) = &quickstep::BinaryOperationFactory::GetBinaryOperation(quickstep::BinaryOperationID::kSubtract);
   }
+#line 5746 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 276:
-/* Line 1792 of yacc.c  */
-#line 1937 "../SqlParser.ypp"
+#line 1937 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.binary_operation_) = &quickstep::BinaryOperationFactory::GetBinaryOperation(quickstep::BinaryOperationID::kModulo);
   }
+#line 5754 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 277:
-/* Line 1792 of yacc.c  */
-#line 1940 "../SqlParser.ypp"
+#line 1940 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.binary_operation_) = &quickstep::BinaryOperationFactory::GetBinaryOperation(quickstep::BinaryOperationID::kMultiply);
   }
+#line 5762 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 278:
-/* Line 1792 of yacc.c  */
-#line 1943 "../SqlParser.ypp"
+#line 1943 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.binary_operation_) = &quickstep::BinaryOperationFactory::GetBinaryOperation(quickstep::BinaryOperationID::kDivide);
   }
+#line 5770 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 279:
-/* Line 1792 of yacc.c  */
-#line 1949 "../SqlParser.ypp"
+#line 1949 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.string_list_) = new quickstep::PtrList<quickstep::ParseString>();
-    (yyval.string_list_)->push_back((yyvsp[(1) - (1)].string_value_));
+    (yyval.string_list_)->push_back((yyvsp[0].string_value_));
   }
+#line 5779 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 280:
-/* Line 1792 of yacc.c  */
-#line 1953 "../SqlParser.ypp"
+#line 1953 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_list_) = (yyvsp[(1) - (3)].string_list_);
-    (yyval.string_list_)->push_back((yyvsp[(3) - (3)].string_value_));
+    (yyval.string_list_) = (yyvsp[-2].string_list_);
+    (yyval.string_list_)->push_back((yyvsp[0].string_value_));
   }
+#line 5788 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 281:
-/* Line 1792 of yacc.c  */
-#line 1959 "../SqlParser.ypp"
+#line 1959 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.string_value_) = (yyvsp[(1) - (1)].string_value_);
+    (yyval.string_value_) = (yyvsp[0].string_value_);
   }
+#line 5796 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 282:
-/* Line 1792 of yacc.c  */
-#line 1962 "../SqlParser.ypp"
+#line 1962 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    if ((yyvsp[(1) - (1)].string_value_)->value().empty()) {
-      quickstep_yyerror(&(yylsp[(1) - (1)]), yyscanner, nullptr, "Zero-length identifier");
+    if ((yyvsp[0].string_value_)->value().empty()) {
+      quickstep_yyerror(&(yylsp[0]), yyscanner, nullptr, "Zero-length identifier");
     }
-    (yyval.string_value_) = (yyvsp[(1) - (1)].string_value_);
+    (yyval.string_value_) = (yyvsp[0].string_value_);
   }
+#line 5807 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 283:
-/* Line 1792 of yacc.c  */
-#line 1970 "../SqlParser.ypp"
+#line 1970 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.boolean_value_) = true;
   }
+#line 5815 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 284:
-/* Line 1792 of yacc.c  */
-#line 1973 "../SqlParser.ypp"
+#line 1973 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.boolean_value_) = true;
   }
+#line 5823 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 285:
-/* Line 1792 of yacc.c  */
-#line 1976 "../SqlParser.ypp"
+#line 1976 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.boolean_value_) = false;
   }
+#line 5831 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 286:
-/* Line 1792 of yacc.c  */
-#line 1979 "../SqlParser.ypp"
+#line 1979 "../SqlParser.ypp" /* yacc.c:1646  */
     {
     (yyval.boolean_value_) = false;
   }
+#line 5839 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 287:
-/* Line 1792 of yacc.c  */
-#line 1985 "../SqlParser.ypp"
+#line 1985 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    (yyval.command_) = new quickstep::ParseCommand((yylsp[(1) - (2)]).first_line, (yylsp[(1) - (2)]).first_column, (yyvsp[(1) - (2)].string_value_), (yyvsp[(2) - (2)].command_argument_list_));
+    (yyval.command_) = new quickstep::ParseCommand((yylsp[-1]).first_line, (yylsp[-1]).first_column, (yyvsp[-1].string_value_), (yyvsp[0].command_argument_list_));
   }
+#line 5847 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 288:
-/* Line 1792 of yacc.c  */
-#line 1990 "../SqlParser.ypp"
+#line 1990 "../SqlParser.ypp" /* yacc.c:1646  */
     {
-    quickstep::PtrVector<quickstep::ParseString> *argument_list = (yyvsp[(1) - (2)].command_argument_list_);
-    argument_list->push_back((yyvsp[(2) - (2)].string_value_));
+    quickstep::PtrVector<quickstep::ParseString> *argument_list = (yyvsp[-1].command_argument_list_);
+    argument_list->push_back((yyvsp[0].string_value_));
     (yyval.command_argument_list_) = argument_list;
   }
+#line 5857 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
   case 289:
-/* Line 1792 of yacc.c  */
-#line 1995 "../SqlParser.ypp"
+#line 1995 "../SqlParser.ypp" /* yacc.c:1646  */
     { /* Epsilon, an empy match. */
     (yyval.command_argument_list_) = new quickstep::PtrVector<quickstep::ParseString>();
   }
+#line 5865 "SqlParser_gen.cpp" /* yacc.c:1646  */
     break;
 
 
-/* Line 1792 of yacc.c  */
-#line 6251 "SqlParser_gen.cpp"
+#line 5869 "SqlParser_gen.cpp" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -6270,7 +5888,7 @@ yyreduce:
   *++yyvsp = yyval;
   *++yylsp = yyloc;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
 
@@ -6285,9 +5903,9 @@ yyreduce:
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
@@ -6338,20 +5956,20 @@ yyerrlab:
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval, &yylloc, yyscanner, parsedStatement);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, &yylloc, yyscanner, parsedStatement);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -6371,7 +5989,7 @@ yyerrorlab:
      goto yyerrorlab;
 
   yyerror_range[1] = yylsp[1-yylen];
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -6384,29 +6002,29 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+        {
+          yyn += YYTERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp, yylsp, yyscanner, parsedStatement);
+                  yystos[yystate], yyvsp, yylsp, yyscanner, parsedStatement);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -6462,14 +6080,14 @@ yyreturn:
       yydestruct ("Cleanup: discarding lookahead",
                   yytoken, &yylval, &yylloc, yyscanner, parsedStatement);
     }
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp, yylsp, yyscanner, parsedStatement);
+                  yystos[*yyssp], yyvsp, yylsp, yyscanner, parsedStatement);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -6480,13 +6098,9 @@ yyreturn:
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
 #endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
-
-
-/* Line 2055 of yacc.c  */
-#line 1999 "../SqlParser.ypp"
+#line 1999 "../SqlParser.ypp" /* yacc.c:1906  */
 
 
 void NotSupported(const YYLTYPE *location, yyscan_t yyscanner, const std::string &feature) {

--- a/parser/preprocessed/SqlParser_gen.hpp
+++ b/parser/preprocessed/SqlParser_gen.hpp
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.7.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison interface for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2012 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,13 +26,13 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
 #ifndef YY_QUICKSTEP_YY_SQLPARSER_GEN_HPP_INCLUDED
 # define YY_QUICKSTEP_YY_SQLPARSER_GEN_HPP_INCLUDED
-/* Enabling traces.  */
+/* Debug traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
 #endif
@@ -40,152 +40,151 @@
 extern int quickstep_yydebug;
 #endif
 
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     TOKEN_COMMAND = 258,
-     TOKEN_NAME = 259,
-     TOKEN_STRING_SINGLE_QUOTED = 260,
-     TOKEN_STRING_DOUBLE_QUOTED = 261,
-     TOKEN_UNSIGNED_NUMVAL = 262,
-     TOKEN_OR = 263,
-     TOKEN_AND = 264,
-     TOKEN_NOT = 265,
-     TOKEN_EQ = 266,
-     TOKEN_NEQ = 267,
-     TOKEN_GEQ = 268,
-     TOKEN_GT = 269,
-     TOKEN_LEQ = 270,
-     TOKEN_LT = 271,
-     TOKEN_REGEXP = 272,
-     TOKEN_LIKE = 273,
-     TOKEN_BETWEEN = 274,
-     TOKEN_IS = 275,
-     UNARY_MINUS = 276,
-     UNARY_PLUS = 277,
-     TOKEN_ADD = 278,
-     TOKEN_ALL = 279,
-     TOKEN_ALTER = 280,
-     TOKEN_AS = 281,
-     TOKEN_ASC = 282,
-     TOKEN_BIGINT = 283,
-     TOKEN_BIT = 284,
-     TOKEN_BITWEAVING = 285,
-     TOKEN_BLOCKPROPERTIES = 286,
-     TOKEN_BLOCKSAMPLE = 287,
-     TOKEN_BLOOM_FILTER = 288,
-     TOKEN_CSB_TREE = 289,
-     TOKEN_BY = 290,
-     TOKEN_CASE = 291,
-     TOKEN_CHARACTER = 292,
-     TOKEN_CHECK = 293,
-     TOKEN_COLUMN = 294,
-     TOKEN_CONSTRAINT = 295,
-     TOKEN_COPY = 296,
-     TOKEN_CREATE = 297,
-     TOKEN_CURRENT = 298,
-     TOKEN_DATE = 299,
-     TOKEN_DATETIME = 300,
-     TOKEN_DAY = 301,
-     TOKEN_DECIMAL = 302,
-     TOKEN_DEFAULT = 303,
-     TOKEN_DELETE = 304,
-     TOKEN_DELIMITER = 305,
-     TOKEN_DESC = 306,
-     TOKEN_DISTINCT = 307,
-     TOKEN_DOUBLE = 308,
-     TOKEN_DROP = 309,
-     TOKEN_ELSE = 310,
-     TOKEN_END = 311,
-     TOKEN_ESCAPE_STRINGS = 312,
-     TOKEN_EXISTS = 313,
-     TOKEN_EXTRACT = 314,
-     TOKEN_FALSE = 315,
-     TOKEN_FIRST = 316,
-     TOKEN_FLOAT = 317,
-     TOKEN_FOLLOWING = 318,
-     TOKEN_FOR = 319,
-     TOKEN_FOREIGN = 320,
-     TOKEN_FROM = 321,
-     TOKEN_FULL = 322,
-     TOKEN_GROUP = 323,
-     TOKEN_HASH = 324,
-     TOKEN_HAVING = 325,
-     TOKEN_HOUR = 326,
-     TOKEN_IN = 327,
-     TOKEN_INDEX = 328,
-     TOKEN_INNER = 329,
-     TOKEN_INSERT = 330,
-     TOKEN_INTEGER = 331,
-     TOKEN_INTERVAL = 332,
-     TOKEN_INTO = 333,
-     TOKEN_JOIN = 334,
-     TOKEN_KEY = 335,
-     TOKEN_LAST = 336,
-     TOKEN_LEFT = 337,
-     TOKEN_LIMIT = 338,
-     TOKEN_LONG = 339,
-     TOKEN_MINUTE = 340,
-     TOKEN_MONTH = 341,
-     TOKEN_NULL = 342,
-     TOKEN_NULLS = 343,
-     TOKEN_OFF = 344,
-     TOKEN_ON = 345,
-     TOKEN_ORDER = 346,
-     TOKEN_OUTER = 347,
-     TOKEN_OVER = 348,
-     TOKEN_PARTITION = 349,
-     TOKEN_PARTITIONS = 350,
-     TOKEN_PERCENT = 351,
-     TOKEN_PRECEDING = 352,
-     TOKEN_PRIMARY = 353,
-     TOKEN_PRIORITY = 354,
-     TOKEN_QUIT = 355,
-     TOKEN_RANGE = 356,
-     TOKEN_REAL = 357,
-     TOKEN_REFERENCES = 358,
-     TOKEN_RIGHT = 359,
-     TOKEN_ROW = 360,
-     TOKEN_ROW_DELIMITER = 361,
-     TOKEN_ROWS = 362,
-     TOKEN_SECOND = 363,
-     TOKEN_SELECT = 364,
-     TOKEN_SET = 365,
-     TOKEN_SMA = 366,
-     TOKEN_SMALLINT = 367,
-     TOKEN_SUBSTRING = 368,
-     TOKEN_TABLE = 369,
-     TOKEN_THEN = 370,
-     TOKEN_TIME = 371,
-     TOKEN_TIMESTAMP = 372,
-     TOKEN_TRUE = 373,
-     TOKEN_TUPLESAMPLE = 374,
-     TOKEN_UNBOUNDED = 375,
-     TOKEN_UNIQUE = 376,
-     TOKEN_UPDATE = 377,
-     TOKEN_USING = 378,
-     TOKEN_VALUES = 379,
-     TOKEN_VARCHAR = 380,
-     TOKEN_WHEN = 381,
-     TOKEN_WHERE = 382,
-     TOKEN_WINDOW = 383,
-     TOKEN_WITH = 384,
-     TOKEN_YEAR = 385,
-     TOKEN_YEARMONTH = 386,
-     TOKEN_EOF = 387,
-     TOKEN_LEX_ERROR = 388
-   };
+  enum yytokentype
+  {
+    TOKEN_COMMAND = 258,
+    TOKEN_NAME = 259,
+    TOKEN_STRING_SINGLE_QUOTED = 260,
+    TOKEN_STRING_DOUBLE_QUOTED = 261,
+    TOKEN_UNSIGNED_NUMVAL = 262,
+    TOKEN_OR = 263,
+    TOKEN_AND = 264,
+    TOKEN_NOT = 265,
+    TOKEN_EQ = 266,
+    TOKEN_LT = 267,
+    TOKEN_LEQ = 268,
+    TOKEN_GT = 269,
+    TOKEN_GEQ = 270,
+    TOKEN_NEQ = 271,
+    TOKEN_LIKE = 272,
+    TOKEN_REGEXP = 273,
+    TOKEN_BETWEEN = 274,
+    TOKEN_IS = 275,
+    UNARY_PLUS = 276,
+    UNARY_MINUS = 277,
+    TOKEN_ADD = 278,
+    TOKEN_ALL = 279,
+    TOKEN_ALTER = 280,
+    TOKEN_AS = 281,
+    TOKEN_ASC = 282,
+    TOKEN_BIGINT = 283,
+    TOKEN_BIT = 284,
+    TOKEN_BITWEAVING = 285,
+    TOKEN_BLOCKPROPERTIES = 286,
+    TOKEN_BLOCKSAMPLE = 287,
+    TOKEN_BLOOM_FILTER = 288,
+    TOKEN_CSB_TREE = 289,
+    TOKEN_BY = 290,
+    TOKEN_CASE = 291,
+    TOKEN_CHARACTER = 292,
+    TOKEN_CHECK = 293,
+    TOKEN_COLUMN = 294,
+    TOKEN_CONSTRAINT = 295,
+    TOKEN_COPY = 296,
+    TOKEN_CREATE = 297,
+    TOKEN_CURRENT = 298,
+    TOKEN_DATE = 299,
+    TOKEN_DATETIME = 300,
+    TOKEN_DAY = 301,
+    TOKEN_DECIMAL = 302,
+    TOKEN_DEFAULT = 303,
+    TOKEN_DELETE = 304,
+    TOKEN_DELIMITER = 305,
+    TOKEN_DESC = 306,
+    TOKEN_DISTINCT = 307,
+    TOKEN_DOUBLE = 308,
+    TOKEN_DROP = 309,
+    TOKEN_ELSE = 310,
+    TOKEN_END = 311,
+    TOKEN_ESCAPE_STRINGS = 312,
+    TOKEN_EXISTS = 313,
+    TOKEN_EXTRACT = 314,
+    TOKEN_FALSE = 315,
+    TOKEN_FIRST = 316,
+    TOKEN_FLOAT = 317,
+    TOKEN_FOLLOWING = 318,
+    TOKEN_FOR = 319,
+    TOKEN_FOREIGN = 320,
+    TOKEN_FROM = 321,
+    TOKEN_FULL = 322,
+    TOKEN_GROUP = 323,
+    TOKEN_HASH = 324,
+    TOKEN_HAVING = 325,
+    TOKEN_HOUR = 326,
+    TOKEN_IN = 327,
+    TOKEN_INDEX = 328,
+    TOKEN_INNER = 329,
+    TOKEN_INSERT = 330,
+    TOKEN_INTEGER = 331,
+    TOKEN_INTERVAL = 332,
+    TOKEN_INTO = 333,
+    TOKEN_JOIN = 334,
+    TOKEN_KEY = 335,
+    TOKEN_LAST = 336,
+    TOKEN_LEFT = 337,
+    TOKEN_LIMIT = 338,
+    TOKEN_LONG = 339,
+    TOKEN_MINUTE = 340,
+    TOKEN_MONTH = 341,
+    TOKEN_NULL = 342,
+    TOKEN_NULLS = 343,
+    TOKEN_OFF = 344,
+    TOKEN_ON = 345,
+    TOKEN_ORDER = 346,
+    TOKEN_OUTER = 347,
+    TOKEN_OVER = 348,
+    TOKEN_PARTITION = 349,
+    TOKEN_PARTITIONS = 350,
+    TOKEN_PERCENT = 351,
+    TOKEN_PRECEDING = 352,
+    TOKEN_PRIMARY = 353,
+    TOKEN_PRIORITY = 354,
+    TOKEN_QUIT = 355,
+    TOKEN_RANGE = 356,
+    TOKEN_REAL = 357,
+    TOKEN_REFERENCES = 358,
+    TOKEN_RIGHT = 359,
+    TOKEN_ROW = 360,
+    TOKEN_ROW_DELIMITER = 361,
+    TOKEN_ROWS = 362,
+    TOKEN_SECOND = 363,
+    TOKEN_SELECT = 364,
+    TOKEN_SET = 365,
+    TOKEN_SMA = 366,
+    TOKEN_SMALLINT = 367,
+    TOKEN_SUBSTRING = 368,
+    TOKEN_TABLE = 369,
+    TOKEN_THEN = 370,
+    TOKEN_TIME = 371,
+    TOKEN_TIMESTAMP = 372,
+    TOKEN_TRUE = 373,
+    TOKEN_TUPLESAMPLE = 374,
+    TOKEN_UNBOUNDED = 375,
+    TOKEN_UNIQUE = 376,
+    TOKEN_UPDATE = 377,
+    TOKEN_USING = 378,
+    TOKEN_VALUES = 379,
+    TOKEN_VARCHAR = 380,
+    TOKEN_WHEN = 381,
+    TOKEN_WHERE = 382,
+    TOKEN_WINDOW = 383,
+    TOKEN_WITH = 384,
+    TOKEN_YEAR = 385,
+    TOKEN_YEARMONTH = 386,
+    TOKEN_EOF = 387,
+    TOKEN_LEX_ERROR = 388
+  };
 #endif
 
-
+/* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
+
+union YYSTYPE
 {
-/* Line 2058 of yacc.c  */
-#line 120 "../SqlParser.ypp"
+#line 120 "../SqlParser.ypp" /* yacc.c:1909  */
 
   quickstep::ParseString *string_value_;
 
@@ -285,41 +284,30 @@ typedef union YYSTYPE
 
   quickstep::ParsePriority *opt_priority_clause_;
 
+#line 288 "SqlParser_gen.hpp" /* yacc.c:1909  */
+};
 
-/* Line 2058 of yacc.c  */
-#line 291 "SqlParser_gen.hpp"
-} YYSTYPE;
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
 # define YYSTYPE_IS_DECLARED 1
 #endif
 
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
 
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int quickstep_yyparse (void *YYPARSE_PARAM);
-#else
-int quickstep_yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
+
 int quickstep_yyparse (yyscan_t yyscanner, quickstep::ParseStatement **parsedStatement);
-#else
-int quickstep_yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 #endif /* !YY_QUICKSTEP_YY_SQLPARSER_GEN_HPP_INCLUDED  */

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(quickstep_types_DateOperatorOverloads ../empty_src.cpp DateOperatorO
 add_library(quickstep_types_DatetimeIntervalType DatetimeIntervalType.cpp DatetimeIntervalType.hpp)
 add_library(quickstep_types_DatetimeLit ../empty_src.cpp DatetimeLit.hpp)
 add_library(quickstep_types_DatetimeType DatetimeType.cpp DatetimeType.hpp)
+add_library(quickstep_types_DecimalLit ../empty_src.cpp DecimalLit.hpp)
+add_library(quickstep_types_DecimalType DecimalType.cpp DecimalType.hpp)
 add_library(quickstep_types_DoubleType DoubleType.cpp DoubleType.hpp)
 add_library(quickstep_types_FloatType FloatType.cpp FloatType.hpp)
 add_library(quickstep_types_IntType IntType.cpp IntType.hpp)
@@ -93,6 +95,16 @@ target_link_libraries(quickstep_types_DatetimeType
                       quickstep_types_port_gmtime_r
                       quickstep_types_port_timegm
                       quickstep_utility_CheckSnprintf
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_types_DecimalType
+                      glog
+                      quickstep_types_DecimalLit
+                      quickstep_types_NullCoercibilityCheckMacro
+                      quickstep_types_NumericSuperType
+                      quickstep_types_Type
+                      quickstep_types_TypeID
+                      quickstep_types_TypedValue
+                      quickstep_utility_EqualsAnyConstant
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_DoubleType
                       quickstep_types_NullCoercibilityCheckMacro
@@ -158,6 +170,7 @@ target_link_libraries(quickstep_types_TypeFactory
                       quickstep_types_CharType
                       quickstep_types_DatetimeIntervalType
                       quickstep_types_DatetimeType
+                      quickstep_types_DecimalType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType
@@ -173,6 +186,7 @@ target_link_libraries(quickstep_types_TypedValue
                       farmhash
                       glog
                       quickstep_types_DatetimeLit
+                      quickstep_types_DecimalLit
                       quickstep_types_IntervalLit
                       quickstep_types_TypeID
                       quickstep_types_Type_proto
@@ -213,6 +227,8 @@ target_link_libraries(quickstep_types
                       quickstep_types_DatetimeIntervalType
                       quickstep_types_DatetimeLit
                       quickstep_types_DatetimeType
+                      quickstep_types_DecimalLit
+                      quickstep_types_DecimalType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType
@@ -294,6 +310,17 @@ target_link_libraries(DatetimeType_unittest
                       quickstep_types_tests_TypeTest_common
                       quickstep_utility_MemStream)
 add_test(DatetimeType_unittest DatetimeType_unittest)
+
+add_executable(DecimalType_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/DecimalType_unittest.cpp")
+target_link_libraries(DecimalType_unittest
+                      gtest
+                      gtest_main
+                      quickstep_types_DecimalLit
+                      quickstep_types_DecimalType
+                      quickstep_types_Type
+                      quickstep_types_TypeFactory
+                      quickstep_types_TypedValue)
+add_test(DecimalType_unittest DecimalType_unittest)
 
 add_executable(DoubleType_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/DoubleType_unittest.cpp")
 target_link_libraries(DoubleType_unittest

--- a/types/DecimalLit.hpp
+++ b/types/DecimalLit.hpp
@@ -1,0 +1,293 @@
+/**
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TYPES_DECIMAL_LIT_HPP_
+#define QUICKSTEP_TYPES_DECIMAL_LIT_HPP_
+
+#include <cstdint>
+#include <cmath>
+
+namespace quickstep {
+
+/** \addtogroup Type
+ *  @{
+ */
+
+/**
+ * @brief A literal representing fixed-precision decimal.
+ **/
+struct DecimalLit {
+  /**
+   * @brief Underlying data type.
+   **/
+  typedef std::int64_t data_type;
+
+  DecimalLit() = default;
+
+  explicit DecimalLit(const int value)
+    : data_(static_cast<data_type>(value * kMaxFractionInt)) {
+  }
+
+  explicit DecimalLit(const std::int64_t value)
+    : data_(static_cast<data_type>(value * kMaxFractionInt)) {
+  }
+
+  explicit DecimalLit(const float value)
+    : data_(static_cast<data_type>(value * kMaxFractionInt)) {
+  }
+
+  explicit DecimalLit(const double value)
+    : data_(static_cast<data_type>(value * kMaxFractionInt)) {
+  }
+
+  inline explicit operator int() const {
+    return static_cast<int>(getIntegerPart());
+  }
+
+  inline explicit operator std::int64_t() const {
+    return static_cast<std::int64_t>(getIntegerPart());
+  }
+
+  inline explicit operator float() const {
+    return static_cast<float>(data_) / kMaxFractionInt;
+  }
+
+  inline explicit operator double() const {
+    return static_cast<double>(data_) / kMaxFractionInt;
+  }
+
+  data_type data_;
+
+  /**
+   * @brief Number of decimals after point.
+   **/
+  static constexpr std::int64_t kPrecisionWidth = 2;
+
+  /**
+   * @brief Normalization factor between Decimal type and floating point types.
+   *        It is always equal to pow(10, kPrecisionWidth).
+   **/
+  static constexpr std::int64_t kMaxFractionInt = 100;
+
+  /**
+   * @brief Getter for the fractional part of the Decimal type.
+   *
+   * @return Fractional part of the Decimal number as unsigned.
+   **/
+  inline std::uint64_t getFractionalPart() const {
+    return static_cast<std::uint64_t>(static_cast<std::uint64_t>(std::abs(data_)) % kMaxFractionInt);
+  }
+
+  /**
+   * @brief Getter for the integer part of the Decimal type.
+   *
+   * @return Integer part of the Decimal number as signed.
+   **/
+  inline std::int64_t getIntegerPart() const {
+    return static_cast<std::int64_t>(data_ / kMaxFractionInt);
+  }
+
+  /**
+   * @brief Operator overloading for "less than".
+   *
+   * @param other Other DecimalLit to be compared.
+   * @return True if this is less than other,
+   *         false otherwise.
+   **/
+  inline bool operator<(const DecimalLit& other) const {
+    return data_ < other.data_;
+  }
+
+  /**
+   * @brief Operator overloading for "greater than".
+   *
+   * @param other Other DecimalLit to be compared.
+   * @return True if this is greater than other,
+   *         false otherwise.
+   **/
+  inline bool operator>(const DecimalLit& other) const {
+    return data_ > other.data_;
+  }
+
+  /**
+   * @brief Operator overloading for "less than or equal to".
+   *
+   * @param other Other DecimalLit to be compared.
+   * @return True if this is less than or equal to other,
+   *         false otherwise.
+   **/
+  inline bool operator<=(const DecimalLit& other) const {
+    return data_ <= other.data_;
+  }
+
+  /**
+   * @brief Operator overloading for "greater than or equal to".
+   *
+   * @param other Other DecimalLit to be compared.
+   * @return True if this is greater than or equal to other,
+   *         false otherwise.
+   **/
+  inline bool operator>=(const DecimalLit& other) const {
+    return data_ >= other.data_;
+  }
+
+  /**
+   * @brief Operator overloading for "equal to".
+   *
+   * @param other Other DecimalLit to be compared.
+   * @return True if this is equal to other,
+   *         false otherwise.
+   **/
+  inline bool operator==(const DecimalLit& other) const {
+    return data_ == other.data_;
+  }
+
+  /**
+   * @brief Operator overloading for "not equal to".
+   *
+   * @param other Other DecimalLit to be compared.
+   * @return True if this is not equal to other,
+   *         false otherwise.
+   **/
+  inline bool operator!=(const DecimalLit& other) const {
+    return data_ != other.data_;
+  }
+
+  /**
+   * @brief Operator overloading for "negate".
+   *
+   * @return Negative of this.
+   **/
+  inline DecimalLit operator-() const {
+    DecimalLit result;
+    result.data_ = -result.data_;
+    return result;
+  }
+
+  /**
+   * @brief Operator overloading for "plus".
+   *
+   * @param other Other DecimalLit to be added.
+   * @return Sum of this and other.
+   **/
+  inline DecimalLit operator+(const DecimalLit& other) const {
+    DecimalLit result;
+    result.data_ = data_ + other.data_;
+    return result;
+  }
+
+  /**
+   * @brief Operator overloading for "subtract".
+   *
+   * @param other Other DecimalLit to be subtract.
+   * @return Subtraction of other from this.
+   **/
+  inline DecimalLit operator-(const DecimalLit& other) const {
+    DecimalLit result;
+    result.data_ = data_ - other.data_;
+    return result;
+  }
+
+  /**
+   * @brief Operator overloading for "multiply".
+   *
+   * @param other Other DecimalLit to be multiplied.
+   * @return Multiplication of this and other.
+   **/
+  inline DecimalLit operator*(const DecimalLit& other) const {
+    DecimalLit result;
+    result.data_ = (data_ * other.data_) / kMaxFractionInt;
+    return result;
+  }
+
+  /**
+   * @brief Operator overloading for "division".
+   *
+   * @param other Divisor DecimalLit.
+   * @return Division of this with other.
+   **/
+  inline DecimalLit operator/(const DecimalLit& other) const {
+    DecimalLit result;
+    result.data_ = (data_ * kMaxFractionInt) / other.data_;
+    return result;
+  }
+
+  /**
+   * @brief Operator overloading for "modulo".
+   *
+   * @param other Mod DecimalLit.
+   * @return This modulo other.
+   **/
+  inline DecimalLit operator%(const DecimalLit& other) const {
+    DecimalLit result;
+    result.data_ = data_ % other.data_;
+    return result;
+  }
+
+  /**
+   * @brief Operator overloading for "inplace add".
+   *
+   * @param other DecimalLit to be added.
+   * @return Reference to this.
+   **/
+  inline DecimalLit& operator+=(const DecimalLit& other) {
+    data_ += other.data_;
+    return *this;
+  }
+
+  /**
+   * @brief Operator overloading for "inplace subtract".
+   *
+   * @param other DecimalLit to be subtracted.
+   * @return Reference to this.
+   **/
+  inline DecimalLit& operator-=(const DecimalLit& other) {
+    data_ -= other.data_;
+    return *this;
+  }
+
+  /**
+   * @brief Operator overloading for "inplace multiply".
+   *
+   * @param other DecimalLit to be multiplied.
+   * @return Reference to this.
+   **/
+  inline DecimalLit& operator*=(const DecimalLit& other) {
+    data_ = (data_ * other.data_) / kMaxFractionInt;
+    return *this;
+  }
+
+  /**
+   * @brief Operator overloading for "inplace divide".
+   *
+   * @param other DecimalLit to be divided.
+   * @return Reference to this.
+   **/
+  inline DecimalLit& operator/=(const DecimalLit& other) {
+    data_ = (data_ * kMaxFractionInt) / other.data_;
+    return *this;
+  }
+};
+
+//** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_TYPES_DECIMAL_LIT_HPP_

--- a/types/DecimalType.cpp
+++ b/types/DecimalType.cpp
@@ -1,0 +1,120 @@
+/**
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *   limitations under the License.
+ **/
+
+#include "types/DecimalType.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <iomanip>
+#include <string>
+#include <sstream>
+
+#include "types/DecimalLit.hpp"
+#include "types/NullCoercibilityCheckMacro.hpp"
+#include "types/Type.hpp"
+#include "types/TypeID.hpp"
+#include "types/TypedValue.hpp"
+#include "utility/EqualsAnyConstant.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+class Type;
+
+const TypeID DecimalType::kStaticTypeID = kDecimal;
+
+bool DecimalType::isSafelyCoercibleFrom(const Type &original_type) const {
+  QUICKSTEP_NULL_COERCIBILITY_CHECK();
+  return QUICKSTEP_EQUALS_ANY_CONSTANT(original_type.getTypeID(),
+                                       kInt, kDecimal);
+}
+
+TypedValue DecimalType::coerceValue(const TypedValue &original_value,
+                                    const Type &original_type) const {
+  DCHECK(isCoercibleFrom(original_type))
+      << "Can't coerce value of Type " << original_type.getName()
+      << " to Type " << getName();
+
+  if (original_value.isNull()) {
+    return makeNullValue();
+  }
+
+  switch (original_type.getTypeID()) {
+    case kInt:
+      return TypedValue(DecimalLit(original_value.getLiteral<int>()));
+    case kLong:
+      return TypedValue(DecimalLit(original_value.getLiteral<std::int64_t>()));
+    case kFloat:
+      return TypedValue(DecimalLit(original_value.getLiteral<float>()));
+    case kDouble:
+      return original_value;
+    default:
+      LOG(FATAL) << "Attempted to coerce Type " << original_type.getName()
+                 << " (not recognized as a numeric Type) to " << getName();
+  }
+}
+
+std::string DecimalType::printValueToString(const TypedValue &value) const {
+  DCHECK(!value.isNull());
+
+  DecimalLit decimal = value.getLiteral<DecimalLit>();
+  std::stringstream ss;
+  ss << decimal.getIntegerPart() << "."
+     << std::setfill('0') << std::setw(DecimalLit::kPrecisionWidth)
+     <<  decimal.getFractionalPart();
+  return ss.str();
+}
+
+void DecimalType::printValueToFile(const TypedValue &value,
+                                   FILE *file,
+                                   const int padding) const {
+  DCHECK(!value.isNull());
+
+  DecimalLit decimal = value.getLiteral<DecimalLit>();
+
+  std::fprintf(file, "%*ld.%0*lu",
+               static_cast<int>(padding -
+                                (DecimalLit::kPrecisionWidth
+                                 + 1 /* Less one space for point. */)),
+               decimal.getIntegerPart(),
+               static_cast<int>(DecimalLit::kPrecisionWidth),
+               decimal.getFractionalPart());
+}
+
+bool DecimalType::parseValueFromString(const std::string &value_string,
+                                       TypedValue *value) const {
+  double parsed_double;
+  int read_chars;
+
+  int matched = std::sscanf(value_string.c_str(),
+                            "%lf%n",
+                            &parsed_double,
+                            &read_chars);
+
+  if (matched != 1 || read_chars != static_cast<int>(value_string.length()))  {
+    return false;
+  }
+
+  *value = TypedValue(DecimalLit(parsed_double));
+  return true;
+}
+
+}  // namespace quickstep

--- a/types/DecimalType.hpp
+++ b/types/DecimalType.hpp
@@ -1,0 +1,124 @@
+/**
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_TYPES_DECIMAL_TYPE_HPP_
+#define QUICKSTEP_TYPES_DECIMAL_TYPE_HPP_
+
+#include <limits>
+#include <string>
+
+#include "types/DecimalLit.hpp"
+#include "types/NumericSuperType.hpp"
+#include "types/TypeID.hpp"
+#include "types/TypedValue.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+class Type;
+
+/** \addtogroup Types
+ *  @{
+ */
+
+/**
+ * @brief A type representing a fixed-precision number.
+ **/
+class DecimalType : public NumericSuperType<DecimalLit> {
+ public:
+  static const TypeID kStaticTypeID;
+
+  /**
+   * @brief Get a reference to the non-nullable singleton instance of this
+   *        Type.
+   *
+   * @return A reference to the non-nullable singleton instance of this Type.
+   **/
+  static const DecimalType& InstanceNonNullable() {
+    static DecimalType instance(false);
+    return instance;
+  }
+
+  /**
+   * @brief Get a reference to the nullable singleton instance of this Type.
+   *
+   * @return A reference to the nullable singleton instance of this Type.
+   **/
+  static const DecimalType& InstanceNullable() {
+    static DecimalType instance(true);
+    return instance;
+  }
+
+  static const DecimalType& Instance(const bool nullable) {
+    if (nullable) {
+      return InstanceNullable();
+    } else {
+      return InstanceNonNullable();
+    }
+  }
+
+  const Type& getNullableVersion() const override {
+    return InstanceNullable();
+  }
+
+  const Type& getNonNullableVersion() const override {
+    return InstanceNonNullable();
+  }
+
+  bool isSafelyCoercibleFrom(const Type &original_type) const override;
+
+  int getPrintWidth() const override {
+    return kPrintWidth;
+  }
+
+  std::string printValueToString(const TypedValue &value) const override;
+
+  void printValueToFile(const TypedValue &value,
+                        FILE *file,
+                        const int padding = 0) const override;
+
+  bool parseValueFromString(const std::string &value_string,
+                            TypedValue *value) const override;
+
+  TypedValue coerceValue(const TypedValue &original_value,
+                         const Type &original_type) const override;
+
+  TypedValue makeZeroValue() const override {
+    return TypedValue(DecimalLit(0));
+  }
+
+ private:
+  static constexpr int kPrintWidth =
+      std::numeric_limits<DecimalLit::data_type>::digits10
+      + 1   // Decimal point '.'
+      + 1;  // Minus sign '-'
+
+  explicit DecimalType(const bool nullable)
+       : NumericSuperType<DecimalLit>(kDecimal, nullable) {
+  }
+
+  DISALLOW_COPY_AND_ASSIGN(DecimalType);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_TYPES_DECIMAL_TYPE_HPP_

--- a/types/NumericSuperType.hpp
+++ b/types/NumericSuperType.hpp
@@ -51,7 +51,7 @@ class NumericSuperType : public Type {
   }
 
   TypedValue makeZeroValue() const override {
-    return TypedValue(static_cast<CppType>(0));
+    return TypedValue(CppType());
   }
 
  protected:

--- a/types/NumericTypeUnifier.hpp
+++ b/types/NumericTypeUnifier.hpp
@@ -19,6 +19,7 @@
 
 namespace quickstep {
 
+class DecimalType;
 class DoubleType;
 class FloatType;
 class IntType;
@@ -76,6 +77,11 @@ struct NumericTypeUnifier<IntType, DoubleType> {
 };
 
 template<>
+struct NumericTypeUnifier<IntType, DecimalType> {
+  typedef DecimalType type;
+};
+
+template<>
 struct NumericTypeUnifier<LongType, IntType> {
   typedef LongType type;
 };
@@ -93,6 +99,11 @@ struct NumericTypeUnifier<LongType, FloatType> {
 template<>
 struct NumericTypeUnifier<LongType, DoubleType> {
   typedef DoubleType type;
+};
+
+template<>
+struct NumericTypeUnifier<LongType, DecimalType> {
+  typedef DecimalType type;
 };
 
 template<>
@@ -116,6 +127,11 @@ struct NumericTypeUnifier<FloatType, DoubleType> {
 };
 
 template<>
+struct NumericTypeUnifier<FloatType, DecimalType> {
+  typedef DecimalType type;
+};
+
+template<>
 struct NumericTypeUnifier<DoubleType, IntType> {
   typedef DoubleType type;
 };
@@ -133,6 +149,36 @@ struct NumericTypeUnifier<DoubleType, FloatType> {
 template<>
 struct NumericTypeUnifier<DoubleType, DoubleType> {
   typedef DoubleType type;
+};
+
+template<>
+struct NumericTypeUnifier<DoubleType, DecimalType> {
+  typedef DecimalType type;
+};
+
+template<>
+struct NumericTypeUnifier<DecimalType, IntType> {
+  typedef DecimalType type;
+};
+
+template<>
+struct NumericTypeUnifier<DecimalType, LongType> {
+  typedef DecimalType type;
+};
+
+template<>
+struct NumericTypeUnifier<DecimalType, FloatType> {
+  typedef DecimalType type;
+};
+
+template<>
+struct NumericTypeUnifier<DecimalType, DoubleType> {
+  typedef DecimalType type;
+};
+
+template<>
+struct NumericTypeUnifier<DecimalType, DecimalType> {
+  typedef DecimalType type;
 };
 
 }  // namespace quickstep

--- a/types/Type.cpp
+++ b/types/Type.cpp
@@ -41,6 +41,9 @@ serialization::Type Type::getProto() const {
     case kDouble:
       proto.set_type_id(serialization::Type::DOUBLE);
       break;
+    case kDecimal:
+      proto.set_type_id(serialization::Type::DECIMAL);
+      break;
     case kDatetime:
       proto.set_type_id(serialization::Type::DATETIME);
       break;

--- a/types/Type.hpp
+++ b/types/Type.hpp
@@ -34,6 +34,7 @@ namespace quickstep {
 
 struct DatetimeIntervalLit;
 struct DatetimeLit;
+struct DecimalLit;
 struct YearMonthIntervalLit;
 
 /** \addtogroup Types
@@ -370,6 +371,8 @@ class Type {
         return TypedValue(*static_cast<const float*>(value_ptr));
       case kDouble:
         return TypedValue(*static_cast<const double*>(value_ptr));
+      case kDecimal:
+        return TypedValue(*static_cast<const DecimalLit*>(value_ptr));
       case kDatetime:
         return TypedValue(*static_cast<const DatetimeLit*>(value_ptr));
       case kDatetimeInterval:

--- a/types/Type.proto
+++ b/types/Type.proto
@@ -25,10 +25,11 @@ message Type {
     DOUBLE = 3;
     CHAR = 4;
     VAR_CHAR = 5;
-    DATETIME = 6;
-    DATETIME_INTERVAL = 7;
-    YEAR_MONTH_INTERVAL = 8;
-    NULL_TYPE = 9;
+    DECIMAL = 6;
+    DATETIME = 7;
+    DATETIME_INTERVAL = 8;
+    YEAR_MONTH_INTERVAL = 9;
+    NULL_TYPE = 10;
   }
 
   required TypeID type_id = 1;

--- a/types/TypeFactory.cpp
+++ b/types/TypeFactory.cpp
@@ -22,6 +22,7 @@
 #include "types/CharType.hpp"
 #include "types/DatetimeIntervalType.hpp"
 #include "types/DatetimeType.hpp"
+#include "types/DecimalType.hpp"
 #include "types/DoubleType.hpp"
 #include "types/FloatType.hpp"
 #include "types/IntType.hpp"
@@ -49,6 +50,8 @@ const Type& TypeFactory::GetType(const TypeID id,
       return FloatType::Instance(nullable);
     case kDouble:
       return DoubleType::Instance(nullable);
+    case kDecimal:
+      return DecimalType::Instance(nullable);
     case kDatetime:
       return DatetimeType::Instance(nullable);
     case kDatetimeInterval:
@@ -90,6 +93,7 @@ bool TypeFactory::ProtoIsValid(const serialization::Type &proto) {
     case serialization::Type::LONG:
     case serialization::Type::FLOAT:
     case serialization::Type::DOUBLE:
+    case serialization::Type::DECIMAL:
     case serialization::Type::DATETIME:
     case serialization::Type::DATETIME_INTERVAL:
     case serialization::Type::YEAR_MONTH_INTERVAL:
@@ -119,6 +123,8 @@ const Type& TypeFactory::ReconstructFromProto(const serialization::Type &proto) 
       return FloatType::Instance(proto.nullable());
     case serialization::Type::DOUBLE:
       return DoubleType::Instance(proto.nullable());
+    case serialization::Type::DECIMAL:
+      return DecimalType::Instance(proto.nullable());
     case serialization::Type::DATETIME:
       return DatetimeType::Instance(proto.nullable());
     case serialization::Type::DATETIME_INTERVAL:
@@ -155,6 +161,8 @@ const Type* TypeFactory::GetUnifyingType(const Type &first, const Type &second) 
       if (((first.getTypeID() == kLong) && (second.getTypeID() == kFloat))
             || ((first.getTypeID() == kFloat) && (second.getTypeID() == kLong))) {
         unifier = &(DoubleType::Instance(true));
+      } else if (first.getTypeID() == kDecimal || second.getTypeID() == kDecimal) {
+        unifier = &(DecimalType::Instance(true));
       }
     }
   } else {
@@ -163,6 +171,8 @@ const Type* TypeFactory::GetUnifyingType(const Type &first, const Type &second) 
       if (((first.getTypeID() == kLong) && (second.getTypeID() == kFloat))
             || ((first.getTypeID() == kFloat) && (second.getTypeID() == kLong))) {
         unifier = &(DoubleType::Instance(false));
+      } else if (first.getTypeID() == kDecimal || second.getTypeID() == kDecimal) {
+        unifier = &(DecimalType::Instance(false));
       }
     }
   }

--- a/types/TypeFactory.hpp
+++ b/types/TypeFactory.hpp
@@ -52,6 +52,7 @@ class TypeFactory {
       case kLong:
       case kFloat:
       case kDouble:
+      case kDecimal:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:

--- a/types/TypeID.cpp
+++ b/types/TypeID.cpp
@@ -26,6 +26,7 @@ const char *kTypeNames[] = {
   "Double",
   "Char",
   "VarChar",
+  "Decimal",
   "Datetime",
   "DatetimeInterval",
   "YearMonthInterval",

--- a/types/TypeID.hpp
+++ b/types/TypeID.hpp
@@ -34,6 +34,7 @@ enum TypeID {
   kDouble,
   kChar,
   kVarChar,
+  kDecimal,
   kDatetime,
   kDatetimeInterval,
   kYearMonthInterval,

--- a/types/TypedValue.cpp
+++ b/types/TypedValue.cpp
@@ -49,6 +49,7 @@ bool TypedValue::isPlausibleInstanceOf(const TypeSignature type) const {
     case kLong:
     case kFloat:
     case kDouble:
+    case kDecimal:
     case kDatetime:
     case kDatetimeInterval:
     case kYearMonthInterval:
@@ -102,6 +103,12 @@ serialization::TypedValue TypedValue::getProto() const {
       proto.set_type_id(serialization::Type::DOUBLE);
       if (!isNull()) {
         proto.set_double_value(getLiteral<double>());
+      }
+      break;
+    case kDecimal:
+      proto.set_type_id(serialization::Type::DECIMAL);
+      if (!isNull()) {
+        proto.set_decimal_value(value_union_.decimal_value.data_);
       }
       break;
     case kDatetime:
@@ -171,6 +178,15 @@ TypedValue TypedValue::ReconstructFromProto(const serialization::TypedValue &pro
       return proto.has_double_value() ?
           TypedValue(static_cast<double>(proto.double_value())) :
           TypedValue(kDouble);
+    case serialization::Type::DECIMAL: {
+      if (proto.has_decimal_value()) {
+        DecimalLit result;
+        result.data_ = proto.decimal_value();
+        return TypedValue(result);
+      } else {
+        return TypedValue(kDecimal);
+      }
+    }
     case serialization::Type::DATETIME:
       if (proto.has_datetime_value()) {
         DatetimeLit datetime;

--- a/types/TypedValue.hpp
+++ b/types/TypedValue.hpp
@@ -25,6 +25,7 @@
 #include <functional>
 
 #include "types/DatetimeLit.hpp"
+#include "types/DecimalLit.hpp"
 #include "types/IntervalLit.hpp"
 #include "types/TypeID.hpp"
 #include "types/TypedValue.pb.h"
@@ -124,6 +125,11 @@ class TypedValue {
       : value_info_(static_cast<std::uint64_t>(kDouble)) {
     // Canonicalize negative zero.
     value_union_.double_value = literal_double == 0 ? 0 : literal_double;
+  }
+
+  explicit TypedValue(const DecimalLit literal_decimal)
+      : value_info_(static_cast<std::uint64_t>(kDecimal)) {
+    value_union_.decimal_value = literal_decimal;
   }
 
   /**
@@ -276,6 +282,7 @@ class TypedValue {
       case kLong:
       case kFloat:
       case kDouble:
+      case kDecimal:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
@@ -307,6 +314,7 @@ class TypedValue {
         return sizeof(value_union_.int_value) <= sizeof(std::size_t);
       case kLong:
       case kDouble:
+      case kDecimal:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
@@ -384,6 +392,7 @@ class TypedValue {
         return sizeof(int);
       case kLong:
       case kDouble:
+      case kDecimal:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
@@ -469,6 +478,7 @@ class TypedValue {
                    || getTypeID() == kLong
                    || getTypeID() == kFloat
                    || getTypeID() == kDouble
+                   || getTypeID() == kDecimal
                    || getTypeID() == kDatetime
                    || getTypeID() == kDatetimeInterval
                    || getTypeID() == kYearMonthInterval));
@@ -564,6 +574,7 @@ class TypedValue {
       case kLong:
       case kFloat:
       case kDouble:
+      case kDecimal:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
@@ -659,6 +670,7 @@ class TypedValue {
       case kLong:
       case kFloat:
       case kDouble:
+      case kDecimal:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
@@ -778,6 +790,7 @@ class TypedValue {
     float float_value;
     double double_value;
     const void* out_of_line_data;
+    DecimalLit decimal_value;
     DatetimeLit datetime_value;
     DatetimeIntervalLit datetime_interval_value;
     YearMonthIntervalLit year_month_interval_value;
@@ -804,6 +817,7 @@ class TypedValue {
 
   static_assert(sizeof(ValueUnion) == sizeof(std::int64_t)
                     && sizeof(ValueUnion) == sizeof(double)
+                    && sizeof(ValueUnion) == sizeof(DecimalLit)
                     && sizeof(ValueUnion) == sizeof(DatetimeLit)
                     && sizeof(ValueUnion) == sizeof(DatetimeIntervalLit)
                     && sizeof(ValueUnion) == sizeof(YearMonthIntervalLit),
@@ -850,6 +864,13 @@ inline double TypedValue::getLiteral<double>() const {
   DCHECK_EQ(kDouble, getTypeID());
   DCHECK(!isNull());
   return value_union_.double_value;
+}
+
+template <>
+inline DecimalLit TypedValue::getLiteral<DecimalLit>() const {
+  DCHECK_EQ(kDecimal, getTypeID());
+  DCHECK(!isNull());
+  return value_union_.decimal_value;
 }
 
 template <>

--- a/types/TypedValue.proto
+++ b/types/TypedValue.proto
@@ -28,7 +28,8 @@ message TypedValue {
   optional float float_value = 4;
   optional double double_value = 5;
   optional bytes out_of_line_data = 6;
-  optional int64 datetime_value = 7;
-  optional int64 datetime_interval_value = 8;
-  optional int64 year_month_interval_value = 9;
+  optional int64 decimal_value = 7;
+  optional int64 datetime_value = 8;
+  optional int64 datetime_interval_value = 9;
+  optional int64 year_month_interval_value = 10;
 }

--- a/types/operations/binary_operations/AddBinaryOperation.cpp
+++ b/types/operations/binary_operations/AddBinaryOperation.cpp
@@ -44,7 +44,8 @@ bool AddBinaryOperation::canApplyToTypes(const Type &left, const Type &right) co
     case kInt:  // Fall through.
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       return (right.getSuperTypeID() == Type::kNumeric);
     }
     case kDatetime: {
@@ -229,12 +230,14 @@ TypedValue AddBinaryOperation::applyToChecked(const TypedValue &left,
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       switch (right_type.getTypeID()) {
         case kInt:
         case kLong:
         case kFloat:
         case kDouble:
+        case kDecimal:
           return applyToCheckedNumericHelper<AddFunctor>(left, left_type,
                                                          right, right_type);
         default:
@@ -304,7 +307,8 @@ UncheckedBinaryOperator* AddBinaryOperation::makeUncheckedBinaryOperatorForTypes
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       if (right.getSuperTypeID() == Type::kNumeric) {
         return makeNumericBinaryOperatorOuterHelper<AddArithmeticUncheckedBinaryOperator>(left, right);
       }

--- a/types/operations/binary_operations/ArithmeticBinaryOperation.hpp
+++ b/types/operations/binary_operations/ArithmeticBinaryOperation.hpp
@@ -22,6 +22,7 @@
 
 #include <string>
 
+#include "types/DecimalType.hpp"
 #include "types/DoubleType.hpp"
 #include "types/FloatType.hpp"
 #include "types/IntType.hpp"
@@ -309,6 +310,14 @@ UncheckedBinaryOperator* ArithmeticBinaryOperation::makeNumericBinaryOperatorOut
         return makeNumericBinaryOperatorInnerHelper<OperatorType, DoubleType, false>(
             left, right);
       }
+    case kDecimal:
+      if (left.isNullable()) {
+        return makeNumericBinaryOperatorInnerHelper<OperatorType, DecimalType,
+                                                    true>(left, right);
+      } else {
+        return makeNumericBinaryOperatorInnerHelper<OperatorType, DecimalType,
+                                                    false>(left, right);
+      }
     default:
       throw OperationInapplicableToType(getName(), 2, left.getName().c_str(), right.getName().c_str());
   }
@@ -361,6 +370,16 @@ UncheckedBinaryOperator* ArithmeticBinaryOperation::makeNumericBinaryOperatorInn
         return new OperatorType<typename NumericTypeUnifier<LeftType, DoubleType>::type,
                                 typename LeftType::cpptype, left_nullable,
                                 typename DoubleType::cpptype, false>();
+      }
+    case kDecimal:
+      if (right.isNullable()) {
+        return new OperatorType<typename NumericTypeUnifier<LeftType, DecimalType>::type,
+                                typename LeftType::cpptype, left_nullable,
+                                typename DecimalType::cpptype, true>();
+      } else {
+        return new OperatorType<typename NumericTypeUnifier<LeftType, DecimalType>::type,
+                                typename LeftType::cpptype, left_nullable,
+                                typename DecimalType::cpptype, false>();
       }
     default:
       throw OperationInapplicableToType(getName(), 2, left.getName().c_str(), right.getName().c_str());

--- a/types/operations/binary_operations/ArithmeticBinaryOperators.hpp
+++ b/types/operations/binary_operations/ArithmeticBinaryOperators.hpp
@@ -35,6 +35,7 @@
 #include "storage/ValueAccessorUtil.hpp"
 #endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 
+#include "types/DecimalLit.hpp"
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/operations/binary_operations/BinaryOperation.hpp"
@@ -75,6 +76,27 @@ struct AddFunctor<float, std::int64_t> {
   }
 };
 
+template <>
+struct AddFunctor<DecimalLit, DecimalLit> {
+  inline DecimalLit operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left + right;
+  }
+};
+
+template <typename RightArgument>
+struct AddFunctor<DecimalLit, RightArgument> {
+  inline DecimalLit operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left + DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument>
+struct AddFunctor<LeftArgument, DecimalLit> {
+  inline DecimalLit operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) + right;
+  }
+};
+
 template <typename LeftArgument, typename RightArgument> struct SubtractFunctor {
   inline auto operator() (const LeftArgument &left, const RightArgument &right) const -> decltype(left - right) {
     return left - right;
@@ -95,6 +117,27 @@ template <>
 struct SubtractFunctor<float, std::int64_t> {
   inline double operator() (const float &left, const std::int64_t &right) const {
     return static_cast<double>(left) - static_cast<double>(right);
+  }
+};
+
+template <>
+struct SubtractFunctor<DecimalLit, DecimalLit> {
+  inline DecimalLit operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left - right;
+  }
+};
+
+template <typename RightArgument>
+struct SubtractFunctor<DecimalLit, RightArgument> {
+  inline DecimalLit operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left - DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument>
+struct SubtractFunctor<LeftArgument, DecimalLit> {
+  inline DecimalLit operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) - right;
   }
 };
 
@@ -121,6 +164,27 @@ struct MultiplyFunctor<float, std::int64_t> {
   }
 };
 
+template <>
+struct MultiplyFunctor<DecimalLit, DecimalLit> {
+  inline DecimalLit operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left * right;
+  }
+};
+
+template <typename RightArgument>
+struct MultiplyFunctor<DecimalLit, RightArgument> {
+  inline DecimalLit operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left * DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument>
+struct MultiplyFunctor<LeftArgument, DecimalLit> {
+  inline DecimalLit operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) * right;
+  }
+};
+
 template <typename LeftArgument, typename RightArgument> struct DivideFunctor {
   inline auto operator() (const LeftArgument &left, const RightArgument &right) const -> decltype(left / right) {
     return left / right;
@@ -144,6 +208,27 @@ struct DivideFunctor<float, std::int64_t> {
   }
 };
 
+template <>
+struct DivideFunctor<DecimalLit, DecimalLit> {
+  inline DecimalLit operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left / right;
+  }
+};
+
+template <typename RightArgument>
+struct DivideFunctor<DecimalLit, RightArgument> {
+  inline DecimalLit operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left / DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument>
+struct DivideFunctor<LeftArgument, DecimalLit> {
+  inline DecimalLit operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) / right;
+  }
+};
+
 template <typename LeftArgument, typename RightArgument> struct IntegerModuloFunctor {
   inline auto operator() (const LeftArgument &left, const RightArgument &right) const -> decltype(left % right) {
     return left % right;
@@ -159,6 +244,27 @@ template <typename LeftArgument, typename RightArgument> struct FloatModuloFunct
   inline auto operator() (const LeftArgument &left, const RightArgument &right) const
       -> decltype(std::fmod(left, right)) {
     return std::fmod(left, right);
+  }
+};
+
+template <>
+struct FloatModuloFunctor<DecimalLit, DecimalLit> {
+  inline DecimalLit operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left % right;
+  }
+};
+
+template <typename RightArgument>
+struct FloatModuloFunctor<DecimalLit, RightArgument> {
+  inline DecimalLit operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left % DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument>
+struct FloatModuloFunctor<LeftArgument, DecimalLit> {
+  inline DecimalLit operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) % right;
   }
 };
 

--- a/types/operations/binary_operations/CMakeLists.txt
+++ b/types/operations/binary_operations/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(quickstep_types_operations_binaryoperations_AddBinaryOpera
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_operations_binaryoperations_ArithmeticBinaryOperation
                       glog
+                      quickstep_types_DecimalType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType
@@ -87,6 +88,7 @@ target_link_libraries(quickstep_types_operations_binaryoperations_ArithmeticBina
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil
+                      quickstep_types_DecimalLit
                       quickstep_types_TypedValue
                       quickstep_types_containers_ColumnVector
                       quickstep_types_operations_binaryoperations_BinaryOperation

--- a/types/operations/binary_operations/DivideBinaryOperation.cpp
+++ b/types/operations/binary_operations/DivideBinaryOperation.cpp
@@ -47,6 +47,7 @@ bool DivideBinaryOperation::canApplyToTypes(const Type &left, const Type &right)
     case kLong:
     case kFloat:
     case kDouble:
+    case kDecimal:
     case kDatetimeInterval:
     case kYearMonthInterval: {
       return (right.getSuperTypeID() == Type::kNumeric);
@@ -238,7 +239,8 @@ TypedValue DivideBinaryOperation::applyToChecked(const TypedValue &left,
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       if (right_type.getSuperTypeID() == Type::kNumeric) {
         return applyToCheckedNumericHelper<DivideFunctor>(left, left_type,
                                                           right, right_type);
@@ -321,7 +323,8 @@ UncheckedBinaryOperator* DivideBinaryOperation::makeUncheckedBinaryOperatorForTy
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       if (right.getSuperTypeID() == Type::kNumeric) {
         return makeNumericBinaryOperatorOuterHelper<DivideArithmeticUncheckedBinaryOperator>(left, right);
       }

--- a/types/operations/binary_operations/ModuloBinaryOperation.cpp
+++ b/types/operations/binary_operations/ModuloBinaryOperation.cpp
@@ -223,6 +223,13 @@ TypedValue ModuloBinaryOperation::applyToChecked(const TypedValue &left,
       }
       break;
     }
+    case kDecimal: {
+      if (right_type.getSuperTypeID() == Type::kNumeric) {
+        return applyToCheckedNumericHelper<FloatModuloFunctor>(left, left_type,
+                                                                 right, right_type);
+      }
+      break;
+    }
     default:
       break;
   }
@@ -243,6 +250,12 @@ UncheckedBinaryOperator* ModuloBinaryOperation::makeUncheckedBinaryOperatorForTy
     }  // Fall through
     case kFloat:
     case kDouble: {
+      if (right.getSuperTypeID() == Type::kNumeric) {
+        return makeNumericBinaryOperatorOuterHelper<FloatModuloArithmeticUncheckedBinaryOperator>(left, right);
+      }
+      break;
+    }
+    case kDecimal: {
       if (right.getSuperTypeID() == Type::kNumeric) {
         return makeNumericBinaryOperatorOuterHelper<FloatModuloArithmeticUncheckedBinaryOperator>(left, right);
       }

--- a/types/operations/binary_operations/MultiplyBinaryOperation.cpp
+++ b/types/operations/binary_operations/MultiplyBinaryOperation.cpp
@@ -51,6 +51,9 @@ bool MultiplyBinaryOperation::canApplyToTypes(const Type &left, const Type &righ
               right.getTypeID() == kDatetimeInterval   ||
               right.getTypeID() == kYearMonthInterval);
     }
+    case kDecimal: {
+      return (right.getSuperTypeID() == Type::kNumeric);
+    }
     case kDatetimeInterval:
     case kYearMonthInterval: {
       return (right.getSuperTypeID() == Type::kNumeric);
@@ -217,7 +220,8 @@ TypedValue MultiplyBinaryOperation::applyToChecked(const TypedValue &left,
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       if (right_type.getSuperTypeID() == Type::kNumeric) {
         return applyToCheckedNumericHelper<MultiplyFunctor>(left, left_type,
                                                             right, right_type);
@@ -308,6 +312,12 @@ UncheckedBinaryOperator* MultiplyBinaryOperation::makeUncheckedBinaryOperatorFor
         return makeDateBinaryOperatorOuterHelper<MultiplyArithmeticUncheckedBinaryOperator,
                                                  YearMonthIntervalType,
                                                  DoubleType::cpptype, YearMonthIntervalLit>(left, right);
+      }
+      break;
+    }
+    case kDecimal: {
+      if (right.getSuperTypeID() == Type::kNumeric) {
+        return makeNumericBinaryOperatorOuterHelper<MultiplyArithmeticUncheckedBinaryOperator>(left, right);
       }
       break;
     }

--- a/types/operations/binary_operations/SubtractBinaryOperation.cpp
+++ b/types/operations/binary_operations/SubtractBinaryOperation.cpp
@@ -44,7 +44,8 @@ bool SubtractBinaryOperation::canApplyToTypes(const Type &left, const Type &righ
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       return (right.getSuperTypeID() == Type::kNumeric);
     }
     case kDatetime: {
@@ -287,7 +288,8 @@ TypedValue SubtractBinaryOperation::applyToChecked(const TypedValue &left,
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       if (right_type.getSuperTypeID() == Type::kNumeric) {
         return applyToCheckedNumericHelper<SubtractFunctor>(left, left_type,
                                                             right, right_type);
@@ -352,7 +354,8 @@ UncheckedBinaryOperator* SubtractBinaryOperation::makeUncheckedBinaryOperatorFor
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       if (right.getSuperTypeID() == Type::kNumeric) {
         return makeNumericBinaryOperatorOuterHelper<SubtractArithmeticUncheckedBinaryOperator>(left, right);
       }

--- a/types/operations/comparisons/BasicComparison.cpp
+++ b/types/operations/comparisons/BasicComparison.cpp
@@ -38,12 +38,14 @@ bool BasicComparison::canCompareTypes(const Type &left, const Type &right) const
     case kInt:
     case kLong:
     case kFloat:
-    case kDouble: {
+    case kDouble:
+    case kDecimal: {
       switch (right.getTypeID()) {
         case kInt:
         case kLong:
         case kFloat:
         case kDouble:
+        case kDecimal:
           return true;
         default:
           return false;

--- a/types/operations/comparisons/CMakeLists.txt
+++ b/types/operations/comparisons/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(quickstep_types_operations_comparisons_AsciiStringComparat
 target_link_libraries(quickstep_types_operations_comparisons_BasicComparison
                       glog
                       quickstep_types_DatetimeLit
+                      quickstep_types_DecimalLit
                       quickstep_types_IntervalLit
                       quickstep_types_Type
                       quickstep_types_TypeErrors

--- a/types/operations/comparisons/ComparisonUtil.hpp
+++ b/types/operations/comparisons/ComparisonUtil.hpp
@@ -149,6 +149,11 @@ auto InvokeOnLessComparatorForTypeIgnoreNullability(const Type &type,
                                      double, false> comp;
       return functor(comp);
     }
+    case kDecimal: {
+      LessLiteralUncheckedComparator<DecimalLit, false,
+                                     DecimalLit, false> comp;
+      return functor(comp);
+    }
     case kChar: {
       const std::size_t string_length
           = static_cast<const AsciiStringSuperType&>(type).getStringLength();
@@ -254,6 +259,10 @@ auto InvokeOnLessComparatorForDifferentTypesIgnoreNullability(
           LessLiteralUncheckedComparator<int, false, double, false> comp;
           return functor(comp);
         }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<int, false, DecimalLit, false> comp;
+          return functor(comp);
+        }
         default:
           return comparison_util_detail::InvokeOnLessComparatorForDifferentTypesFallback(
               left_type, right_type, functor);
@@ -280,6 +289,11 @@ auto InvokeOnLessComparatorForDifferentTypesIgnoreNullability(
                                          double, false> comp;
           return functor(comp);
         }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<std::int64_t, false,
+                                         DecimalLit, false> comp;
+          return functor(comp);
+        }
         default:
           return comparison_util_detail::InvokeOnLessComparatorForDifferentTypesFallback(
               left_type, right_type, functor);
@@ -303,6 +317,10 @@ auto InvokeOnLessComparatorForDifferentTypesIgnoreNullability(
           LessLiteralUncheckedComparator<float, false, double, false> comp;
           return functor(comp);
         }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<float, false, DecimalLit, false> comp;
+          return functor(comp);
+        }
         default:
           return comparison_util_detail::InvokeOnLessComparatorForDifferentTypesFallback(
               left_type, right_type, functor);
@@ -324,6 +342,37 @@ auto InvokeOnLessComparatorForDifferentTypesIgnoreNullability(
         }
         case kDouble: {
           LessLiteralUncheckedComparator<double, false, double, false> comp;
+          return functor(comp);
+        }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<double, false, DecimalLit, false> comp;
+          return functor(comp);
+        }
+        default:
+          return comparison_util_detail::InvokeOnLessComparatorForDifferentTypesFallback(
+              left_type, right_type, functor);
+      }
+    }
+    case kDecimal: {
+      switch (right_type.getTypeID()) {
+        case kInt: {
+          LessLiteralUncheckedComparator<DecimalLit, false, int, false> comp;
+          return functor(comp);
+        }
+        case kLong: {
+          LessLiteralUncheckedComparator<DecimalLit, false, std::int64_t, false> comp;
+          return functor(comp);
+        }
+        case kFloat: {
+          LessLiteralUncheckedComparator<DecimalLit, false, float, false> comp;
+          return functor(comp);
+        }
+        case kDouble: {
+          LessLiteralUncheckedComparator<DecimalLit, false, double, false> comp;
+          return functor(comp);
+        }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<DecimalLit, false, DecimalLit, false> comp;
           return functor(comp);
         }
         default:
@@ -544,6 +593,11 @@ auto InvokeOnBothLessComparatorsForDifferentTypesIgnoreNullability(
           LessLiteralUncheckedComparator<double, false, int, false> comp_reversed;
           return functor(comp, comp_reversed);
         }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<int, false, DecimalLit, false> comp;
+          LessLiteralUncheckedComparator<DecimalLit, false, int, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
         default:
           return comparison_util_detail::InvokeOnBothLessComparatorsForDifferentTypesFallback(
               left_type, right_type, functor);
@@ -575,6 +629,11 @@ auto InvokeOnBothLessComparatorsForDifferentTypesIgnoreNullability(
                                          std::int64_t, false> comp_reversed;
           return functor(comp, comp_reversed);
         }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<std::int64_t, false, DecimalLit, false> comp;
+          LessLiteralUncheckedComparator<DecimalLit, false, std::int64_t, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
         default:
           return comparison_util_detail::InvokeOnBothLessComparatorsForDifferentTypesFallback(
               left_type, right_type, functor);
@@ -599,6 +658,11 @@ auto InvokeOnBothLessComparatorsForDifferentTypesIgnoreNullability(
         case kDouble: {
           LessLiteralUncheckedComparator<float, false, double, false> comp;
           LessLiteralUncheckedComparator<double, false, float, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<float, false, DecimalLit, false> comp;
+          LessLiteralUncheckedComparator<DecimalLit, false, float, false> comp_reversed;
           return functor(comp, comp_reversed);
         }
         default:
@@ -627,9 +691,45 @@ auto InvokeOnBothLessComparatorsForDifferentTypesIgnoreNullability(
           LessLiteralUncheckedComparator<double, false, double, false> comp;
           return functor(comp, comp);
         }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<double, false, DecimalLit, false> comp;
+          LessLiteralUncheckedComparator<DecimalLit, false, double, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
         default:
           return comparison_util_detail::InvokeOnBothLessComparatorsForDifferentTypesFallback(
               left_type, right_type, functor);
+      }
+    }
+    case kDecimal: {
+      switch (right_type.getTypeID()) {
+        case kInt: {
+          LessLiteralUncheckedComparator<DecimalLit, false, int, false> comp;
+          LessLiteralUncheckedComparator<int, false, DecimalLit, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
+        case kLong: {
+          LessLiteralUncheckedComparator<DecimalLit, false, std::int64_t, false> comp;
+          LessLiteralUncheckedComparator<std::int64_t, false, DecimalLit, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
+        case kFloat: {
+          LessLiteralUncheckedComparator<DecimalLit, false, float, false> comp;
+          LessLiteralUncheckedComparator<float, false, DecimalLit, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
+        case kDouble: {
+          LessLiteralUncheckedComparator<DecimalLit, false, double, false> comp;
+          LessLiteralUncheckedComparator<double, false, DecimalLit, false> comp_reversed;
+          return functor(comp, comp_reversed);
+        }
+        case kDecimal: {
+          LessLiteralUncheckedComparator<DecimalLit, false, DecimalLit, false> comp;
+          return functor(comp, comp);
+        }
+      default:
+        return comparison_util_detail::InvokeOnBothLessComparatorsForDifferentTypesFallback(
+            left_type, right_type, functor);
       }
     }
     case kChar: {
@@ -959,6 +1059,8 @@ inline bool CheckUntypedValuesEqual(const Type &type, const void *left, const vo
       return STLLiteralEqual<float>()(left, right);
     case kDouble:
       return STLLiteralEqual<double>()(left, right);
+    case kDecimal:
+      return STLLiteralEqual<DecimalLit>()(left, right);
     case kChar:
       return STLCharEqual(static_cast<const AsciiStringSuperType&>(type).getStringLength())(left, right);
     case kVarChar:
@@ -1216,6 +1318,8 @@ inline TypedValue GetLastValueForType(const Type &type) {
       return TypedValue(std::numeric_limits<float>::max());
     case kDouble:
       return TypedValue(std::numeric_limits<double>::max());
+    case kDecimal:
+      return TypedValue(DecimalLit{std::numeric_limits<std::int64_t>::max()});
     case kChar:
       return TypedValue(kChar, kLastString, 2);
     case kVarChar:

--- a/types/operations/comparisons/LiteralComparators.hpp
+++ b/types/operations/comparisons/LiteralComparators.hpp
@@ -45,10 +45,52 @@ template <typename LeftArgument, typename RightArgument> struct EqualFunctor
   }
 };
 
+template <> struct EqualFunctor<DecimalLit, DecimalLit>
+    : public std::binary_function<DecimalLit, DecimalLit, bool> {
+  inline bool operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left == right;
+  }
+};
+
+template <typename RightArgument> struct EqualFunctor<DecimalLit, RightArgument>
+    : public std::binary_function<DecimalLit, RightArgument, bool> {
+  inline bool operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left == DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument> struct EqualFunctor<LeftArgument, DecimalLit>
+    : public std::binary_function<LeftArgument, DecimalLit, bool> {
+  inline bool operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) == right;
+  }
+};
+
 template <typename LeftArgument, typename RightArgument> struct NotEqualFunctor
     : public std::binary_function<LeftArgument, RightArgument, bool> {
   inline bool operator() (const LeftArgument &left, const RightArgument &right) const {
     return left != right;
+  }
+};
+
+template <> struct NotEqualFunctor<DecimalLit, DecimalLit>
+    : public std::binary_function<DecimalLit, DecimalLit, bool> {
+  inline bool operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left != right;
+  }
+};
+
+template <typename RightArgument> struct NotEqualFunctor<DecimalLit, RightArgument>
+    : public std::binary_function<DecimalLit, RightArgument, bool> {
+  inline bool operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left != DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument> struct NotEqualFunctor<LeftArgument, DecimalLit>
+    : public std::binary_function<LeftArgument, DecimalLit, bool> {
+  inline bool operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) != right;
   }
 };
 
@@ -59,10 +101,52 @@ template <typename LeftArgument, typename RightArgument> struct LessFunctor
   }
 };
 
+template <> struct LessFunctor<DecimalLit, DecimalLit>
+    : public std::binary_function<DecimalLit, DecimalLit, bool> {
+  inline bool operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left < right;
+  }
+};
+
+template <typename RightArgument> struct LessFunctor<DecimalLit, RightArgument>
+    : public std::binary_function<DecimalLit, RightArgument, bool> {
+  inline bool operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left < DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument> struct LessFunctor<LeftArgument, DecimalLit>
+    : public std::binary_function<LeftArgument, DecimalLit, bool> {
+  inline bool operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) < right;
+  }
+};
+
 template <typename LeftArgument, typename RightArgument> struct LessOrEqualFunctor
     : public std::binary_function<LeftArgument, RightArgument, bool> {
   inline bool operator() (const LeftArgument &left, const RightArgument &right) const {
     return left <= right;
+  }
+};
+
+template <> struct LessOrEqualFunctor<DecimalLit, DecimalLit>
+    : public std::binary_function<DecimalLit, DecimalLit, bool> {
+  inline bool operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left <= right;
+  }
+};
+
+template <typename RightArgument> struct LessOrEqualFunctor<DecimalLit, RightArgument>
+    : public std::binary_function<DecimalLit, RightArgument, bool> {
+  inline bool operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left <= DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument> struct LessOrEqualFunctor<LeftArgument, DecimalLit>
+    : public std::binary_function<LeftArgument, DecimalLit, bool> {
+  inline bool operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) <= right;
   }
 };
 
@@ -73,12 +157,55 @@ template <typename LeftArgument, typename RightArgument> struct GreaterFunctor
   }
 };
 
+template <> struct GreaterFunctor<DecimalLit, DecimalLit>
+    : public std::binary_function<DecimalLit, DecimalLit, bool> {
+  inline bool operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left > right;
+  }
+};
+
+template <typename RightArgument> struct GreaterFunctor<DecimalLit, RightArgument>
+    : public std::binary_function<DecimalLit, RightArgument, bool> {
+  inline bool operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left > DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument> struct GreaterFunctor<LeftArgument, DecimalLit>
+    : public std::binary_function<LeftArgument, DecimalLit, bool> {
+  inline bool operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) > right;
+  }
+};
+
 template <typename LeftArgument, typename RightArgument> struct GreaterOrEqualFunctor
     : public std::binary_function<LeftArgument, RightArgument, bool> {
   inline bool operator() (const LeftArgument &left, const RightArgument &right) const {
     return left >= right;
   }
 };
+
+template <> struct GreaterOrEqualFunctor<DecimalLit, DecimalLit>
+    : public std::binary_function<DecimalLit, DecimalLit, bool> {
+  inline bool operator() (const DecimalLit &left, const DecimalLit &right) const {
+    return left >= right;
+  }
+};
+
+template <typename RightArgument> struct GreaterOrEqualFunctor<DecimalLit, RightArgument>
+    : public std::binary_function<DecimalLit, RightArgument, bool> {
+  inline bool operator() (const DecimalLit &left, const RightArgument &right) const {
+    return left >= DecimalLit(right);
+  }
+};
+
+template <typename LeftArgument> struct GreaterOrEqualFunctor<LeftArgument, DecimalLit>
+    : public std::binary_function<LeftArgument, DecimalLit, bool> {
+  inline bool operator() (const LeftArgument &left, const DecimalLit &right) const {
+    return DecimalLit(left) >= right;
+  }
+};
+
 
 template <template <typename LeftArgument, typename RightArgument> class ComparisonFunctor,
           typename LeftCppType, bool left_nullable,

--- a/types/operations/unary_operations/ArithmeticUnaryOperations.cpp
+++ b/types/operations/unary_operations/ArithmeticUnaryOperations.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "types/DatetimeIntervalType.hpp"
+#include "types/DecimalType.hpp"
 #include "types/DoubleType.hpp"
 #include "types/FloatType.hpp"
 #include "types/IntType.hpp"
@@ -40,7 +41,7 @@ namespace quickstep {
 bool ArithmeticUnaryOperation::canApplyToType(const Type &type) const {
   return QUICKSTEP_EQUALS_ANY_CONSTANT(
       type.getTypeID(),
-      kInt, kLong, kFloat, kDouble, kDatetimeInterval, kYearMonthInterval);
+      kInt, kLong, kFloat, kDouble, kDecimal, kDatetimeInterval, kYearMonthInterval);
 }
 
 const Type* ArithmeticUnaryOperation::resultTypeForArgumentType(const Type &type) const {
@@ -66,7 +67,7 @@ const Type* ArithmeticUnaryOperation::pushDownTypeHint(const Type *type_hint) co
 bool NegateUnaryOperation::resultTypeIsPlausible(const Type &result_type) const {
   return QUICKSTEP_EQUALS_ANY_CONSTANT(
       result_type.getTypeID(),
-      kInt, kLong, kFloat, kDouble, kDatetimeInterval, kYearMonthInterval);
+      kInt, kLong, kFloat, kDouble, kDecimal, kDatetimeInterval, kYearMonthInterval);
 }
 
 TypedValue NegateUnaryOperation::applyToChecked(const TypedValue &argument,
@@ -86,6 +87,8 @@ TypedValue NegateUnaryOperation::applyToChecked(const TypedValue &argument,
       return TypedValue(-argument.getLiteral<typename FloatType::cpptype>());
     case kDouble:
       return TypedValue(-argument.getLiteral<typename DoubleType::cpptype>());
+    case kDecimal:
+      return TypedValue(-argument.getLiteral<typename DecimalType::cpptype>());
     case kDatetimeInterval:
       return TypedValue(-argument.getLiteral<typename DatetimeIntervalType::cpptype>());
     case kYearMonthInterval:
@@ -122,6 +125,12 @@ UncheckedUnaryOperator* NegateUnaryOperation::makeUncheckedUnaryOperatorForType(
         return new NegateUncheckedUnaryOperator<DoubleType, true>();
       } else {
         return new NegateUncheckedUnaryOperator<DoubleType, false>();
+      }
+    case kDecimal:
+      if (type.isNullable()) {
+        return new NegateUncheckedUnaryOperator<DecimalType, true>();
+      } else {
+        return new NegateUncheckedUnaryOperator<DecimalType, false>();
       }
     case kDatetimeInterval:
       if (type.isNullable()) {

--- a/types/operations/unary_operations/CMakeLists.txt
+++ b/types/operations/unary_operations/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(quickstep_types_operations_unaryoperations_UnaryOperationID UnaryOpe
 target_link_libraries(quickstep_types_operations_unaryoperations_ArithmeticUnaryOperations
                       glog
                       quickstep_types_DatetimeIntervalType
+                      quickstep_types_DecimalType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType
@@ -75,6 +76,7 @@ target_link_libraries(quickstep_types_operations_unaryoperations_NumericCastOper
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil
+                      quickstep_types_DecimalType
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType

--- a/types/operations/unary_operations/NumericCastOperation.hpp
+++ b/types/operations/unary_operations/NumericCastOperation.hpp
@@ -29,6 +29,7 @@
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
+#include "types/DecimalType.hpp"
 #include "types/DoubleType.hpp"
 #include "types/FloatType.hpp"
 #include "types/IntType.hpp"
@@ -126,7 +127,7 @@ class UncheckedNumericCastOperator : public UncheckedUnaryOperator {
           result->appendNullValue();
         } else {
           *static_cast<typename TargetType::cpptype*>(result->getPtrForDirectWrite())
-              = static_cast<typename SourceType::cpptype>(*scalar_arg);
+              = static_cast<typename TargetType::cpptype>(*scalar_arg);
         }
       }
       return result;
@@ -285,6 +286,8 @@ class NumericCastOperation : public UnaryOperation {
         return makeUncheckedUnaryOperatorHelperForTargetNullability<SourceType, source_nullability, FloatType>();
       case kDouble:
         return makeUncheckedUnaryOperatorHelperForTargetNullability<SourceType, source_nullability, DoubleType>();
+      case kDecimal:
+        return makeUncheckedUnaryOperatorHelperForTargetNullability<SourceType, source_nullability, DecimalType>();
       default:
         FATAL_ERROR("Unhandled type " << kTypeNames[target_type_.getTypeID()]);
     }

--- a/types/tests/DecimalType_unittest.cpp
+++ b/types/tests/DecimalType_unittest.cpp
@@ -1,0 +1,82 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include <string>
+
+#include "types/DecimalLit.hpp"
+#include "types/DecimalType.hpp"
+#include "types/Type.hpp"
+#include "types/TypeFactory.hpp"
+#include "types/TypedValue.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+
+TEST(DecimalTypeTest, PrintValueTest) {
+  const Type &decimal_type = TypeFactory::GetType(kDecimal);
+
+  // Try integer version.
+  DecimalLit integer_decimal = DecimalLit(36509);
+  TypedValue value_for_integer_decimal(integer_decimal);
+  EXPECT_EQ(std::string("36509.00"),
+            decimal_type.printValueToString(value_for_integer_decimal));
+
+  // Try double version.
+  DecimalLit double_decimal = DecimalLit(36509.65);
+  TypedValue value_for_double_decimal(double_decimal);
+  EXPECT_EQ(std::string("36509.65"),
+            decimal_type.printValueToString(value_for_double_decimal));
+
+  // Try truncation of double version.
+  DecimalLit double_decimal_truncated = DecimalLit(36509.6526762);
+  TypedValue value_for_double_decimal_truncated(double_decimal_truncated);
+  EXPECT_EQ(std::string("36509.65"),
+            decimal_type.printValueToString(
+                value_for_double_decimal_truncated));
+
+  // Test that number is truncated, not rounded.
+  double_decimal_truncated = DecimalLit(36509.6599999);
+  TypedValue value_for_double_decimal_truncated_other(double_decimal_truncated);
+  EXPECT_EQ(std::string("36509.65"),
+            decimal_type.printValueToString(
+                value_for_double_decimal_truncated));
+}
+
+TEST(DecimalTypeTest, DecimalLitOperationsTest) {
+  const Type &decimal_type = TypeFactory::GetType(kDecimal);
+
+  DecimalLit decimal_a(560.35);
+  DecimalLit decimal_b(439.65);
+
+  EXPECT_EQ(std::string("1000.00"),
+            decimal_type.printValueToString(TypedValue(decimal_a + decimal_b)));
+
+  EXPECT_EQ(std::string("120.70"),
+            decimal_type.printValueToString(TypedValue(decimal_a - decimal_b)));
+
+  EXPECT_EQ(std::string("246357.87"),
+            decimal_type.printValueToString(TypedValue(decimal_a * decimal_b)));
+
+  EXPECT_EQ(std::string("1.27"),
+            decimal_type.printValueToString(TypedValue(decimal_a / decimal_b)));
+
+  EXPECT_EQ(std::string("120.70"),
+            decimal_type.printValueToString(TypedValue(decimal_a % decimal_b)));
+}
+
+}  // namespace quickstep


### PR DESCRIPTION
- This request adds the simple Decimal type which represents fixed precision numbers. 
- In practice, Decimal type is used with 2 arguments: precision and scale.
- Precision is the number of digits (base 10) that the type can show.
- Scale is the number of digits (base 10) after point.
- For example, Decimal(6, 2) can represent numbers from -9999.99 to +9999.99.
- The type does not accept any precision and scale argument for now. It takes default values 18 for precision and 2 for scale. It is chosen since precision 18 is the limit that 64 bits can represent safely, and scale 2 is what TPCH requires.