### PR TITLE
Go back to using LLVM Apt repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,6 @@ env:
   - BUILD_TYPE=Debug VECTOR_COPY_ELISION_LEVEL=selection
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=selection
 
-before_install:
-  - LLVM_VERSION=3.7.1
-  - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
-  - if [[ $CC = "clang" ]]; then
-      wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH;
-      mkdir -p $HOME/clang-$LLVM_VERSION;
-      tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang-$LLVM_VERSION --strip-components 1;
-      ln -sf $HOME/clang-$LLVM_VERSION/bin/clang++ $HOME/clang-$LLVM_VERSION/bin/clang++-3.7;
-      export PATH=$HOME/clang-$LLVM_VERSION/bin:$PATH;
-      export CPPFLAGS="-I $HOME/clang-$LLVM_VERSION/include/c++/v1";
-      echo "Using clang at " `which $CC-3.7` " and $CXX at " `which $CXX-3.7`;
-    fi
-
 install:
   - if [ "$CC" = "gcc" ]; then
       export MAKE_JOBS=1;
@@ -91,9 +78,11 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.7
     packages:
       - gcc-5
       - g++-5
+      - clang-3.7
       - binutils-gold
       - libprotobuf-dev
       - protobuf-compiler


### PR DESCRIPTION
LLVM Apt repositories are back online. 
http://lists.llvm.org/pipermail/llvm-dev/2016-June/101500.html