### PR TITLE
Minor bug fix in QueryManager base.

### DIFF
--- a/query_execution/QueryManagerBase.cpp
+++ b/query_execution/QueryManagerBase.cpp
@@ -71,13 +71,14 @@ QueryManagerBase::QueryManagerBase(QueryHandle *query_handle)
 
 QueryManagerBase::QueryStatusCode QueryManagerBase::queryStatus(
     const dag_node_index op_index) {
-  if (query_exec_state_->hasExecutionFinished(op_index)) {
-    return QueryStatusCode::kOperatorExecuted;
-  }
-
-  // As kQueryExecuted takes precedence over kOperatorExecuted, we check again.
+  // As kQueryExecuted takes precedence over kOperatorExecuted, we first check
+  // whether the query has finished its execution.
   if (query_exec_state_->hasQueryExecutionFinished()) {
     return QueryStatusCode::kQueryExecuted;
+  }
+
+  if (query_exec_state_->hasExecutionFinished(op_index)) {
+    return QueryStatusCode::kOperatorExecuted;
   }
 
   return QueryStatusCode::kNone;


### PR DESCRIPTION
Modified the order in which we check the completion of query and completion of an operator in the queryStatus function. Based on the semantics of the return value of ``queryStatus`` function, query completion return code takes precedence over operator completion. Hence changed the order in which we perform these checks. Note that this bug was present in the original code and was carried forward during the code refactoring of QueryManager. 