### PR TITLE
QUICKSTEP-38. Add support for python3 to utility scripts

### DIFF
--- a/cyclic_dependency.py
+++ b/cyclic_dependency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Script to do analyze the dependencies in Quickstep particularly cycles in the
 # dependency graph. This script can be used to find:
@@ -32,6 +32,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import itertools
 import networkx as nx
@@ -110,18 +114,18 @@ def process_cmakelists_file(cmakelists_filename, qs_module_dirs):
 # target mapping, and target to node mapping.
 def create_graph(deps_in_cmake):
     nodes = set()
-    for source, dest_set in deps_in_cmake.iteritems():
+    for source, dest_set in iter(deps_in_cmake.items()):
         nodes.add(source)
         nodes.update(dest_set)
 
     nodes_list = list(nodes)
     nodes_map = {}
-    for i, n in zip(xrange(len(nodes_list)), nodes_list):
+    for i, n in zip(range(len(nodes_list)), nodes_list):
         nodes_map[n] = i
 
     G = nx.DiGraph()
 
-    for source, dest_set in deps_in_cmake.iteritems():
+    for source, dest_set in iter(deps_in_cmake.items()):
         source_node = nodes_map[source]
         for dest in dest_set:
             if source == dest: continue
@@ -137,17 +141,17 @@ def find_strongly_connected_components(G, nodes_list):
         if len(n) > 1:
             components += 1
             # Only output components bigger than 1.
-            print [nodes_list[i] for i in n]
+            print([nodes_list[i] for i in n])
     return components
 
 # Lists cycles in the graph truncating to 100 cycles.
 def find_cycles(G, nodes_list, truncate):
     cycles = 0
     for n in nx.simple_cycles(G):
-        print [nodes_list[i] for i in n]
+        print([nodes_list[i] for i in n])
         cycles += 1
         if cycles >= truncate:
-            print "Many cycles found. Truncating to {0} cycles.".format(truncate)
+            print("Many cycles found. Truncating to {0} cycles.".format(truncate))
             break
     return cycles
 
@@ -156,16 +160,16 @@ def find_path(G, nodes_list, nodes_map, source, target):
     source_node = nodes_map[source]
     target_node = nodes_map[target]
     if nx.has_path(G, source_node, target_node):
-        print [nodes_list[i] for i in nx.shortest_path(G,
+        print([nodes_list[i] for i in nx.shortest_path(G,
                 source_node,
-                target_node)]
+                target_node)])
     else:
-        print 'No path.'
+        print('No path.')
 
 def main():
     if not os.getcwd().endswith("quickstep"):
-        print ("WARNING: you don't appear to be running in the root quickstep "
-               "source directory. Don't blame me if something goes wrong.")
+        print("WARNING: you don't appear to be running in the root quickstep "
+              "source directory. Don't blame me if something goes wrong.")
     qs_module_dirs = []
     for filename in os.listdir("."):
         if (os.path.isdir(filename)

--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -199,6 +199,7 @@ target_link_libraries(quickstep_queryoptimizer_PhysicalGenerator
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_rules_PruneColumns
                       quickstep_queryoptimizer_rules_StarSchemaHashJoinOrderOptimization
+                      quickstep_queryoptimizer_rules_SwapProbeBuild
                       quickstep_queryoptimizer_strategy_Aggregate
                       quickstep_queryoptimizer_strategy_Join
                       quickstep_queryoptimizer_strategy_OneToOne

--- a/query_optimizer/PhysicalGenerator.cpp
+++ b/query_optimizer/PhysicalGenerator.cpp
@@ -28,6 +28,7 @@
 #include "query_optimizer/physical/Physical.hpp"
 #include "query_optimizer/rules/PruneColumns.hpp"
 #include "query_optimizer/rules/StarSchemaHashJoinOrderOptimization.hpp"
+#include "query_optimizer/rules/SwapProbeBuild.hpp"
 #include "query_optimizer/strategy/Aggregate.hpp"
 #include "query_optimizer/strategy/Join.hpp"
 #include "query_optimizer/strategy/OneToOne.hpp"
@@ -98,6 +99,7 @@ P::PhysicalPtr PhysicalGenerator::optimizePlan() {
     rules.emplace_back(new StarSchemaHashJoinOrderOptimization());
   }
   rules.emplace_back(new PruneColumns());
+  rules.emplace_back(new SwapProbeBuild());
 
   for (std::unique_ptr<Rule<P::Physical>> &rule : rules) {
     physical_plan_ = rule->apply(physical_plan_);

--- a/query_optimizer/physical/HashJoin.hpp
+++ b/query_optimizer/physical/HashJoin.hpp
@@ -20,6 +20,7 @@
 #ifndef QUICKSTEP_QUERY_OPTIMIZER_PHYSICAL_HASHJOIN_HPP_
 #define QUICKSTEP_QUERY_OPTIMIZER_PHYSICAL_HASHJOIN_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/query_optimizer/rules/BottomUpRule.hpp
+++ b/query_optimizer/rules/BottomUpRule.hpp
@@ -54,6 +54,7 @@ class BottomUpRule : public Rule<TreeType> {
   TreeNodePtr apply(const TreeNodePtr &tree) override {
     DCHECK(tree != nullptr);
 
+    init(tree);
     std::vector<std::shared_ptr<const TreeType>> new_children;
     bool has_changed_children = false;
     for (const std::shared_ptr<const TreeType> &child : tree->children()) {
@@ -79,6 +80,15 @@ class BottomUpRule : public Rule<TreeType> {
    * @param The updated node by the rule.
    */
   virtual TreeNodePtr applyToNode(const TreeNodePtr &node) = 0;
+
+  /**
+   * @brief Override this method to implement the initialization code
+   *        for the rule.
+   *
+   * @param input The input tree.
+   */
+  virtual void init(const TreeNodePtr &input) {
+  }
 
  private:
   DISALLOW_COPY_AND_ASSIGN(BottomUpRule);

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(quickstep_queryoptimizer_rules_RuleHelper RuleHelper.cpp RuleHelper.
 add_library(quickstep_queryoptimizer_rules_StarSchemaHashJoinOrderOptimization
             StarSchemaHashJoinOrderOptimization.cpp
             StarSchemaHashJoinOrderOptimization.hpp)
+add_library(quickstep_queryoptimizer_rules_SwapProbeBuild SwapProbeBuild.cpp SwapProbeBuild.hpp)
 add_library(quickstep_queryoptimizer_rules_TopDownRule ../../empty_src.cpp TopDownRule.hpp)
 add_library(quickstep_queryoptimizer_rules_UpdateExpression UpdateExpression.cpp UpdateExpression.hpp)
 add_library(quickstep_queryoptimizer_rules_UnnestSubqueries UnnestSubqueries.cpp UnnestSubqueries.hpp)
@@ -127,6 +128,16 @@ target_link_libraries(quickstep_queryoptimizer_rules_StarSchemaHashJoinOrderOpti
                       quickstep_queryoptimizer_physical_TopLevelPlan
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_queryoptimizer_rules_SwapProbeBuild
+                      quickstep_queryoptimizer_costmodel_SimpleCostModel
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_physical_HashJoin
+                      quickstep_queryoptimizer_physical_PatternMatcher
+                      quickstep_queryoptimizer_physical_Physical
+                      quickstep_queryoptimizer_physical_TopLevelPlan
+                      quickstep_queryoptimizer_rules_BottomUpRule
+                      quickstep_queryoptimizer_rules_Rule
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_TopDownRule
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_utility_Macros)
@@ -185,6 +196,7 @@ target_link_libraries(quickstep_queryoptimizer_rules
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_queryoptimizer_rules_RuleHelper
                       quickstep_queryoptimizer_rules_StarSchemaHashJoinOrderOptimization
+                      quickstep_queryoptimizer_rules_SwapProbeBuild
                       quickstep_queryoptimizer_rules_TopDownRule
                       quickstep_queryoptimizer_rules_UpdateExpression
                       quickstep_queryoptimizer_rules_UnnestSubqueries)

--- a/query_optimizer/rules/SwapProbeBuild.cpp
+++ b/query_optimizer/rules/SwapProbeBuild.cpp
@@ -1,0 +1,62 @@
+#include "query_optimizer/rules/SwapProbeBuild.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/physical/HashJoin.hpp"
+#include "query_optimizer/physical/PatternMatcher.hpp"
+#include "query_optimizer/physical/Physical.hpp"
+#include "query_optimizer/physical/TopLevelPlan.hpp"
+#include "query_optimizer/rules/Rule.hpp"
+
+
+namespace quickstep {
+namespace optimizer {
+
+P::PhysicalPtr SwapProbeBuild::applyToNode(const P::PhysicalPtr &input) {
+  P::HashJoinPtr hash_join;
+
+  if (P::SomeHashJoin::MatchesWithConditionalCast(input, &hash_join)
+      && hash_join->join_type() == P::HashJoin::JoinType::kInnerJoin) {
+    P::PhysicalPtr left = hash_join->left();
+    P::PhysicalPtr right = hash_join->right();
+
+    std::size_t left_cardinality = cost_model_->estimateCardinality(left);
+    std::size_t right_cardinality = cost_model_->estimateCardinality(right);
+
+    if (right_cardinality > left_cardinality) {
+      std::vector<E::AttributeReferencePtr> left_join_attributes = hash_join->left_join_attributes();
+      std::vector<E::AttributeReferencePtr> right_join_attributes = hash_join->right_join_attributes();
+
+      P::PhysicalPtr output = P::HashJoin::Create(right,
+                                                  left,
+                                                  right_join_attributes,
+                                                  left_join_attributes,
+                                                  hash_join->residual_predicate(),
+                                                  hash_join->project_expressions(),
+                                                  hash_join->join_type());
+      LOG_APPLYING_RULE(input, output);
+      return output;
+    }
+  }
+
+  LOG_IGNORING_RULE(input);
+  return input;
+}
+
+void SwapProbeBuild::init(const P::PhysicalPtr &input) {
+  if (cost_model_ == nullptr) {
+    P::TopLevelPlanPtr top_level;
+    if (P::SomeTopLevelPlan::MatchesWithConditionalCast(input, &top_level)) {
+      cost_model_.reset(new C::SimpleCostModel(top_level->shared_subplans()));
+    } else {
+      std::vector<P::PhysicalPtr> plans = {input};
+      cost_model_.reset(new C::SimpleCostModel(plans));
+    }
+  }
+}
+
+}  // namespace optimizer
+}  // namespace quickstep

--- a/query_optimizer/rules/SwapProbeBuild.hpp
+++ b/query_optimizer/rules/SwapProbeBuild.hpp
@@ -1,0 +1,48 @@
+#ifndef QUICKSTEP_QUERY_OPTIMIZER_RULES_SWAP_PROBE_BUILD_HPP_
+#define QUICKSTEP_QUERY_OPTIMIZER_RULES_SWAP_PROBE_BUILD_HPP_
+
+#include <memory>
+#include <string>
+
+#include "query_optimizer/physical/Physical.hpp"
+#include "query_optimizer/rules/Rule.hpp"
+#include "query_optimizer/rules/BottomUpRule.hpp"
+#include "query_optimizer/cost_model/SimpleCostModel.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+namespace optimizer {
+
+/** \addtogroup OptimizerRules
+ *  @{
+ */
+
+namespace P = ::quickstep::optimizer::physical;
+namespace E = ::quickstep::optimizer::expressions;
+namespace C = ::quickstep::optimizer::cost;
+
+/**
+ * @brief Rule that applies to a physical plan to arrange probe and
+ *        build side based on the cardinalities.
+ */
+class SwapProbeBuild : public BottomUpRule<P::Physical> {
+ public:
+  SwapProbeBuild() {
+  }
+
+  std::string getName() const override { return "SwapProbeBuild"; }
+
+ protected:
+  P::PhysicalPtr applyToNode(const P::PhysicalPtr &input) override;
+  void init(const P::PhysicalPtr &input) override;
+
+ private:
+  std::unique_ptr<C::SimpleCostModel> cost_model_;
+
+  DISALLOW_COPY_AND_ASSIGN(SwapProbeBuild);
+};
+
+}  // namespace optimizer
+}  // namespace quickstep
+
+#endif

--- a/query_optimizer/tests/physical_generator/Select.test
+++ b/query_optimizer/tests/physical_generator/Select.test
@@ -2232,10 +2232,7 @@ TopLevelPlan
 [Physical Plan]
 TopLevelPlan
 +-plan=HashJoin
-| +-left=TableReference[relation=b]
-| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
-| | +-AttributeReference[id=1,name=x,relation=b,type=Int]
-| +-right=Aggregate
+| +-left=Aggregate
 | | +-input=TableReference[relation=c]
 | | | +-AttributeReference[id=2,name=x,relation=c,type=Int]
 | | | +-AttributeReference[id=3,name=y,relation=c,type=Int]
@@ -2245,6 +2242,9 @@ TopLevelPlan
 | |   +-Alias[id=4,name=,alias=$aggregate0,relation=$aggregate,type=Long NULL]
 | |     +-AggregateFunction[function=SUM]
 | |       +-AttributeReference[id=3,name=y,relation=c,type=Int]
+| +-right=TableReference[relation=b]
+| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
+| | +-AttributeReference[id=1,name=x,relation=b,type=Int]
 | +-project_expressions=
 | | +-Alias[id=5,name=,alias=(x+SubqueryExpression),relation=,type=Long NULL]
 | |   +-Add
@@ -2252,9 +2252,9 @@ TopLevelPlan
 | |     +-AttributeReference[id=4,name=,alias=$aggregate0,relation=$aggregate,
 | |       type=Long NULL]
 | +-left_join_attributes=
-| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
+| | +-AttributeReference[id=2,name=x,relation=c,type=Int]
 | +-right_join_attributes=
-|   +-AttributeReference[id=2,name=x,relation=c,type=Int]
+|   +-AttributeReference[id=0,name=w,relation=b,type=Int]
 +-output_attributes=
   +-AttributeReference[id=5,name=,alias=(x+SubqueryExpression),relation=,
     type=Long NULL]
@@ -2369,10 +2369,7 @@ TopLevelPlan
 [Physical Plan]
 TopLevelPlan
 +-plan=HashJoin
-| +-left=TableReference[relation=b]
-| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
-| | +-AttributeReference[id=1,name=x,relation=b,type=Int]
-| +-right=Aggregate
+| +-left=Aggregate
 | | +-input=TableReference[relation=c]
 | | | +-AttributeReference[id=2,name=x,relation=c,type=Int]
 | | | +-AttributeReference[id=3,name=y,relation=c,type=Int]
@@ -2382,6 +2379,9 @@ TopLevelPlan
 | |   +-Alias[id=4,name=,alias=$aggregate0,relation=$aggregate,type=Long NULL]
 | |     +-AggregateFunction[function=SUM]
 | |       +-AttributeReference[id=3,name=y,relation=c,type=Int]
+| +-right=TableReference[relation=b]
+| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
+| | +-AttributeReference[id=1,name=x,relation=b,type=Int]
 | +-residual_predicate=Greater
 | | +-AttributeReference[id=1,name=x,relation=b,type=Int]
 | | +-AttributeReference[id=4,name=,alias=$aggregate0,relation=$aggregate,
@@ -2390,9 +2390,9 @@ TopLevelPlan
 | | +-AttributeReference[id=0,name=w,relation=b,type=Int]
 | | +-AttributeReference[id=1,name=x,relation=b,type=Int]
 | +-left_join_attributes=
-| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
+| | +-AttributeReference[id=2,name=x,relation=c,type=Int]
 | +-right_join_attributes=
-|   +-AttributeReference[id=2,name=x,relation=c,type=Int]
+|   +-AttributeReference[id=0,name=w,relation=b,type=Int]
 +-output_attributes=
   +-AttributeReference[id=0,name=w,relation=b,type=Int]
   +-AttributeReference[id=1,name=x,relation=b,type=Int]
@@ -2476,10 +2476,7 @@ TopLevelPlan
 [Physical Plan]
 TopLevelPlan
 +-plan=HashJoin
-| +-left=TableReference[relation=b]
-| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
-| | +-AttributeReference[id=1,name=x,relation=b,type=Int]
-| +-right=NestedLoopsJoin
+| +-left=NestedLoopsJoin
 | | +-left=Aggregate
 | | | +-input=TableReference[relation=c]
 | | | | +-AttributeReference[id=2,name=x,relation=c,type=Int]
@@ -2518,6 +2515,9 @@ TopLevelPlan
 | |       | type=Long NULL]
 | |       +-AttributeReference[id=9,name=,alias=$aggregate0,relation=$aggregate,
 | |         type=Long NULL]
+| +-right=TableReference[relation=b]
+| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
+| | +-AttributeReference[id=1,name=x,relation=b,type=Int]
 | +-project_expressions=
 | | +-Alias[id=11,name=,alias=(x+SubqueryExpression),relation=,type=Long NULL]
 | |   +-Add
@@ -2525,9 +2525,9 @@ TopLevelPlan
 | |     +-AttributeReference[id=10,name=,alias=(SUM(y)+SubqueryExpression),
 | |       relation=,type=Long NULL]
 | +-left_join_attributes=
-| | +-AttributeReference[id=0,name=w,relation=b,type=Int]
+| | +-AttributeReference[id=2,name=x,relation=c,type=Int]
 | +-right_join_attributes=
-|   +-AttributeReference[id=2,name=x,relation=c,type=Int]
+|   +-AttributeReference[id=0,name=w,relation=b,type=Int]
 +-output_attributes=
   +-AttributeReference[id=11,name=,alias=(x+SubqueryExpression),relation=,
     type=Long NULL]

--- a/validate_cmakelists.py
+++ b/validate_cmakelists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """Script to do basic sanity checking for target_link_libraries() commands in
 CMakeLists.txt files.
@@ -30,6 +30,10 @@ TODO List / Known Issues & Limitations:
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import os
 import sys
@@ -334,8 +338,8 @@ def process_cmakelists_file(cmakelists_filename, qs_module_dirs):
                 if "CMAKE_VALIDATE_IGNORE_END" in line:
                     scan_state = previous_state
                 elif "CMAKE_VALIDATE_IGNORE_BEGIN" in line:
-                    print "Nested IGNORE_BEGIN directives found in: "\
-                        + cmakelists_filename + ", exiting"
+                    print("Nested IGNORE_BEGIN directives found in: "
+                        + cmakelists_filename + ", exiting")
                     exit(-1)
                 else:
                     continue
@@ -397,25 +401,25 @@ def process_cmakelists_file(cmakelists_filename, qs_module_dirs):
                     stitched_string = ""
                     scan_state = CMAKE_SCANNING_NONE
     # After scanning, report any missing dependencies.
-    for target, include_deps in deps_from_includes.iteritems():
+    for target, include_deps in iter(deps_from_includes.items()):
         if target in skipped_targets:
             pass
         elif len(include_deps) != 0:
             if target not in deps_in_cmake:
                 if not (target in include_deps and len(include_deps) == 1):
                     validation_failed_targets.add(target)
-                    print "Missing target_link_libraries() for " + target + ":"
+                    print("Missing target_link_libraries() for " + target + ":")
                     for dep in sorted(include_deps):
-                        print "\t" + dep
+                        print("\t" + dep)
             else:
                 missing_deps = (include_deps
                                 - deps_in_cmake[target]
                                 - IGNORED_DEPENDENCIES)
                 if len(missing_deps) != 0:
                     validation_failed_targets.add(target)
-                    print "Missing target_link_libraries() for " + target + ":"
+                    print("Missing target_link_libraries() for " + target + ":")
                     for dep in sorted(missing_deps):
-                        print "\t" + dep
+                        print("\t" + dep)
         elif target == module_targetname:
             # Special case hack for module all-in-one library
             missing_deps = (frozenset(deps_from_includes.keys())
@@ -427,21 +431,21 @@ def process_cmakelists_file(cmakelists_filename, qs_module_dirs):
                     true_missing_deps.add(dep)
             if len(true_missing_deps) != 0:
                 validation_failed_targets.add(target)
-                print "Missing target_link_libraries() for " + target + ":"
+                print("Missing target_link_libraries() for " + target + ":")
                 for dep in sorted(true_missing_deps):
-                    print "\t" + dep
+                    print("\t" + dep)
     # Also report possibly superfluous extra dependencies.
-    for target, cmake_deps in deps_in_cmake.iteritems():
+    for target, cmake_deps in iter(deps_in_cmake.items()):
         if (target not in skipped_targets) and (target in deps_from_includes):
             extra_deps = cmake_deps - deps_from_includes[target]
             if target in extra_deps:
                 extra_deps.remove(target)
             if len(extra_deps) != 0 and target != module_targetname:
                 validation_failed_targets.add(target)
-                print ("Possibly superfluous target_link_libraries() for "
+                print("Possibly superfluous target_link_libraries() for "
                        + target + ":")
                 for dep in sorted(extra_deps):
-                    print "\t" + dep
+                    print("\t" + dep)
     return (validation_failed_targets, skipped_targets, generated_targets)
 
 def main(cmakelists_to_process):
@@ -461,8 +465,8 @@ def main(cmakelists_to_process):
             missing or superfluous dependencies.
     """
     if not os.getcwd().endswith("quickstep"):
-        print ("WARNING: you don't appear to be running in the root quickstep "
-               "source directory. Don't blame me if something goes wrong.")
+        print("WARNING: you don't appear to be running in the root quickstep "
+              "source directory. Don't blame me if something goes wrong.")
     qs_module_dirs = []
     for filename in os.listdir("."):
         if (os.path.isdir(filename)
@@ -493,17 +497,17 @@ def main(cmakelists_to_process):
         global_skipped_targets.update(local_skipped_targets)
         global_generated_targets.update(local_generated_targets)
     if len(global_skipped_targets) != 0:
-        print ("WARNING: The following targets had multiple add_library() "
+        print("WARNING: The following targets had multiple add_library() "
                + "commands and were NOT checked by this script (they should "
                + "be manually checked):")
         for target in sorted(global_skipped_targets):
-            print "\t" + target
+            print("\t" + target)
     if len(global_generated_targets) != 0:
-        print ("INFO: The add_library() commands for the following targets "
+        print("INFO: The add_library() commands for the following targets "
                + "appear to reference generated sources, so they were not "
                + "checked):")
         for target in sorted(global_generated_targets):
-            print "\t" + target
+            print("\t" + target)
     return len(global_validation_failed_targets)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three core changes:
- update from python2 print command, to python3 print function [1]
- switch from xrange to range [1]
- switch from dict.iteritems to iter(dict.items())  [2]

[1] http://python-future.org/compatible_idioms.html
[2] http://legacy.python.org/dev/peps/pep-0469/