### PR TITLE
Visualize execution plan DAGs annotated with profiling stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,6 +770,7 @@ target_link_libraries(quickstep_cli_shell
                       quickstep_queryoptimizer_QueryProcessor
                       quickstep_storage_PreloaderThread
                       quickstep_threading_ThreadIDBasedMap
+                      quickstep_utility_ExecutionDAGVisualizer
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
                       quickstep_utility_SqlError

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -75,6 +75,7 @@ typedef quickstep::LineReaderDumb LineReaderImpl;
 
 #include "storage/PreloaderThread.hpp"
 #include "threading/ThreadIDBasedMap.hpp"
+#include "utility/ExecutionDAGVisualizer.hpp"
 #include "utility/Macros.hpp"
 #include "utility/PtrVector.hpp"
 #include "utility/SqlError.hpp"
@@ -185,6 +186,10 @@ DEFINE_string(profile_file_name, "",
               // To put things in perspective, the first run is, in my experiments, about 5-10
               // times more expensive than the average run. That means the query needs to be
               // run at least a hundred times to make the impact of the first run small (< 5 %).
+DEFINE_bool(visualize_execution_dag, false,
+            "If true, visualize the execution plan DAG into a graph in DOT "
+            "format (DOT is a plain text graph description language) which is "
+            "then printed via stderr.");
 
 }  // namespace quickstep
 
@@ -361,7 +366,7 @@ int main(int argc, char* argv[]) {
       query_processor->getStorageManager(),
       -1,  // Don't pin the Foreman thread.
       num_numa_nodes_system,
-      quickstep::FLAGS_profile_and_report_workorder_perf);
+      quickstep::FLAGS_profile_and_report_workorder_perf || quickstep::FLAGS_visualize_execution_dag);
 
   // Start the worker threads.
   for (Worker &worker : workers) {
@@ -434,6 +439,12 @@ int main(int argc, char* argv[]) {
         }
 
         DCHECK(query_handle->getQueryPlanMutable() != nullptr);
+        std::unique_ptr<quickstep::ExecutionDAGVisualizer> dag_visualizer;
+        if (quickstep::FLAGS_visualize_execution_dag) {
+          dag_visualizer.reset(
+              new quickstep::ExecutionDAGVisualizer(*query_handle->getQueryPlanMutable()));
+        }
+
         start = std::chrono::steady_clock::now();
         QueryExecutionUtil::ConstructAndSendAdmitRequestMessage(
             main_thread_client_id,
@@ -470,6 +481,12 @@ int main(int argc, char* argv[]) {
             // TODO(harshad) - Allow user specified file instead of stdout.
             foreman.printWorkOrderProfilingResults(query_handle->query_id(),
                                                    stdout);
+          }
+          if (quickstep::FLAGS_visualize_execution_dag) {
+            const auto &profiling_stats =
+                foreman.getWorkOrderProfilingResults(query_handle->query_id());
+            dag_visualizer->bindProfilingStats(profiling_stats);
+            std::cerr << "\n" << dag_visualizer->toDOT() << "\n";
           }
         } catch (const std::exception &e) {
           fprintf(stderr, "QUERY EXECUTION ERROR: %s\n", e.what());

--- a/query_execution/ForemanSingleNode.cpp
+++ b/query_execution/ForemanSingleNode.cpp
@@ -236,22 +236,26 @@ void ForemanSingleNode::sendWorkerMessage(const size_t worker_thread_index,
       << worker_directory_->getClientID(worker_thread_index);
 }
 
+const std::vector<WorkOrderTimeEntry>& ForemanSingleNode
+    ::getWorkOrderProfilingResults(const std::size_t query_id) const {
+  return policy_enforcer_->getProfilingResults(query_id);
+}
+
 void ForemanSingleNode::printWorkOrderProfilingResults(const std::size_t query_id,
                                                        std::FILE *out) const {
-  const std::vector<
-      std::tuple<std::size_t, std::size_t, std::size_t>>
-      &recorded_times = policy_enforcer_->getProfilingResults(query_id);
+  const std::vector<WorkOrderTimeEntry> &recorded_times =
+      policy_enforcer_->getProfilingResults(query_id);
   fputs("Query ID,Worker ID,NUMA Socket,Operator ID,Time (microseconds)\n", out);
   for (auto workorder_entry : recorded_times) {
     // Note: Index of the "worker thread index" in the tuple is 0.
-    const std::size_t worker_id = std::get<0>(workorder_entry);
+    const std::size_t worker_id = workorder_entry.worker_id;
     fprintf(out,
             "%lu,%lu,%d,%lu,%lu\n",
             query_id,
             worker_id,
             worker_directory_->getNUMANode(worker_id),
-            std::get<1>(workorder_entry),  // Operator ID.
-            std::get<2>(workorder_entry));  // Time.
+            workorder_entry.operator_id,  // Operator ID.
+            workorder_entry.end_time - workorder_entry.start_time);  // Time.
   }
 }
 

--- a/query_execution/ForemanSingleNode.hpp
+++ b/query_execution/ForemanSingleNode.hpp
@@ -76,6 +76,17 @@ class ForemanSingleNode final : public ForemanBase {
 
   ~ForemanSingleNode() override {}
 
+
+  /**
+   * @brief Get the results of profiling individual work orders for a given
+   *        query.
+   *
+   * @param query_id The ID of the query for which the results are to be printed.
+   * @return A vector of tuples, each being a single profiling entry.
+   **/
+  const std::vector<WorkOrderTimeEntry>& getWorkOrderProfilingResults(
+      const std::size_t query_id) const;
+
   /**
    * @brief Print the results of profiling individual work orders for a given
    *        query.

--- a/query_execution/PolicyEnforcerBase.cpp
+++ b/query_execution/PolicyEnforcerBase.cpp
@@ -28,6 +28,7 @@
 #include "catalog/PartitionScheme.hpp"
 #include "query_execution/QueryExecutionMessages.pb.h"
 #include "query_execution/QueryExecutionState.hpp"
+#include "query_execution/QueryExecutionTypedefs.hpp"
 #include "query_execution/QueryManagerBase.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
@@ -165,13 +166,14 @@ bool PolicyEnforcerBase::admitQueries(
 void PolicyEnforcerBase::recordTimeForWorkOrder(
     const serialization::NormalWorkOrderCompletionMessage &proto) {
   const std::size_t query_id = proto.query_id();
-  if (workorder_time_recorder_.find(query_id) == workorder_time_recorder_.end()) {
-    workorder_time_recorder_[query_id];
-  }
-  workorder_time_recorder_[query_id].emplace_back(
-      proto.worker_thread_index(),
-      proto.operator_index(),
-      proto.execution_time_in_microseconds());
+  std::vector<WorkOrderTimeEntry> &workorder_time_entries
+      = workorder_time_recorder_[query_id];
+  workorder_time_entries.emplace_back();
+  WorkOrderTimeEntry &entry = workorder_time_entries.back();
+  entry.worker_id = proto.worker_thread_index(),
+  entry.operator_id = proto.operator_index(),
+  entry.start_time = proto.execution_start_time(),
+  entry.end_time = proto.execution_end_time();
 }
 
 }  // namespace quickstep

--- a/query_execution/PolicyEnforcerBase.hpp
+++ b/query_execution/PolicyEnforcerBase.hpp
@@ -126,8 +126,8 @@ class PolicyEnforcerBase {
    *
    * @return A vector of tuples, each being a single profiling entry.
    **/
-  inline const std::vector<std::tuple<std::size_t, std::size_t, std::size_t>>&
-      getProfilingResults(const std::size_t query_id) const {
+  inline const std::vector<WorkOrderTimeEntry>& getProfilingResults(
+      const std::size_t query_id) const {
     DCHECK(profile_individual_workorders_);
     DCHECK(workorder_time_recorder_.find(query_id) !=
            workorder_time_recorder_.end());
@@ -158,16 +158,7 @@ class PolicyEnforcerBase {
   // The queries which haven't been admitted yet.
   std::queue<QueryHandle*> waiting_queries_;
 
-  // Key = Query ID.
-  // Value = A tuple indicating a record of executing a work order.
-  // Within a tuple ...
-  // 1st element: Logical worker ID.
-  // 2nd element: Operator ID.
-  // 3rd element: Time in microseconds to execute the work order.
-  std::unordered_map<
-      std::size_t,
-      std::vector<std::tuple<std::size_t, std::size_t, std::size_t>>>
-      workorder_time_recorder_;
+  WorkOrderTimeRecorder workorder_time_recorder_;
 
  private:
   /**

--- a/query_execution/QueryExecutionMessages.proto
+++ b/query_execution/QueryExecutionMessages.proto
@@ -38,7 +38,10 @@ message NormalWorkOrderCompletionMessage {
   required uint64 operator_index = 1;
   required uint64 worker_thread_index = 2;
   required uint64 query_id = 3;
-  optional uint64 execution_time_in_microseconds = 4;
+  
+  // Epoch time in microseconds.  
+  optional uint64 execution_start_time = 4;
+  optional uint64 execution_end_time = 5;
 }
 
 // A message sent upon completion of a rebuild WorkOrder execution.
@@ -46,7 +49,10 @@ message RebuildWorkOrderCompletionMessage {
   required uint64 operator_index = 1;
   required uint64 worker_thread_index = 2;
   required uint64 query_id = 3;
-  optional uint64 execution_time_in_microseconds = 4;
+
+  // Epoch time in microseconds.
+  optional uint64 execution_start_time = 4;
+  optional uint64 execution_end_time = 5;
 }
 
 message CatalogRelationNewBlockMessage {

--- a/query_execution/QueryExecutionTypedefs.hpp
+++ b/query_execution/QueryExecutionTypedefs.hpp
@@ -18,6 +18,9 @@
 #ifndef QUICKSTEP_QUERY_EXECUTION_QUERY_EXECUTION_TYPEDEFS_HPP_
 #define QUICKSTEP_QUERY_EXECUTION_QUERY_EXECUTION_TYPEDEFS_HPP_
 
+#include <unordered_map>
+#include <vector>
+
 #include "query_optimizer/QueryOptimizerConfig.h"  // For QUICKSTEP_DISTRIBUTED
 #include "threading/ThreadIDBasedMap.hpp"
 
@@ -97,6 +100,18 @@ enum QueryExecutionMessageType : message_type_id {
   kBlockDomainUnregistrationMessage,  // From StorageManager to BlockLocator.
 #endif
 };
+
+// WorkOrder profiling data structures.
+// Profiling record for an individual work order.
+struct WorkOrderTimeEntry {
+  std::size_t worker_id;
+  std::size_t operator_id;
+  std::size_t start_time;  // Epoch time measured in microseconds
+  std::size_t end_time;  // Epoch time measured in microseconds
+};
+// Key = query ID.
+// Value = vector of work order profiling records.
+typedef std::unordered_map<std::size_t, std::vector<WorkOrderTimeEntry>> WorkOrderTimeRecorder;
 
 /** @} */
 

--- a/query_execution/Worker.cpp
+++ b/query_execution/Worker.cpp
@@ -120,14 +120,21 @@ void Worker::executeWorkOrderHelper(const TaggedMessage &tagged_message,
   worker_message.getWorkOrder()->execute();
   end = std::chrono::steady_clock::now();
   delete worker_message.getWorkOrder();
-  const uint64_t execution_time_microseconds =
-      std::chrono::duration_cast<std::chrono::microseconds>(end - start)
-          .count();
+
+  // Convert the measured timestamps to epoch times in microseconds.
+  const uint64_t execution_start_time =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          start.time_since_epoch()).count();
+  const uint64_t execution_end_time =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          end.time_since_epoch()).count();
+
   // Construct the proto message.
   proto->set_operator_index(worker_message.getRelationalOpIndex());
   proto->set_query_id(query_id_for_workorder);
   proto->set_worker_thread_index(worker_thread_index_);
-  proto->set_execution_time_in_microseconds(execution_time_microseconds);
+  proto->set_execution_start_time(execution_start_time);
+  proto->set_execution_end_time(execution_end_time);
 }
 
 }  // namespace quickstep

--- a/query_execution/tests/QueryManagerSingleNode_unittest.cpp
+++ b/query_execution/tests/QueryManagerSingleNode_unittest.cpp
@@ -17,6 +17,7 @@
 
 #include <climits>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -102,6 +103,10 @@ class MockOperator: public RelationalOperator {
         num_calls_feedblock_(0),
         num_calls_feedblocks_(0),
         num_calls_donefeedingblocks_(0) {
+  }
+
+  std::string getName() const override {
+    return "MockOperator";
   }
 
 #define MOCK_OP_LOG(x) VLOG(x) << "Op[" << op_index_ << "]: " << __func__ << ": "

--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -18,6 +18,7 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_AGGREGATION_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_AGGREGATION_OPERATOR_HPP_
 
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -68,6 +69,7 @@ class AggregationOperator : public RelationalOperator {
                       bool input_relation_is_stored,
                       const QueryContext::aggregation_state_id aggr_state_index)
       : RelationalOperator(query_id),
+        input_relation_(input_relation),
         input_relation_is_stored_(input_relation_is_stored),
         input_relation_block_ids_(input_relation_is_stored ? input_relation.getBlocksSnapshot()
                                                            : std::vector<block_id>()),
@@ -76,6 +78,14 @@ class AggregationOperator : public RelationalOperator {
         started_(false) {}
 
   ~AggregationOperator() override {}
+
+  std::string getName() const override {
+    return "AggregationOperator";
+  }
+
+  const CatalogRelation& input_relation() const {
+    return input_relation_;
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,
@@ -103,6 +113,7 @@ class AggregationOperator : public RelationalOperator {
    **/
   serialization::WorkOrder* createWorkOrderProto(const block_id block);
 
+  const CatalogRelation &input_relation_;
   const bool input_relation_is_stored_;
   std::vector<block_id> input_relation_block_ids_;
   const QueryContext::aggregation_state_id aggr_state_index_;

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -18,6 +18,7 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_BUILD_HASH_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_BUILD_HASH_OPERATOR_HPP_
 
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -92,6 +93,14 @@ class BuildHashOperator : public RelationalOperator {
       started_(false) {}
 
   ~BuildHashOperator() override {}
+
+  const CatalogRelation& input_relation() const {
+    return input_relation_;
+  }
+
+  std::string getName() const override {
+    return "BuildHashOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,
@@ -195,6 +204,10 @@ class BuildHashWorkOrder : public WorkOrder {
         storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
 
   ~BuildHashWorkOrder() override {}
+
+  const CatalogRelationSchema& input_relation() const {
+    return input_relation_;
+  }
 
   void execute() override;
 

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -69,6 +69,10 @@ class CreateIndexOperator : public RelationalOperator {
 
   ~CreateIndexOperator() override {}
 
+  std::string getName() const override {
+    return "CreateIndexOperator";
+  }
+
   /**
    * @note No WorkOrder generated for this operator.
    **/

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_CREATE_TABLE_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <memory>
 
 #include "catalog/CatalogRelation.hpp"
@@ -65,6 +66,10 @@ class CreateTableOperator : public RelationalOperator {
         database_(DCHECK_NOTNULL(database)) {}
 
   ~CreateTableOperator() override {}
+
+  std::string getName() const override {
+    return "CreateTableOperator";
+  }
 
   /**
    * @note No WorkOrder generated for this operator.

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_DELETE_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -80,6 +81,10 @@ class DeleteOperator : public RelationalOperator {
         num_workorders_generated_(0) {}
 
   ~DeleteOperator() override {}
+
+  std::string getName() const override {
+    return "DeleteOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -18,6 +18,8 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_DESTROY_HASH_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_DESTROY_HASH_OPERATOR_HPP_
 
+#include <string>
+
 #include "query_execution/QueryContext.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
@@ -57,6 +59,10 @@ class DestroyHashOperator : public RelationalOperator {
         work_generated_(false) {}
 
   ~DestroyHashOperator() override {}
+
+  std::string getName() const override {
+    return "DestroyHashOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_DROP_TABLE_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -73,6 +74,10 @@ class DropTableOperator : public RelationalOperator {
         work_generated_(false) {}
 
   ~DropTableOperator() override {}
+
+  std::string getName() const override {
+    return "DropTableOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_FINALIZE_AGGREGATION_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <memory>
 
 #include "catalog/CatalogRelation.hpp"
@@ -73,6 +74,10 @@ class FinalizeAggregationOperator : public RelationalOperator {
         started_(false) {}
 
   ~FinalizeAggregationOperator() override {}
+
+  std::string getName() const override {
+    return "FinalizeAggregationOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -156,6 +157,29 @@ class HashJoinOperator : public RelationalOperator {
   }
 
   ~HashJoinOperator() override {}
+
+  std::string getName() const override {
+    switch (join_type_) {
+      case JoinType::kInnerJoin:
+        return "HashJoinOperator";
+      case JoinType::kLeftSemiJoin:
+        return "HashJoinOperator(LeftSemi)";
+      case JoinType::kLeftAntiJoin:
+        return "HashJoinOperator(LeftAnti)";
+      case JoinType::kLeftOuterJoin:
+        return "HashJoinOperator(LeftOuter)";
+      default: break;
+    }
+    LOG(FATAL) << "Unknown join type in HashJoinOperator::getName()";
+  }
+
+  const CatalogRelation& build_relation() const {
+    return build_relation_;
+  }
+
+  const CatalogRelation& probe_relation() const {
+    return probe_relation_;
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/InsertOperator.hpp
+++ b/relational_operators/InsertOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_INSERT_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <memory>
 
 #include "catalog/CatalogRelation.hpp"
@@ -72,6 +73,10 @@ class InsertOperator : public RelationalOperator {
         work_generated_(false) {}
 
   ~InsertOperator() override {}
+
+  std::string getName() const override {
+    return "InsertOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -115,6 +116,10 @@ class NestedLoopsJoinOperator : public RelationalOperator {
   }
 
   ~NestedLoopsJoinOperator() override {}
+
+  std::string getName() const override {
+    return "NestedLoopsJoinOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_RELATIONAL_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -53,6 +54,13 @@ class RelationalOperator {
    * @brief Virtual destructor.
    **/
   virtual ~RelationalOperator() {}
+
+  /**
+   * @brief Get the name of this relational operator.
+   *
+   * @return The name of this relational operator.
+   */
+  virtual std::string getName() const = 0;
 
   /**
    * @brief Generate all the next WorkOrders for this RelationalOperator.
@@ -224,6 +232,15 @@ class RelationalOperator {
    **/
   void setOperatorIndex(const std::size_t operator_index) {
     op_index_ = operator_index;
+  }
+
+  /**
+   * @brief Get the index of this operator in the query plan DAG.
+   *
+   * @return The index of this operator in the query plan DAG.
+   */
+  std::size_t getOperatorIndex() const {
+    return op_index_;
   }
 
  protected:

--- a/relational_operators/SampleOperator.hpp
+++ b/relational_operators/SampleOperator.hpp
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -92,6 +93,10 @@ class SampleOperator : public RelationalOperator {
         started_(false) {}
 
   ~SampleOperator() override {}
+
+  std::string getName() const override {
+    return "SampleOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_SAVE_BLOCKS_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -63,6 +64,10 @@ class SaveBlocksOperator : public RelationalOperator {
         num_workorders_generated_(0) {}
 
   ~SaveBlocksOperator() override {}
+
+  std::string getName() const override {
+    return "SaveBlocksOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_SELECT_OPERATOR_HPP_
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -188,6 +189,14 @@ class SelectOperator : public RelationalOperator {
   }
 
   ~SelectOperator() override {}
+
+  std::string getName() const override {
+    return "SelectOperator";
+  }
+
+  const CatalogRelation& input_relation() const {
+    return input_relation_;
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/SortMergeRunOperator.hpp
+++ b/relational_operators/SortMergeRunOperator.hpp
@@ -19,6 +19,7 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_SORT_MERGE_RUN_OPERATOR_HPP_
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -128,6 +129,10 @@ class SortMergeRunOperator : public RelationalOperator {
    * @brief Destructor.
    **/
   ~SortMergeRunOperator() {}
+
+  std::string getName() const override {
+    return "SortMergeRunOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -18,6 +18,7 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_SORT_RUN_GENERATION_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_SORT_RUN_GENERATION_OPERATOR_HPP_
 
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -108,6 +109,10 @@ class SortRunGenerationOperator : public RelationalOperator {
         input_relation_is_stored_(input_relation_is_stored) {}
 
   ~SortRunGenerationOperator() {}
+
+  std::string getName() const override {
+    return "SortRunGenerationOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -19,6 +19,7 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_TABLE_GENERATOR_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_TABLE_GENERATOR_OPERATOR_HPP_
 
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -75,6 +76,10 @@ class TableGeneratorOperator : public RelationalOperator {
         started_(false) {}
 
   ~TableGeneratorOperator() override {}
+
+  std::string getName() const override {
+    return "TableGeneratorOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/TextScanOperator.hpp
+++ b/relational_operators/TextScanOperator.hpp
@@ -134,6 +134,10 @@ class TextScanOperator : public RelationalOperator {
 
   ~TextScanOperator() override {}
 
+  std::string getName() const override {
+    return "TextScanOperator";
+  }
+
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,
                         StorageManager *storage_manager,

--- a/relational_operators/UpdateOperator.hpp
+++ b/relational_operators/UpdateOperator.hpp
@@ -20,6 +20,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -93,6 +94,10 @@ class UpdateOperator : public RelationalOperator {
         started_(false) {}
 
   ~UpdateOperator() override {}
+
+  std::string getName() const override {
+    return "UpdateOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/relational_operators/WindowAggregationOperator.hpp
+++ b/relational_operators/WindowAggregationOperator.hpp
@@ -20,6 +20,7 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_WINDOW_AGGREGATION_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_WINDOW_AGGREGATION_OPERATOR_HPP_
 
+#include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
@@ -77,6 +78,10 @@ class WindowAggregationOperator : public RelationalOperator {
         generated_(false) {}
 
   ~WindowAggregationOperator() override {}
+
+  std::string getName() const override {
+    return "WindowAggregationOperator";
+  }
 
   bool getAllWorkOrders(WorkOrdersContainer *container,
                         QueryContext *query_context,

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -167,6 +167,9 @@ add_library(quickstep_utility_Cast ../empty_src.cpp Cast.hpp)
 add_library(quickstep_utility_CheckSnprintf ../empty_src.cpp CheckSnprintf.hpp)
 add_library(quickstep_utility_DAG ../empty_src.cpp DAG.hpp)
 add_library(quickstep_utility_EqualsAnyConstant ../empty_src.cpp EqualsAnyConstant.hpp)
+add_library(quickstep_utility_ExecutionDAGVisualizer
+            ExecutionDAGVisualizer.cpp
+            ExecutionDAGVisualizer.hpp)
 add_library(quickstep_utility_Glob Glob.cpp Glob.hpp)
 add_library(quickstep_utility_HashPair ../empty_src.cpp HashPair.hpp)
 add_library(quickstep_utility_Macros ../empty_src.cpp Macros.hpp)
@@ -225,6 +228,16 @@ target_link_libraries(quickstep_utility_CheckSnprintf
 target_link_libraries(quickstep_utility_DAG
                       glog
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_utility_ExecutionDAGVisualizer
+                      quickstep_catalog_CatalogRelationSchema
+                      quickstep_queryexecution_QueryExecutionTypedefs
+                      quickstep_queryoptimizer_QueryPlan
+                      quickstep_relationaloperators_AggregationOperator
+                      quickstep_relationaloperators_BuildHashOperator
+                      quickstep_relationaloperators_HashJoinOperator
+                      quickstep_relationaloperators_SelectOperator
+                      quickstep_utility_Macros
+                      quickstep_utility_StringUtil)
 target_link_libraries(quickstep_utility_Glob
                       glog)
 target_link_libraries(quickstep_utility_MemStream
@@ -303,6 +316,7 @@ target_link_libraries(quickstep_utility
                       quickstep_utility_CheckSnprintf
                       quickstep_utility_DAG
                       quickstep_utility_EqualsAnyConstant
+                      quickstep_utility_ExecutionDAGVisualizer
                       quickstep_utility_Glob
                       quickstep_utility_HashPair
                       quickstep_utility_Macros

--- a/utility/ExecutionDAGVisualizer.cpp
+++ b/utility/ExecutionDAGVisualizer.cpp
@@ -1,0 +1,230 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#include "utility/ExecutionDAGVisualizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <limits>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "catalog/CatalogRelationSchema.hpp"
+#include "query_execution/QueryExecutionTypedefs.hpp"
+#include "query_optimizer/QueryPlan.hpp"
+#include "relational_operators/AggregationOperator.hpp"
+#include "relational_operators/BuildHashOperator.hpp"
+#include "relational_operators/HashJoinOperator.hpp"
+#include "relational_operators/SelectOperator.hpp"
+#include "utility/StringUtil.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+ExecutionDAGVisualizer::ExecutionDAGVisualizer(const QueryPlan &plan) {
+  // Do not display these relational operators in the graph.
+  std::set<std::string> no_display_op_names =
+      { "DestroyHashOperator", "DropTableOperator" };
+
+  const auto &dag = plan.getQueryPlanDAG();
+  num_nodes_ = dag.size();
+
+  // Collect DAG vertices info.
+  std::vector<bool> display_ops(num_nodes_, false);
+  for (std::size_t node_index = 0; node_index < num_nodes_; ++node_index) {
+    const auto &node = dag.getNodePayload(node_index);
+    const std::string relop_name = node.getName();
+    if (no_display_op_names.find(relop_name) == no_display_op_names.end()) {
+      display_ops[node_index] = true;
+      NodeInfo &node_info = nodes_[node_index];
+      node_info.id = node_index;
+      node_info.labels.emplace_back(
+          "[" + std::to_string(node.getOperatorIndex()) + "] " + relop_name);
+
+      std::vector<std::pair<std::string, const CatalogRelationSchema*>> input_relations;
+      if (relop_name == "AggregationOperator") {
+        const AggregationOperator &aggregation_op =
+            static_cast<const AggregationOperator&>(node);
+        input_relations.emplace_back("input", &aggregation_op.input_relation());
+      } else if (relop_name == "BuildHashOperator") {
+        const BuildHashOperator &build_hash_op =
+            static_cast<const BuildHashOperator&>(node);
+        input_relations.emplace_back("input", &build_hash_op.input_relation());
+      } else if (relop_name == "HashJoinOperator") {
+        const HashJoinOperator &hash_join_op =
+            static_cast<const HashJoinOperator&>(node);
+        input_relations.emplace_back("probe side", &hash_join_op.probe_relation());
+      } else if (relop_name == "SelectOperator") {
+        const SelectOperator &select_op =
+            static_cast<const SelectOperator&>(node);
+        input_relations.emplace_back("input", &select_op.input_relation());
+      }
+      for (const auto &rel_pair : input_relations) {
+        if (!rel_pair.second->isTemporary()) {
+          node_info.labels.emplace_back(
+              rel_pair.first + " stored relation [" +
+              rel_pair.second->getName() + "]");
+        }
+      }
+    }
+  }
+
+  // Collect DAG edges info.
+  for (std::size_t node_index = 0; node_index < num_nodes_; ++node_index) {
+    if (display_ops[node_index]) {
+      for (const auto &link : dag.getDependents(node_index)) {
+        if (display_ops[link.first]) {
+          edges_.emplace_back();
+          edges_.back().src_node_id = node_index;
+          edges_.back().dst_node_id = link.first;
+          edges_.back().is_pipeline_breaker = link.second;
+        }
+      }
+    }
+  }
+}
+
+void ExecutionDAGVisualizer::bindProfilingStats(
+  const std::vector<WorkOrderTimeEntry> &execution_time_records) {
+  std::vector<std::size_t> time_start(num_nodes_, std::numeric_limits<std::size_t>::max());
+  std::vector<std::size_t> time_end(num_nodes_, 0);
+  std::vector<std::size_t> time_elapsed(num_nodes_, 0);
+  std::size_t overall_start_time = std::numeric_limits<std::size_t>::max();
+  std::size_t overall_end_time = 0;
+  for (const auto &entry : execution_time_records) {
+    const std::size_t relop_index = entry.operator_id;
+    DCHECK_LT(relop_index, num_nodes_);
+
+    const std::size_t workorder_start_time = entry.start_time;
+    const std::size_t workorder_end_time = entry.end_time;
+    overall_start_time = std::min(overall_start_time, workorder_start_time);
+    overall_end_time = std::max(overall_end_time, workorder_end_time);
+
+    time_start[relop_index] =
+        std::min(time_start[relop_index], workorder_start_time);
+    time_end[relop_index] =
+        std::max(time_end[relop_index], workorder_end_time);
+    time_elapsed[relop_index] += (workorder_end_time - workorder_start_time);
+  }
+
+  double total_time_elapsed = 0;
+  for (std::size_t i = 0; i < time_elapsed.size(); ++i) {
+    total_time_elapsed += time_elapsed[i];
+  }
+  std::vector<double> time_percentage(num_nodes_, 0);
+  std::vector<double> span_percentage(num_nodes_, 0);
+  double overall_span = overall_end_time - overall_start_time;
+  double max_percentage = 0;
+  for (std::size_t i = 0; i < time_elapsed.size(); ++i) {
+    time_percentage[i] = time_elapsed[i] / total_time_elapsed * 100;
+    span_percentage[i] = (time_end[i] - time_start[i]) / overall_span * 100;
+    max_percentage = std::max(max_percentage, time_percentage[i] + span_percentage[i]);
+  }
+
+  for (std::size_t node_index = 0; node_index < num_nodes_; ++node_index) {
+    if (nodes_.find(node_index) != nodes_.end()) {
+      const std::size_t relop_start_time = time_start[node_index];
+      const std::size_t relop_end_time = time_end[node_index];
+      const std::size_t relop_elapsed_time = time_elapsed[node_index];
+      NodeInfo &node_info = nodes_[node_index];
+
+      const double hue =
+          (time_percentage[node_index] + span_percentage[node_index]) / max_percentage;
+      node_info.color = std::to_string(hue) + " " + std::to_string(hue) + " 1.0";
+
+      if (overall_start_time == 0) {
+        node_info.labels.emplace_back(
+            "span: " +
+            std::to_string((relop_end_time - relop_start_time) / 1000) + "ms");
+      } else {
+        node_info.labels.emplace_back(
+            "span: [" +
+            std::to_string((relop_start_time - overall_start_time) / 1000) + "ms, " +
+            std::to_string((relop_end_time - overall_start_time) / 1000) + "ms] (" +
+            FormatDigits(span_percentage[node_index], 2) + "%)");
+      }
+
+      node_info.labels.emplace_back(
+          "total: " +
+          std::to_string(relop_elapsed_time / 1000) + "ms (" +
+          FormatDigits(time_percentage[node_index], 2) + "%)");
+
+      const double concurrency =
+          static_cast<double>(relop_elapsed_time) / (relop_end_time - relop_start_time);
+      node_info.labels.emplace_back(
+          "effective concurrency: " + FormatDigits(concurrency, 2));
+    }
+  }
+}
+
+std::string ExecutionDAGVisualizer::toDOT() {
+  // Format output graph
+  std::ostringstream graph_oss;
+  graph_oss << "digraph g {\n";
+  graph_oss << "  rankdir=BT\n";
+  graph_oss << "  node [penwidth=2]\n";
+  graph_oss << "  edge [fontsize=16 fontcolor=gray penwidth=2]\n\n";
+
+  // Format nodes
+  for (const auto &node_pair : nodes_) {
+    const NodeInfo &node_info = node_pair.second;
+    graph_oss << "  " << node_info.id << " [ ";
+    if (!node_info.labels.empty()) {
+      graph_oss << "label=\""
+                << EscapeSpecialChars(JoinToString(node_info.labels, "&#10;"))
+                << "\" ";
+    }
+    if (!node_info.color.empty()) {
+      graph_oss << "style=filled fillcolor=\"" << node_info.color << "\" ";
+    }
+    graph_oss << "]\n";
+  }
+  graph_oss << "\n";
+
+  // Format edges
+  for (const EdgeInfo &edge_info : edges_) {
+    graph_oss << "  " << edge_info.src_node_id << " -> "
+              << edge_info.dst_node_id << " [ ";
+    if (edge_info.is_pipeline_breaker) {
+      graph_oss << "style=dashed ";
+    }
+    if (!edge_info.labels.empty()) {
+      graph_oss << "label=\""
+                << EscapeSpecialChars(JoinToString(edge_info.labels, "&#10;"))
+                << "\" ";
+    }
+    graph_oss << "]\n";
+  }
+  graph_oss << "}\n";
+
+  return graph_oss.str();
+}
+
+std::string ExecutionDAGVisualizer::FormatDigits(const double value,
+                                                 const int num_digits) {
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(num_digits) << value;
+  return oss.str();
+}
+
+}  // namespace quickstep

--- a/utility/ExecutionDAGVisualizer.hpp
+++ b/utility/ExecutionDAGVisualizer.hpp
@@ -1,0 +1,112 @@
+/**
+ *   Copyright 2016, Quickstep Research Group, Computer Sciences Department,
+ *     University of Wisconsin—Madison.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
+#ifndef QUICKSTEP_UTILITY_EXECUTION_DAG_VISUALIZER_HPP_
+#define QUICKSTEP_UTILITY_EXECUTION_DAG_VISUALIZER_HPP_
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+class QueryPlan;
+struct WorkOrderTimeEntry;
+
+/** \addtogroup Utility
+ *  @{
+ */
+
+/**
+ * @brief A visualizer that converts an execution plan DAG into a graph in
+ *        DOT format. Note that DOT is a plain text graph description language.
+ *
+ * @note This utility tool can be further extended to be more generic.
+ */
+class ExecutionDAGVisualizer {
+ public:
+  /**
+   * @brief Constructor
+   *
+   * @param plan The execution plan to be visualized.
+   */
+  explicit ExecutionDAGVisualizer(const QueryPlan &plan);
+
+  /**
+   * @brief Destructor
+   */
+  ~ExecutionDAGVisualizer() {}
+
+  /**
+   * @brief Summarize the execution timing stats and bind the stats to the
+   *        corresponding relational operators in the execution plan.
+   *
+   * @param execution_time_records The profiled timing records of execution.
+   */
+  void bindProfilingStats(
+      const std::vector<WorkOrderTimeEntry> &execution_time_records);
+
+  /**
+   * @brief Get the string represenation of the visualized execution plan
+   *        in DOT format (DOT is a plain text graph description language).
+   *
+   * @return The execution plan graph in DOT format.
+   */
+  std::string toDOT();
+
+ private:
+  /**
+   * @brief Format a float value to string representation with the specified
+   *        number of decimal digits.
+   */
+  static std::string FormatDigits(const double value,
+                                  const int num_digits);
+
+  /**
+   * @brief Information of a graph node.
+   */
+  struct NodeInfo {
+    std::size_t id;
+    std::vector<std::string> labels;
+    std::string color;
+  };
+
+  /**
+   * @brief Information of a graph edge.
+   */
+  struct EdgeInfo {
+    std::size_t src_node_id;
+    std::size_t dst_node_id;
+    std::vector<std::string> labels;
+    bool is_pipeline_breaker;
+  };
+
+  std::size_t num_nodes_;
+  std::map<std::size_t, NodeInfo> nodes_;
+  std::vector<EdgeInfo> edges_;
+
+  DISALLOW_COPY_AND_ASSIGN(ExecutionDAGVisualizer);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif /* QUICKSTEP_UTILITY_EXECUTION_DAG_VISUALIZER_HPP_ */


### PR DESCRIPTION
This PR adds support for visualization of execution plan DAGs. Each relational operator in the DAG is also annotated with the execution profiling stats of its work orders. The main changes are
- Added a `getName()` method for each relational operator.
- Implemented visualization code in `utility/ExecutionDAGVisualizer.*`.
- Slightly refactored work order profiling code to record both start time and end time of each work order.

To enable this feature, set the gflag `visualize_execution_dag` to true, e.g.
```
quickstep_cli_shell -visualize_execution_dag=true
```
The execution DAG will be printed via `stderr` in DOT format. Each relational operator node in the DAG contains the following information:
- Relational operator ID, Relational operator name.
- The input relation's name (if it is a stored relation).
- Total execution time of all the work orders of this relational operator.
- Execution time span (start time of the first work order and finish time of the last work order) of this relational operator.
- Degree of concurrency (total time / span) of this relational operator.

The coloring of each node indicates whether it is computational intensive. E.g. a _red_ color indicates that the relational operator incurs either long total execution time or long time span.

Here's an example output, for SSB query 05:
```
digraph g {
  rankdir=BT
  node [penwidth=2]
  edge [fontsize=16 fontcolor=gray penwidth=2]

  0 [ label="[0] SelectOperator&#10;input stored relation [supplier]&#10;span: [0ms, 6ms] (0.74%)&#10;total: 38ms (0.13%)&#10;effective concurrency: 6.29" style=filled fillcolor="0.004717 0.004717 1.0" ]
  1 [ label="[1] SelectOperator&#10;input stored relation [part]&#10;span: [0ms, 10ms] (1.25%)&#10;total: 273ms (0.90%)&#10;effective concurrency: 26.26" style=filled fillcolor="0.011673 0.011673 1.0" ]
  2 [ label="[2] BuildHashOperator&#10;span: [10ms, 12ms] (0.21%)&#10;total: 19ms (0.06%)&#10;effective concurrency: 11.20" style=filled fillcolor="0.001494 0.001494 1.0" ]
  3 [ label="[3] HashJoinOperator&#10;probe side stored relation [lineorder]&#10;span: [17ms, 752ms] (88.04%)&#10;total: 29059ms (95.43%)&#10;effective concurrency: 39.53" style=filled fillcolor="1.000000 1.000000 1.0" ]
  5 [ label="[5] BuildHashOperator&#10;span: [6ms, 9ms] (0.39%)&#10;total: 6ms (0.02%)&#10;effective concurrency: 1.97" style=filled fillcolor="0.002248 0.002248 1.0" ]
  6 [ label="[6] HashJoinOperator&#10;span: [748ms, 773ms] (3.04%)&#10;total: 438ms (1.44%)&#10;effective concurrency: 17.28" style=filled fillcolor="0.024394 0.024394 1.0" ]
  8 [ label="[8] BuildHashOperator&#10;input stored relation [ddate]&#10;span: [8ms, 8ms] (0.05%)&#10;total: 0ms (0.00%)&#10;effective concurrency: 1.00" style=filled fillcolor="0.000274 0.000274 1.0" ]
  9 [ label="[9] HashJoinOperator&#10;span: [767ms, 806ms] (4.65%)&#10;total: 372ms (1.22%)&#10;effective concurrency: 9.59" style=filled fillcolor="0.032002 0.032002 1.0" ]
  11 [ label="[11] AggregationOperator&#10;span: [792ms, 832ms] (4.80%)&#10;total: 223ms (0.73%)&#10;effective concurrency: 5.58" style=filled fillcolor="0.030163 0.030163 1.0" ]
  12 [ label="[12] FinalizeAggregationOperator&#10;span: [832ms, 833ms] (0.02%)&#10;total: 0ms (0.00%)&#10;effective concurrency: 1.00" style=filled fillcolor="0.000139 0.000139 1.0" ]
  13 [ label="[13] SortRunGenerationOperator&#10;span: [834ms, 834ms] (0.01%)&#10;total: 0ms (0.00%)&#10;effective concurrency: 1.00" style=filled fillcolor="0.000030 0.000030 1.0" ]
  14 [ label="[14] SortMergeRunOperator&#10;span: [834ms, 834ms] (0.01%)&#10;total: 0ms (0.00%)&#10;effective concurrency: 1.00" style=filled fillcolor="0.000043 0.000043 1.0" ]
  16 [ label="[16] SelectOperator&#10;span: [834ms, 834ms] (0.00%)&#10;total: 0ms (0.00%)&#10;effective concurrency: 1.00" style=filled fillcolor="0.000011 0.000011 1.0" ]

  0 -> 6 [ style=dashed ]
  0 -> 5 [ ]
  1 -> 3 [ style=dashed ]
  1 -> 2 [ ]
  2 -> 3 [ style=dashed ]
  3 -> 6 [ ]
  5 -> 6 [ style=dashed ]
  6 -> 9 [ ]
  8 -> 9 [ style=dashed ]
  9 -> 11 [ ]
  11 -> 12 [ style=dashed ]
  12 -> 13 [ ]
  13 -> 14 [ ]
  14 -> 16 [ ]
}
```

To convert the DOT description into an image. A quick way is to use online visualization tools (e.g. http://www.webgraphviz.com, just copy and paste the graph description into the webpage's textbox and click _Generate Graph!_).

The output can also be redirected to a file and then converted to an image with the dot tool, e.g.
```
quickstep_cli_shell -visualize_execution_dag=true < some_query.sql 2> some_graph.dot

dot -Gsize="8,10.5" -Teps some_graph.dot -o some_graph.eps
```
Here eps can be `pdf`, `png`, etc.