### PR TITLE
Constructed Generators once in the optimizer.

### DIFF
--- a/query_optimizer/Optimizer.cpp
+++ b/query_optimizer/Optimizer.cpp
@@ -26,13 +26,11 @@ namespace optimizer {
 
 void Optimizer::generateQueryHandle(const ParseStatement &parse_statement,
                                     QueryHandle *query_handle) {
-  LogicalGenerator logical_generator(&optimizer_context_);
-  PhysicalGenerator physical_generator;
   ExecutionGenerator execution_generator(&optimizer_context_, query_handle);
 
   execution_generator.generatePlan(
-      physical_generator.generatePlan(
-          logical_generator.generatePlan(parse_statement)));
+      physical_generator_.generatePlan(
+          logical_generator_.generatePlan(parse_statement)));
 }
 
 }  // namespace optimizer

--- a/query_optimizer/Optimizer.hpp
+++ b/query_optimizer/Optimizer.hpp
@@ -18,7 +18,9 @@
 #ifndef QUICKSTEP_QUERY_OPTIMIZER_OPTIMIZER_HPP_
 #define QUICKSTEP_QUERY_OPTIMIZER_OPTIMIZER_HPP_
 
+#include "query_optimizer/LogicalGenerator.hpp"
 #include "query_optimizer/OptimizerContext.hpp"
+#include "query_optimizer/PhysicalGenerator.hpp"
 #include "utility/Macros.hpp"
 
 namespace quickstep {
@@ -48,7 +50,8 @@ class Optimizer {
    */
   Optimizer(CatalogDatabase *database,
             StorageManager *storage_manager)
-      : optimizer_context_(database, storage_manager) {}
+      : optimizer_context_(database, storage_manager),
+        logical_generator_(&optimizer_context_) {}
 
   /**
    * @brief Destructor.
@@ -77,6 +80,8 @@ class Optimizer {
 
  private:
   OptimizerContext optimizer_context_;
+  LogicalGenerator logical_generator_;
+  PhysicalGenerator physical_generator_;
 
   DISALLOW_COPY_AND_ASSIGN(Optimizer);
 };


### PR DESCRIPTION
Instead of creating generators each time per query, do so once, and reuse the instances for every query.