### PR TITLE
QUICKSTEP-53 DateLit improvements

### DIFF
--- a/types/DateOperatorOverloads.hpp
+++ b/types/DateOperatorOverloads.hpp
@@ -122,8 +122,8 @@ inline DatetimeLit operator+(const YearMonthIntervalLit &lhs, const DatetimeLit 
 }
 
 inline DateLit operator+(const DateLit &lhs, const YearMonthIntervalLit &rhs) {
-  std::int32_t result_year = lhs.year + (rhs.months / 12);
-  std::uint8_t result_month = lhs.month + (rhs.months % 12);
+  std::int32_t result_year = lhs.yearField() + (rhs.months / 12);
+  std::uint8_t result_month = static_cast<std::uint8_t>(lhs.monthField()) + (rhs.months % 12);
 
   if (result_month > 11) {
     result_month -= 12;
@@ -131,7 +131,7 @@ inline DateLit operator+(const DateLit &lhs, const YearMonthIntervalLit &rhs) {
   }
 
   const std::uint8_t result_day = static_cast<std::uint8_t>(
-      ClampDayOfMonth(result_year, result_month, lhs.day));
+      ClampDayOfMonth(result_year, result_month, lhs.dayField()));
 
   return DateLit::Create(result_year, result_month, result_day);
 }
@@ -187,8 +187,8 @@ inline DatetimeLit operator-(const DatetimeLit &lhs, const YearMonthIntervalLit 
 }
 
 inline DateLit operator-(const DateLit &lhs, const YearMonthIntervalLit &rhs) {
-  std::int32_t result_year = lhs.year - (rhs.months / 12);
-  std::int8_t result_month = lhs.month - (rhs.months % 12);
+  std::int32_t result_year = lhs.yearField() - (rhs.months / 12);
+  std::int8_t result_month = static_cast<std::int8_t>(lhs.monthField()) - (rhs.months % 12);
 
   if (result_month < 0) {
     --result_year;
@@ -196,7 +196,7 @@ inline DateLit operator-(const DateLit &lhs, const YearMonthIntervalLit &rhs) {
   }
 
   const std::uint8_t result_day = static_cast<std::uint8_t>(
-      ClampDayOfMonth(result_year, result_month, lhs.day));
+      ClampDayOfMonth(result_year, result_month, lhs.dayField()));
 
   return DateLit::Create(result_year, result_month, result_day);
 }

--- a/types/DateType.cpp
+++ b/types/DateType.cpp
@@ -60,7 +60,7 @@ std::string DateType::printValueToString(const TypedValue &value) const {
   DCHECK(!value.isNull());
 
   const DateLit literal = value.getLiteral<DateLit>();
-  const std::int32_t year = literal.year;
+  const std::int32_t year = literal.yearField();
 
   char datebuf[DateLit::kIsoChars + 1];
   std::size_t chars_written = 0;
@@ -78,9 +78,9 @@ std::string DateType::printValueToString(const TypedValue &value) const {
   // All the rest of the ISO 8601 date/time parts.
   snprintf_result = snprintf(datebuf + chars_written,
                              sizeof(datebuf) - chars_written,
-                             "%02d-%02d",
-                             literal.month,
-                             literal.day);
+                             "%02u-%02u",
+                             literal.monthField(),
+                             literal.dayField());
   CheckSnprintf(snprintf_result, sizeof(datebuf), &chars_written);
 
   return std::string(datebuf);

--- a/types/TypedValue.cpp
+++ b/types/TypedValue.cpp
@@ -110,10 +110,7 @@ serialization::TypedValue TypedValue::getProto() const {
     case kDate:
       proto.set_type_id(serialization::Type::DATE);
       if (!isNull()) {
-        serialization::TypedValue::DateLit *literal_date_proto = proto.mutable_date_value();
-        literal_date_proto->set_year(value_union_.date_value.year);
-        literal_date_proto->set_month(value_union_.date_value.month);
-        literal_date_proto->set_day(value_union_.date_value.day);
+        proto.set_date_value(getLiteral<DateLit>().year_month_day);
       }
       break;
     case kDatetime:
@@ -185,9 +182,7 @@ TypedValue TypedValue::ReconstructFromProto(const serialization::TypedValue &pro
           TypedValue(kDouble);
     case serialization::Type::DATE:
       if (proto.has_date_value()) {
-        return TypedValue(DateLit::Create(proto.date_value().year(),
-                                          proto.date_value().month(),
-                                          proto.date_value().day()));
+        return TypedValue(DateLit::Create(proto.date_value()));
       } else {
         return TypedValue(kDate);
       }

--- a/types/TypedValue.hpp
+++ b/types/TypedValue.hpp
@@ -393,10 +393,10 @@ class TypedValue {
     switch (getTypeID()) {
       case kInt:
       case kFloat:
+      case kDate:
         return sizeof(int);
       case kLong:
       case kDouble:
-      case kDate:
       case kDatetime:
       case kDatetimeInterval:
       case kYearMonthInterval:
@@ -552,6 +552,8 @@ class TypedValue {
           // 4 bytes byte-for-byte copy.
           *static_cast<int*>(destination) = value_union_.int_value;
           break;
+        case kDate:
+          *static_cast<DateLit*>(destination) = value_union_.date_value;
         default:
           // 8 bytes byte-for-byte copy.
           *static_cast<ValueUnion*>(destination) = value_union_;

--- a/types/TypedValue.proto
+++ b/types/TypedValue.proto
@@ -34,11 +34,5 @@ message TypedValue {
   optional int64 datetime_interval_value = 8;
   optional int64 year_month_interval_value = 9;
 
-  message DateLit {
-    required int32 year = 1;
-    required uint32 month = 2;
-    required uint32 day = 3;
-  }
-
-  optional DateLit date_value = 10;
+  optional uint32 date_value = 10;
 }

--- a/types/operations/unary_operations/DateExtractOperation.cpp
+++ b/types/operations/unary_operations/DateExtractOperation.cpp
@@ -444,7 +444,7 @@ TypedValue DateExtractOperation::applyToChecked(const TypedValue &argument,
       } else {
         // argument type is kDate.
         DCHECK_EQ(TypeID::kDate, argument.getTypeID());
-        return TypedValue(argument.getLiteral<DateLit>().monthField());
+        return TypedValue(static_cast<std::int32_t>(argument.getLiteral<DateLit>().monthField()));
       }
     }
     case DateExtractUnit::kDay:


### PR DESCRIPTION
This PR changes DateLit represantation:

- Encode year, month and day information into an u32 field instead of keeping them separate in three different fields. The change reduces the size of DateLit from 48 bits to 32 bits.
- With the internal representation change, we changed the comparison operators' implementation. They now use one unsigned integer comparison for each method.

- Performance of the following query on TPCH data scale factor 100. 
Note: Before each query, `echo 3 > /proc/sys/vm/drop_caches && free && sync` command was run.
`SELECT EXTRACT(year FROM o_orderdate) AS orderyear FROM orders;`

|  Run    | master (ms)  | date-representation (ms) |
|----------|-----------------:|--------------------------------:|
|  1        |  34389.416    |   34850.132 
|  2        |  234.757        |   182.955 
|  3        |  221.087        |   177.373 
|  4        |  231.232        |   203.132
|  5        |  221.473        |  190.977

EDIT: Performance numbers are added.