### PR TITLE
Refactor bulk insert for SplitRowStore

### DIFF
--- a/storage/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp
+++ b/storage/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp
@@ -550,7 +550,7 @@ TEST_P(SplitRowStoreTupleStorageSubBlockTest, BulkInsertWithRemappedAttributesTe
           relation_->getAttributeById(2)->getType(),
           max_tuple_capacity));
 
-  // TODO This code is shared with BulkInsertCode and can be refactored out.
+  // TODO(marc) This code is shared with BulkInsertCode and can be refactored out.
   std::size_t storage_used = 0;
   int current_tuple_idx = 0;
   std::size_t tuple_max_size = relation_->getMaximumByteLength();

--- a/storage/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp
+++ b/storage/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp
@@ -473,14 +473,11 @@ TEST_P(SplitRowStoreTupleStorageSubBlockTest, BulkInsertTest) {
 
   std::size_t storage_used = 0;
   int current_tuple_idx = 0;
+  std::size_t tuple_max_size = relation_->getMaximumByteLength();
+  std::size_t tuple_slot_size = getTupleSlotSize();
   for (;;) {
     Tuple current_tuple(createSampleTuple(current_tuple_idx));
-    const std::size_t current_tuple_storage_bytes
-        = getTupleSlotSize()
-          + (testVariableLength() ? (current_tuple.getAttributeValue(2).isNull() ?
-                                     0 : current_tuple.getAttributeValue(2).getDataSize())
-                                  : 0);
-    if (storage_used + current_tuple_storage_bytes <= getTupleStorageSize()) {
+    if ((getTupleStorageSize() - storage_used) / tuple_max_size > 0) {
       int_vector->appendTypedValue(current_tuple.getAttributeValue(0));
       double_vector->appendTypedValue(current_tuple.getAttributeValue(1));
       if (testVariableLength()) {
@@ -491,7 +488,11 @@ TEST_P(SplitRowStoreTupleStorageSubBlockTest, BulkInsertTest) {
             ->appendTypedValue(current_tuple.getAttributeValue(2));
       }
 
-      storage_used += current_tuple_storage_bytes;
+      storage_used += tuple_slot_size;
+      if (testVariableLength() && !current_tuple.getAttributeValue(2).isNull()) {
+        storage_used += current_tuple.getAttributeValue(2).getDataSize();
+      }
+
       ++current_tuple_idx;
     } else {
       break;
@@ -549,27 +550,29 @@ TEST_P(SplitRowStoreTupleStorageSubBlockTest, BulkInsertWithRemappedAttributesTe
           relation_->getAttributeById(2)->getType(),
           max_tuple_capacity));
 
+  // TODO This code is shared with BulkInsertCode and can be refactored out.
   std::size_t storage_used = 0;
   int current_tuple_idx = 0;
+  std::size_t tuple_max_size = relation_->getMaximumByteLength();
+  std::size_t tuple_slot_size = getTupleSlotSize();
   for (;;) {
     Tuple current_tuple(createSampleTuple(current_tuple_idx));
-    const std::size_t current_tuple_storage_bytes
-        = getTupleSlotSize()
-          + (testVariableLength() ? (current_tuple.getAttributeValue(2).isNull() ?
-                                     0 : current_tuple.getAttributeValue(2).getDataSize())
-                                  : 0);
-    if (storage_used + current_tuple_storage_bytes <= getTupleStorageSize()) {
+    if ((getTupleStorageSize() - storage_used) / tuple_max_size > 0) {
       int_vector->appendTypedValue(current_tuple.getAttributeValue(0));
       double_vector->appendTypedValue(current_tuple.getAttributeValue(1));
       if (testVariableLength()) {
         static_cast<IndirectColumnVector*>(string_vector)
-            ->appendTypedValue(current_tuple.getAttributeValue(2));
+          ->appendTypedValue(current_tuple.getAttributeValue(2));
       } else {
         static_cast<NativeColumnVector*>(string_vector)
-            ->appendTypedValue(current_tuple.getAttributeValue(2));
+          ->appendTypedValue(current_tuple.getAttributeValue(2));
       }
 
-      storage_used += current_tuple_storage_bytes;
+      storage_used += tuple_slot_size;
+      if (testVariableLength() && !current_tuple.getAttributeValue(2).isNull()) {
+        storage_used += current_tuple.getAttributeValue(2).getDataSize();
+      }
+
       ++current_tuple_idx;
     } else {
       break;

--- a/utility/BitVector.hpp
+++ b/utility/BitVector.hpp
@@ -183,6 +183,19 @@ class BitVector {
   }
 
   /**
+   * @brief Assign this BitVector's contents to the pointed-to memory.
+   *
+   * @warning caller is responsible for ensuring the Bitvector has the correct
+   *          ownership and size.
+   *
+   * @param ptr Pointer to data representing a BitVector with the same parameters
+   *            as this BitVector.
+   **/
+  inline void setMemory(void *ptr) {
+    this->data_array_ = static_cast<std::size_t*>(ptr);
+  }
+
+  /**
    * @brief Similar to assignFrom(), but the other BitVector to assign from is
    *        allowed to be longer than this one.
    * @warning Only available when enable_short_version is false.


### PR DESCRIPTION
This code refactors out multiple calls to the catalog in tight insert loops.

**Correctness**
I did not add any new tests because the tests in SplitRowStore_unittest covered both bulk and bulkWithRemappedAttributes insert methods.

**Benchmarks**
*Process*
Create a table with 6 int attributes and two varchar attributes. Then run a query with 50% selectivity and which selects on the varchar attribute as well as some of the int attributes, and insertion time should be slightly faster. Data in the relation is uniform-random distributed. The machine I tested this on was my laptop which should be a fair canidate because the relation in question is 1GB which easily fits in my memory.
```SQL
-- relation is ~ 1GB
create table splitrow (i0 int,i1 int,i2 int,i3 int,i4 int,s0 varchar(32),s1 varchar(32));
copy splitrow from 'splitrow.qs' WITH (DELIMITER '|');

-- test 1
select * from splitrow where i0 < 5000000; -- half the 1gb relation
select * from splitrow where i0 < 5000000;
select * from splitrow where i0 < 5000000;

-- test 2
select * from splitrow where i0 < 10; -- less than a one thousandth the 1gb relation
select * from splitrow where i0 < 10;
select * from splitrow where i0 < 10;
```

Test 1 results
```
Without change:   16420.618 ms
With change:       8122.209 ms
```

Test 2 results
```
Without change:   603.432 ms
With change:      604.629 ms
```
TLDR

We see a 2x improvement on large inserts.