### PR TITLE
Optimize PackedRowStoreValueAccessor & BasicColumnStoreValueAccessor by removing redundant computations and clearly exposing a strided memory access pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 Makefile.in
 autom4te.cache
 .DS_Store
+.idea
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=selection
 
 install:
-  - if [ "$CC" = "gcc" ]; then
+  - if [ "$CC" = "gcc" ] || [[ "$BUILD_TYPE" = "Release" &&  "$VECTOR_COPY_ELISION_LEVEL" = "selection" ]]; then
       export MAKE_JOBS=1;
     else
       export MAKE_JOBS=2;

--- a/storage/BasicColumnStoreValueAccessor.hpp
+++ b/storage/BasicColumnStoreValueAccessor.hpp
@@ -81,7 +81,7 @@ class BasicColumnStoreValueAccessorHelper {
   template <bool check_null = true>
   inline const ColumnAccessor<check_null>* getColumnAccessor(const tuple_id &current_tuple_position,
                                                              const attribute_id attr_id) const {
-    DEBUG_ASSERT(relation_.hasAttributeWithId(attr_id));
+    DCHECK(relation_.hasAttributeWithId(attr_id));
     const void* base_location = static_cast<const char*>(column_stripes_[attr_id]);
     const std::size_t stride = relation_.getAttributeById(attr_id)->getType().maximumByteLength();
     std::unique_ptr<ColumnAccessor<check_null>> column_accessor;

--- a/storage/CompressedColumnStoreValueAccessor.hpp
+++ b/storage/CompressedColumnStoreValueAccessor.hpp
@@ -67,6 +67,39 @@ class CompressedColumnStoreValueAccessorHelper {
     return num_tuples_;
   }
 
+  /**
+   * @brief Returns whether this accessor has a fast strided ColumnAccessor available
+   *        that can be used to optimize memory access in a tight loop iteration
+   *        over the underlying storage block.
+   *
+   * @return true if fast ColumnAccessor is supported, otherwise false.
+   */
+  inline bool isColumnAccessorSupported() const {
+    return false;
+  }
+
+  /**
+   * @brief Get a pointer to a ColumnAccessor object that provides a fast strided memory
+   *        access on the underlying storage block.
+   * @note The ownership of the returned object lies with the caller.
+   * @warning This method should only be called if isColumnAccessorSupported() method
+   *          returned true. If ColumnAccessor is not supported this method will return a nullptr.
+   *
+   * @param current_tuple_position A constant reference to the tuple position in the containing
+   *        ValueAccessor. This reference value is shared between the containing ValueAccessor &
+   *        a ColumnAccessor. However, a ColumnAccessor *CANNOT* modify this tuple position.
+   * @param attr_id The attribute id on which this ColumnAccessor will be created.
+   *
+   * @return A pointer to a ColumnAccessor object with specific properties set that can be used
+   *         in a tight loop iterations over the underlying storage block.
+   **/
+  template <bool check_null = true>
+  inline const ColumnAccessor<check_null>* getColumnAccessor(const tuple_id &current_tuple_position,
+                                                             const attribute_id attr_id) const {
+    // Return nullptr because this value accessor does not support column accessor yet.
+    return nullptr;
+  }
+
   template <bool check_null>
   inline const void* getAttributeValue(const tuple_id tuple,
                                        const attribute_id attr) const {

--- a/storage/CompressedPackedRowStoreValueAccessor.hpp
+++ b/storage/CompressedPackedRowStoreValueAccessor.hpp
@@ -75,6 +75,39 @@ class CompressedPackedRowStoreValueAccessorHelper {
     return num_tuples_;
   }
 
+  /**
+   * @brief Returns whether this accessor has a fast strided ColumnAccessor available
+   *        that can be used to optimize memory access in a tight loop iteration
+   *        over the underlying storage block.
+   *
+   * @return true if fast ColumnAccessor is supported, otherwise false.
+   */
+  inline bool isColumnAccessorSupported() const {
+    return false;
+  }
+
+  /**
+   * @brief Get a pointer to a ColumnAccessor object that provides a fast strided memory
+   *        access on the underlying storage block.
+   * @note The ownership of the returned object lies with the caller.
+   * @warning This method should only be called if isColumnAccessorSupported() method
+   *          returned true. If ColumnAccessor is not supported this method will return a nullptr.
+   *
+   * @param current_tuple_position A constant reference to the tuple position in the containing
+   *        ValueAccessor. This reference value is shared between the containing ValueAccessor &
+   *        a ColumnAccessor. However, a ColumnAccessor *CANNOT* modify this tuple position.
+   * @param attr_id The attribute id on which this ColumnAccessor will be created.
+   *
+   * @return A pointer to a ColumnAccessor object with specific properties set that can be used
+   *         in a tight loop iterations over the underlying storage block.
+   **/
+  template <bool check_null = true>
+  inline const ColumnAccessor<check_null>* getColumnAccessor(const tuple_id &current_tuple_position,
+                                                             const attribute_id attr_id) const {
+    // Return nullptr because this value accessor does not support column accessor yet.
+    return nullptr;
+  }
+
   template <bool check_null>
   inline const void* getAttributeValue(const tuple_id tuple,
                                        const attribute_id attr) const {

--- a/storage/PackedRowStoreValueAccessor.hpp
+++ b/storage/PackedRowStoreValueAccessor.hpp
@@ -78,7 +78,7 @@ class PackedRowStoreValueAccessorHelper {
   template <bool check_null = true>
   inline const ColumnAccessor<check_null>* getColumnAccessor(const tuple_id &current_tuple_position,
                                                              const attribute_id attr_id) const {
-    DEBUG_ASSERT(relation_.hasAttributeWithId(attr_id));
+    DCHECK(relation_.hasAttributeWithId(attr_id));
     const void* base_location = static_cast<const char*>(tuple_storage_)
         + relation_.getFixedLengthAttributeOffset(attr_id);
     const std::size_t stride = relation_.getFixedByteLength();

--- a/storage/SplitRowStoreValueAccessor.hpp
+++ b/storage/SplitRowStoreValueAccessor.hpp
@@ -97,6 +97,24 @@ class SplitRowStoreValueAccessor : public ValueAccessor {
     return num_tuples_;
   }
 
+  /**
+   * @brief Get a pointer to a ColumnAccessor object that provides a fast strided memory
+   *        access on the underlying storage block.
+   * @note The ownership of the returned object lies with the caller.
+   * @warning This method should only be called if isColumnAccessorSupported() method
+   *          returned true. If ColumnAccessor is not supported this method will return a nullptr.
+   *
+   * @param attr_id The attribute id on which this ColumnAccessor will be created.
+   *
+   * @return A pointer to a ColumnAccessor object with specific properties set that can be used
+   *         in a tight loop iterations over the underlying storage block.
+   **/
+  template <bool check_null = true>
+  inline const ColumnAccessor<check_null>* getColumnAccessor(const attribute_id attr_id) const {
+    // Column Accessors are currently unsupported for this value accessor, hence nullptr.
+    return nullptr;
+  }
+
   template <bool check_null = true>
   inline const void* getUntypedValue(const attribute_id attr_id) const {
     return getUntypedValueAtAbsolutePosition<check_null>(attr_id, current_position_);

--- a/storage/ValueAccessor.hpp
+++ b/storage/ValueAccessor.hpp
@@ -1016,9 +1016,9 @@ class ColumnAccessor {
    * @return An untyped pointer to the attribute value for the current tuple.
    **/
   inline const void* getUntypedValue() const {
-    DEBUG_ASSERT(current_tuple_position_ < num_tuples_);
+    DCHECK(current_tuple_position_ < num_tuples_);
     if (check_null) {
-      DEBUG_ASSERT(null_bitmap_ != nullptr);
+      DCHECK(null_bitmap_ != nullptr);
       if ((nullable_base_ != -1)
           && null_bitmap_->getBit(current_tuple_position_ * nullable_stride_ + nullable_base_)) {
         return nullptr;

--- a/storage/tests/PackedRowStoreTupleStorageSubBlock_unittest.cpp
+++ b/storage/tests/PackedRowStoreTupleStorageSubBlock_unittest.cpp
@@ -250,7 +250,7 @@ class PackedRowStoreTupleStorageSubBlockTest : public ::testing::TestWithParam<b
                                                     tuple_store_->getAttributeValueTyped(tid, 2)));
     }
   }
-  
+
   template<bool check_null>
   void checkColumnAccessor() {
     initializeNewBlock(kSubBlockSize);
@@ -269,7 +269,7 @@ class PackedRowStoreTupleStorageSubBlockTest : public ::testing::TestWithParam<b
       while (accessor->next()) {
         const void *va_value = column_accessor->getUntypedValue();
         std::unique_ptr<Tuple> expected_tuple(createSampleTuple(tid));
-         
+
         if (expected_tuple->getAttributeValue(value_accessor_id).isNull()) {
           ASSERT_TRUE(va_value == nullptr);
         } else {
@@ -406,11 +406,11 @@ TEST_P(PackedRowStoreTupleStorageSubBlockTest, InsertInBatchTest) {
   EXPECT_EQ(row_capacity - 1, tuple_store_->getMaxTupleID());
   EXPECT_EQ(row_capacity, tuple_store_->numTuples());
 }
-  
+
 TEST_P(PackedRowStoreTupleStorageSubBlockTest, ColumnAccessorTest) {
-  if (GetParam()) { // when true, the attributes can be nullable.
+  if (GetParam()) {   // when true, the attributes can be nullable.
     checkColumnAccessor<true>();
-  } else { // when false, the attributes are non-null.
+  } else {   // when false, the attributes are non-null.
     checkColumnAccessor<false>();
   }
 }

--- a/types/containers/ColumnVectorsValueAccessor.hpp
+++ b/types/containers/ColumnVectorsValueAccessor.hpp
@@ -121,6 +121,24 @@ class ColumnVectorsValueAccessor : public ValueAccessor {
     return column_length_;
   }
 
+  /**
+   * @brief Get a pointer to a ColumnAccessor object that provides a fast strided memory
+   *        access on the underlying storage block.
+   * @note The ownership of the returned object lies with the caller.
+   * @warning This method should only be called if isColumnAccessorSupported() method
+   *          returned true. If ColumnAccessor is not supported this method will return a nullptr.
+   *
+   * @param attr_id The attribute id on which this ColumnAccessor will be created.
+   *
+   * @return A pointer to a ColumnAccessor object with specific properties set that can be used
+   *         in a tight loop iterations over the underlying storage block.
+   **/
+  template <bool check_null = true>
+  inline const ColumnAccessor<check_null>* getColumnAccessor(const attribute_id attr_id) const {
+    // Column Accessors are currently unsupported for this value accessor, hence nullptr.
+    return nullptr;
+  }
+
   template <bool check_null = true>
   inline const void* getUntypedValue(const attribute_id attr_id) const {
     return getUntypedValueAtAbsolutePosition<check_null>(attr_id, current_position_);

--- a/types/operations/comparisons/AsciiStringComparators-inl.hpp
+++ b/types/operations/comparisons/AsciiStringComparators-inl.hpp
@@ -280,8 +280,8 @@ TupleIdSequence* AsciiStringUncheckedComparator<ComparisonFunctor,
             left_column_accessor(accessor->template getColumnAccessor<left_nullable>(left_id));
         std::unique_ptr<const ColumnAccessor<right_nullable>>
             right_column_accessor(accessor->template getColumnAccessor<right_nullable>(right_id));
-        DEBUG_ASSERT(left_column_accessor != nullptr);
-        DEBUG_ASSERT(right_column_accessor != nullptr);
+        DCHECK(left_column_accessor != nullptr);
+        DCHECK(right_column_accessor != nullptr);
         while (accessor->next()) {
           const void *left_value = left_column_accessor->getUntypedValue();
           const void *right_value = right_column_accessor->getUntypedValue();
@@ -357,7 +357,7 @@ TupleIdSequence* AsciiStringUncheckedComparator<ComparisonFunctor,
         // column accessor available for the iteration on the underlying block.
         std::unique_ptr<const ColumnAccessor<va_nullable>>
             column_accessor(accessor->template getColumnAccessor<va_nullable>(value_accessor_attr_id));
-        DEBUG_ASSERT(column_accessor != nullptr);
+        DCHECK(column_accessor != nullptr);
         while (accessor->next()) {
           const void *va_value = column_accessor->getUntypedValue();
           result->set(accessor->getCurrentPosition(),
@@ -488,7 +488,7 @@ TupleIdSequence* AsciiStringUncheckedComparator<ComparisonFunctor,
             // column accessor available for the iteration on the underlying block.
             std::unique_ptr<const ColumnAccessor<va_nullable>>
                 column_accessor(accessor->template getColumnAccessor<va_nullable>(value_accessor_attr_id));
-            DEBUG_ASSERT(column_accessor != nullptr);
+            DCHECK(column_accessor != nullptr);
             while (accessor->next()) {
               const void *cv_value
                   = column_vector.template getUntypedValue<cv_nullable>(cv_pos);

--- a/types/operations/comparisons/Comparison-inl.hpp
+++ b/types/operations/comparisons/Comparison-inl.hpp
@@ -316,8 +316,8 @@ TupleIdSequence* UncheckedComparator::compareSingleValueAccessorDefaultImpl(
             left_column_accessor(accessor->template getColumnAccessor<left_nullable>(left_id));
         std::unique_ptr<const ColumnAccessor<right_nullable>>
             right_column_accessor(accessor->template getColumnAccessor<right_nullable>(right_id));
-        DEBUG_ASSERT(left_column_accessor != nullptr);
-        DEBUG_ASSERT(right_column_accessor != nullptr);
+        DCHECK(left_column_accessor != nullptr);
+        DCHECK(right_column_accessor != nullptr);
         while (accessor->next()) {
           result->set(accessor->getCurrentPosition(),
                       this->compareDataPtrs(

--- a/types/operations/comparisons/LiteralComparators-inl.hpp
+++ b/types/operations/comparisons/LiteralComparators-inl.hpp
@@ -280,8 +280,8 @@ TupleIdSequence* LiteralUncheckedComparator<ComparisonFunctor,
             left_column_accessor(accessor->template getColumnAccessor<left_nullable>(left_id));
         std::unique_ptr<const ColumnAccessor<right_nullable>>
             right_column_accessor(accessor->template getColumnAccessor<right_nullable>(right_id));
-        DEBUG_ASSERT(left_column_accessor != nullptr);
-        DEBUG_ASSERT(right_column_accessor != nullptr);
+        DCHECK(left_column_accessor != nullptr);
+        DCHECK(right_column_accessor != nullptr);
         while (accessor->next()) {
           const void *left_value = left_column_accessor->getUntypedValue();
           const void *right_value = right_column_accessor->getUntypedValue();
@@ -363,7 +363,7 @@ TupleIdSequence* LiteralUncheckedComparator<ComparisonFunctor,
         // column accessor available for the iteration on the underlying block.
         std::unique_ptr<const ColumnAccessor<va_nullable>>
             column_accessor(accessor->template getColumnAccessor<va_nullable>(value_accessor_attr_id));
-        DEBUG_ASSERT(column_accessor != nullptr);
+        DCHECK(column_accessor != nullptr);
         while (accessor->next()) {
           const void *va_value = column_accessor->getUntypedValue();
           result->set(accessor->getCurrentPosition(),
@@ -497,7 +497,7 @@ TupleIdSequence* LiteralUncheckedComparator<ComparisonFunctor,
           // column accessor available for the iteration on the underlying block.
           std::unique_ptr<const ColumnAccessor<va_nullable>>
               column_accessor(accessor->template getColumnAccessor<va_nullable>(value_accessor_attr_id));
-          DEBUG_ASSERT(column_accessor != nullptr);
+          DCHECK(column_accessor != nullptr);
           while (accessor->next()) {
             const void *cv_value
                 = native_column_vector.getUntypedValue<cv_nullable>(cv_pos);
@@ -554,7 +554,7 @@ TypedValue LiteralUncheckedComparator<ComparisonFunctor,
       // column accessor available for the iteration on the underlying block.
       std::unique_ptr<const ColumnAccessor<left_nullable>>
           column_accessor(accessor->template getColumnAccessor<left_nullable>(value_accessor_id));
-      DEBUG_ASSERT(column_accessor != nullptr);
+      DCHECK(column_accessor != nullptr);
       while (accessor->next()) {
         const void *va_value = column_accessor->getUntypedValue();
         if (left_nullable && !va_value) {

--- a/types/operations/comparisons/LiteralComparators-inl.hpp
+++ b/types/operations/comparisons/LiteralComparators-inl.hpp
@@ -273,13 +273,32 @@ TupleIdSequence* LiteralUncheckedComparator<ComparisonFunctor,
       }
     } else {
       accessor->beginIteration();
-      while (accessor->next()) {
-        const void *left_value = accessor->template getUntypedValue<left_nullable>(left_id);
-        const void *right_value = accessor->template getUntypedValue<right_nullable>(right_id);
-        result->set(accessor->getCurrentPosition(),
-                    (!((left_nullable && (left_value == nullptr))
-                        || (right_nullable && (right_value == nullptr))))
-                            && this->compareDataPtrsHelper<true>(left_value, right_value));
+      if (accessor->isColumnAccessorSupported()) {
+        // If ColumnAccessor is supported on the underlying accessor, we have a fast strided
+        // column accessor available for the iteration on the underlying block.
+        std::unique_ptr<const ColumnAccessor<left_nullable>>
+            left_column_accessor(accessor->template getColumnAccessor<left_nullable>(left_id));
+        std::unique_ptr<const ColumnAccessor<right_nullable>>
+            right_column_accessor(accessor->template getColumnAccessor<right_nullable>(right_id));
+        DEBUG_ASSERT(left_column_accessor != nullptr);
+        DEBUG_ASSERT(right_column_accessor != nullptr);
+        while (accessor->next()) {
+          const void *left_value = left_column_accessor->getUntypedValue();
+          const void *right_value = right_column_accessor->getUntypedValue();
+          result->set(accessor->getCurrentPosition(),
+                      (!((left_nullable && (left_value == nullptr))
+                          || (right_nullable && (right_value == nullptr))))
+                          && this->compareDataPtrsHelper<true>(left_value, right_value));
+        }
+      } else {
+        while (accessor->next()) {
+          const void *left_value = accessor->template getUntypedValue<left_nullable>(left_id);
+          const void *right_value = accessor->template getUntypedValue<right_nullable>(right_id);
+          result->set(accessor->getCurrentPosition(),
+                      (!((left_nullable && (left_value == nullptr))
+                          || (right_nullable && (right_value == nullptr))))
+                          && this->compareDataPtrsHelper<true>(left_value, right_value));
+        }
       }
       if (!short_circuit && (filter != nullptr)) {
         result->intersectWith(*filter);
@@ -339,12 +358,27 @@ TupleIdSequence* LiteralUncheckedComparator<ComparisonFunctor,
       }
     } else {
       accessor->beginIteration();
-      while (accessor->next()) {
-        const void *va_value
-            = accessor->template getUntypedValue<va_nullable>(value_accessor_attr_id);
-        result->set(accessor->getCurrentPosition(),
-                    !(va_nullable && (va_value == nullptr))
-                        && this->compareDataPtrsHelper<value_accessor_on_left>(va_value, &literal));
+      if (accessor->isColumnAccessorSupported()) {
+        // If ColumnAccessor is supported on the underlying accessor, we have a fast strided
+        // column accessor available for the iteration on the underlying block.
+        std::unique_ptr<const ColumnAccessor<va_nullable>>
+            column_accessor(accessor->template getColumnAccessor<va_nullable>(value_accessor_attr_id));
+        DEBUG_ASSERT(column_accessor != nullptr);
+        while (accessor->next()) {
+          const void *va_value = column_accessor->getUntypedValue();
+          result->set(accessor->getCurrentPosition(),
+                      !(va_nullable && (va_value == nullptr))
+                          && this->compareDataPtrsHelper<value_accessor_on_left>(va_value, &literal));
+        }
+      } else {
+        while (accessor->next()) {
+          const void *va_value
+              = accessor->template getUntypedValue<va_nullable>(value_accessor_attr_id);
+          result->set(accessor->getCurrentPosition(),
+                      !(va_nullable && (va_value == nullptr))
+                          && this->compareDataPtrsHelper<value_accessor_on_left>(va_value,
+                                                                                 &literal));
+        }
       }
       if (!short_circuit && (filter != nullptr)) {
         result->intersectWith(*filter);
@@ -458,16 +492,36 @@ TupleIdSequence* LiteralUncheckedComparator<ComparisonFunctor,
       } else {
         accessor->beginIteration();
         std::size_t cv_pos = 0;
-        while (accessor->next()) {
-          const void *cv_value
-              = native_column_vector.getUntypedValue<cv_nullable>(cv_pos);
-          const void *va_value
-              = accessor->template getUntypedValue<va_nullable>(value_accessor_attr_id);
-          result->set(cv_pos,
-                      (!((cv_nullable && (cv_value == nullptr))
-                          || (va_nullable && (va_value == nullptr))))
-                              && this->compareDataPtrsHelper<column_vector_on_left>(cv_value, va_value));
-          ++cv_pos;
+        if (accessor->isColumnAccessorSupported()) {
+          // If ColumnAccessor is supported on the underlying accessor, we have a fast strided
+          // column accessor available for the iteration on the underlying block.
+          std::unique_ptr<const ColumnAccessor<va_nullable>>
+              column_accessor(accessor->template getColumnAccessor<va_nullable>(value_accessor_attr_id));
+          DEBUG_ASSERT(column_accessor != nullptr);
+          while (accessor->next()) {
+            const void *cv_value
+                = native_column_vector.getUntypedValue<cv_nullable>(cv_pos);
+            const void *va_value = column_accessor->getUntypedValue();
+            result->set(cv_pos,
+                        (!((cv_nullable && (cv_value == nullptr))
+                            || (va_nullable && (va_value == nullptr))))
+                            && this->compareDataPtrsHelper<column_vector_on_left>(cv_value,
+                                                                                  va_value));
+            ++cv_pos;
+          }
+        } else {
+          while (accessor->next()) {
+            const void *cv_value
+                = native_column_vector.getUntypedValue<cv_nullable>(cv_pos);
+            const void *va_value
+                = accessor->template getUntypedValue<va_nullable>(value_accessor_attr_id);
+            result->set(cv_pos,
+                        (!((cv_nullable && (cv_value == nullptr))
+                            || (va_nullable && (va_value == nullptr))))
+                            && this->compareDataPtrsHelper<column_vector_on_left>(cv_value,
+                                                                                  va_value));
+            ++cv_pos;
+          }
         }
       }
       if (!short_circuit && (filter != nullptr)) {
@@ -495,13 +549,30 @@ TypedValue LiteralUncheckedComparator<ComparisonFunctor,
       accessor,
       [&](auto *accessor) -> void {  // NOLINT(build/c++11)
     accessor->beginIteration();
-    while (accessor->next()) {
-      const void *va_value = accessor->template getUntypedValue<left_nullable>(value_accessor_id);
-      if (left_nullable && !va_value) {
-        continue;
+    if (accessor->isColumnAccessorSupported()) {
+      // If ColumnAccessor is supported on the underlying accessor, we have a fast strided
+      // column accessor available for the iteration on the underlying block.
+      std::unique_ptr<const ColumnAccessor<left_nullable>>
+          column_accessor(accessor->template getColumnAccessor<left_nullable>(value_accessor_id));
+      DEBUG_ASSERT(column_accessor != nullptr);
+      while (accessor->next()) {
+        const void *va_value = column_accessor->getUntypedValue();
+        if (left_nullable && !va_value) {
+          continue;
+        }
+        if (!current_literal || this->compareDataPtrsHelper<true>(va_value, current_literal)) {
+          current_literal = va_value;
+        }
       }
-      if (!current_literal || this->compareDataPtrsHelper<true>(va_value, current_literal)) {
-        current_literal = va_value;
+    } else {
+      while (accessor->next()) {
+        const void *va_value = accessor->template getUntypedValue<left_nullable>(value_accessor_id);
+        if (left_nullable && !va_value) {
+          continue;
+        }
+        if (!current_literal || this->compareDataPtrsHelper<true>(va_value, current_literal)) {
+          current_literal = va_value;
+        }
       }
     }
   });

--- a/types/operations/comparisons/PatternMatchingComparators-inl.hpp
+++ b/types/operations/comparisons/PatternMatchingComparators-inl.hpp
@@ -247,7 +247,7 @@ TupleIdSequence* PatternMatchingUncheckedComparator<is_like_pattern, is_negation
         std::unique_ptr<const ColumnAccessor<left_nullable>>
             column_accessor
             (accessor->template getColumnAccessor<left_nullable>(value_accessor_attr_id));
-        DEBUG_ASSERT(column_accessor != nullptr);
+        DCHECK(column_accessor != nullptr);
         while (accessor->next()) {
           const void *va_value = column_accessor->getUntypedValue();
           result->set(accessor->getCurrentPosition(),


### PR DESCRIPTION
This PR proposes to optimize the way value accessors are currently used to read values from a storage block. Code profiling revealed that almost 10%-15% of the execution time was being spent in making redundant method calls to CatalogRelationSchema to find out properties that are anyway always constant when iterating over a given column. A simple caching of these values could give significant improvements. Moreover, during code analysis it was found that even more opportunities for compiler induced optimization and vectorization exist, if a simple semantics of a strided memory access pattern is exposed to the compiler & the runtime. After all, most iterations over a column in a relation can be expressed by as simple equation as: `base_address + tuple_id * offset`, where base_address and offset are constant. Exposing this semantics opens a whole lot of interesting opportunities, which otherwise have been obscured in the existing design of ValueAccessors. Rewriting the entire set of ValueAccessors is a mammoth  task. Therefore, this PR and few subsequent PRs will propose to do this incrementally, always making sure that each PR addresses end-to-end functionality for some subset of features.

This PR specifically optimizes PackedRowStoreValueAccessor & BasicColumnStoreValueAccessor only. To demonstrate the end-to-end benefit of this optimization, predicate evaluation involving relational operators, regular expressions & literal comparison have been refactored to be cognizant of such optimizations. 

Tests:
------
- Tests for changes to PackedRowStoreValueAccessor have been added in PackedRowStoreTupleStorargeSubBlock_unittest.cpp
- BasicColumnStoreTupleStorageSubBlock_unittest.cpp has existing tests which test various code paths that invoke the new functionalities for BasicColumnStoreValueAccessor.

Performance Numbers:
-----------------------

A simple selection query `select count(*) from lineorder where lo_discount > 5` on SSB Scale Factor 100 improves by almost 18-20%. Following lists the **query completion time** for 20 trials for SSB-SF-100 done on the standard Cloudlab machine with and without the current patch:

| Trial #       | w/o ColumnAccessors  (in seconds)         | w/ ColumnAccessor (in seconds) |
| ------------- |:-------------:| -----:|
| 1 | 293 | 218
| 2 | 267 | 222
| 3 | 254 | 227
| 4 | 255 | 230
| 5 | 256 | 193
| 6 | 244 | 214
| 7 | 244 | 207
| 8 | 235 | 198
| 9 | 226 | 189
| 10 | 225 | 182
| 11 | 226 | 184
| 12 | 223 | 181
| 13 | 222 | 177
| 14 | 224 | 174
| 15 | 225 | 173
| 16 | 219 | 170
| 17 | 219 | 161
| 18 | 220 | 164
| 19 | 217 | 161
| 20 | 219 | 159
| Mean |236 |189 |




