### PR TITLE
Improve StarSchemaSimpleCostModel to provide better group cardinality estimation for aggregations.

### DIFF
--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
                       quickstep_queryoptimizer_QueryHandle
                       quickstep_queryoptimizer_QueryPlan
                       quickstep_queryoptimizer_costmodel_CostModel
-                      quickstep_queryoptimizer_costmodel_SimpleCostModel
+                      quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
                       quickstep_queryoptimizer_expressions_AggregateFunction
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference

--- a/query_optimizer/ExecutionGenerator.hpp
+++ b/query_optimizer/ExecutionGenerator.hpp
@@ -37,7 +37,6 @@
 #include "query_optimizer/QueryHandle.hpp"
 #include "query_optimizer/QueryPlan.hpp"
 #include "query_optimizer/cost_model/CostModel.hpp"
-#include "query_optimizer/cost_model/SimpleCostModel.hpp"
 #include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"

--- a/query_optimizer/cost_model/CMakeLists.txt
+++ b/query_optimizer/cost_model/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
 
 # Link dependencies:
 target_link_libraries(quickstep_queryoptimizer_costmodel_CostModel
+                      quickstep_queryoptimizer_physical_Aggregate
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_costmodel_SimpleCostModel
@@ -50,6 +51,7 @@ target_link_libraries(quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostMod
                       quickstep_queryoptimizer_expressions_ComparisonExpression
                       quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_ExpressionType
+                      quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_LogicalAnd
                       quickstep_queryoptimizer_expressions_LogicalOr
                       quickstep_queryoptimizer_expressions_PatternMatcher
@@ -57,6 +59,7 @@ target_link_libraries(quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostMod
                       quickstep_queryoptimizer_physical_Aggregate
                       quickstep_queryoptimizer_physical_HashJoin
                       quickstep_queryoptimizer_physical_NestedLoopsJoin
+                      quickstep_queryoptimizer_physical_PatternMatcher
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_physical_PhysicalType
                       quickstep_queryoptimizer_physical_Selection

--- a/query_optimizer/cost_model/CostModel.hpp
+++ b/query_optimizer/cost_model/CostModel.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 
+#include "query_optimizer/physical/Aggregate.hpp"
 #include "query_optimizer/physical/Physical.hpp"
 #include "utility/Macros.hpp"
 
@@ -52,6 +53,16 @@ class CostModel {
    */
   virtual std::size_t estimateCardinality(
       const physical::PhysicalPtr &physical_plan) = 0;
+
+  /**
+   * @brief Estimate the number of groups of an aggregation.
+   *
+   * @param aggregate The physical plan of the aggregation.
+   * @return The estimated number of groups.
+   */
+  virtual std::size_t estimateNumGroupsForAggregate(const physical::AggregatePtr &aggregate) {
+    return estimateCardinality(aggregate);
+  }
 
  protected:
   /**

--- a/query_optimizer/expressions/ExpressionUtil.hpp
+++ b/query_optimizer/expressions/ExpressionUtil.hpp
@@ -95,6 +95,25 @@ bool ContainsExpression(
 }
 
 /**
+ * @brief Checks whether expr_id equals any expression's id in \p expressions.
+ *
+ * @param expressions A list of expressions to be checked with.
+ * @param expr_id The ExprId that is to be checked if it is in \p expressions.
+ * @return True if \p expr_id is contained by \p expressions.
+ */
+template <class NamedExpressionType>
+bool ContainsExprId(
+    const std::vector<std::shared_ptr<const NamedExpressionType>> &expressions,
+    const ExprId expr_id) {
+  for (const std::shared_ptr<const NamedExpressionType> &expression : expressions) {
+    if (expression->id() == expr_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * @brief Checks whether \p left is a subset of \p right.
  *
  * @param left The left operand of the subset operator (i.e. the one that may be

--- a/query_optimizer/rules/StarSchemaHashJoinOrderOptimization.hpp
+++ b/query_optimizer/rules/StarSchemaHashJoinOrderOptimization.hpp
@@ -103,7 +103,7 @@ class StarSchemaHashJoinOrderOptimization : public Rule<physical::Physical> {
 
       if (lhs->estimated_selectivity < rhs->estimated_selectivity) {
         return !swapped;
-      } else if (lhs->estimated_cardinality < 1000u &&
+      } else if (lhs->estimated_cardinality < 100u &&
                  rhs->estimated_cardinality > 10000u &&
                  lhs->estimated_selectivity < rhs->estimated_selectivity * 1.5) {
         return !swapped;


### PR DESCRIPTION
This PR revises `StarSchemaSimpleCostModel` to provide better group cardinality estimation for aggregations. This information will be used by a subsequent PR from Harshad to decide when to use _partitioned hash tables_.

The estimation relies on the _number of distinct values_ statistic of each group-by attribute, which can be gathered by running `\analyze` command on the corresponding tables.

This PR does not affect the query plans for SSB queries. It changes some of the TPC-H query plans (and a subsequent `LIPFilter` PR will bring more changes to TPC-H query plans).
