### PR TITLE
Fix memory leak in FastSeparateChaining hash table

### DIFF
--- a/expressions/aggregation/AggregationHandle.hpp
+++ b/expressions/aggregation/AggregationHandle.hpp
@@ -406,6 +406,14 @@ class AggregationHandle {
   virtual void initPayload(std::uint8_t *byte_ptr) const {}
 
   /**
+   * @brief Destroy the payload (in the aggregation hash table) for the given
+   *        aggregation handle.
+   *
+   * @param byte_ptr The pointer to the aggregation state in the hash table.
+   **/
+  virtual void destroyPayload(std::uint8_t *byte_ptr) const {}
+
+  /**
    * @brief Inform the aggregation handle to block (prohibit) updates on the
    *        aggregation state.
    **/

--- a/expressions/aggregation/AggregationHandleAvg.hpp
+++ b/expressions/aggregation/AggregationHandleAvg.hpp
@@ -161,6 +161,14 @@ class AggregationHandleAvg : public AggregationConcreteHandle {
     *count_ptr = blank_state_.count_;
   }
 
+  void destroyPayload(std::uint8_t *byte_ptr) const override {
+    TypedValue *sum_ptr =
+        reinterpret_cast<TypedValue *>(byte_ptr + blank_state_.sum_offset_);
+    if (sum_ptr != nullptr) {
+      sum_ptr->~TypedValue();
+    }
+  }
+
   AggregationState* accumulateColumnVectors(
       const std::vector<std::unique_ptr<ColumnVector>> &column_vectors)
       const override;

--- a/expressions/aggregation/AggregationHandleMax.hpp
+++ b/expressions/aggregation/AggregationHandleMax.hpp
@@ -129,6 +129,13 @@ class AggregationHandleMax : public AggregationConcreteHandle {
     *max_ptr = t1;
   }
 
+  void destroyPayload(std::uint8_t *byte_ptr) const override {
+    TypedValue *max_ptr = reinterpret_cast<TypedValue *>(byte_ptr);
+    if (max_ptr != nullptr) {
+      max_ptr->~TypedValue();
+    }
+  }
+
   AggregationState* accumulateColumnVectors(
       const std::vector<std::unique_ptr<ColumnVector>> &column_vectors)
       const override;

--- a/expressions/aggregation/AggregationHandleMin.hpp
+++ b/expressions/aggregation/AggregationHandleMin.hpp
@@ -131,6 +131,13 @@ class AggregationHandleMin : public AggregationConcreteHandle {
     *min_ptr = t1;
   }
 
+  void destroyPayload(std::uint8_t *byte_ptr) const override {
+    TypedValue *min_ptr = reinterpret_cast<TypedValue *>(byte_ptr);
+    if (min_ptr != nullptr) {
+      min_ptr->~TypedValue();
+    }
+  }
+
   AggregationState* accumulateColumnVectors(
       const std::vector<std::unique_ptr<ColumnVector>> &column_vectors)
       const override;

--- a/expressions/aggregation/AggregationHandleSum.hpp
+++ b/expressions/aggregation/AggregationHandleSum.hpp
@@ -153,6 +153,14 @@ class AggregationHandleSum : public AggregationConcreteHandle {
     *null_ptr = true;
   }
 
+  void destroyPayload(std::uint8_t *byte_ptr) const override {
+    TypedValue *sum_ptr =
+        reinterpret_cast<TypedValue *>(byte_ptr + blank_state_.sum_offset_);
+    if (sum_ptr != nullptr) {
+      sum_ptr->~TypedValue();
+    }
+  }
+
   AggregationState* accumulateColumnVectors(
       const std::vector<std::unique_ptr<ColumnVector>> &column_vectors)
       const override;

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -187,6 +187,20 @@ class QueryContext {
   }
 
   /**
+   * @brief Destroy the payloads from the aggregation hash tables.
+   *
+   * @warning After calling these methods, the hash table will be in an invalid
+   *          state. No other operation should be performed on them.
+   *
+   * @param id The ID of the AggregationOperationState.
+   **/
+  inline void destroyAggregationHashTablePayload(const aggregation_state_id id) {
+    DCHECK_LT(id, aggregation_states_.size());
+    DCHECK(aggregation_states_[id]);
+    aggregation_states_[id]->destroyAggregationHashTablePayload();
+  }
+
+  /**
    * @brief Whether the given GeneratorFunctionHandle id is valid.
    *
    * @param id The GeneratorFunctionHandle id.

--- a/relational_operators/DestroyAggregationStateOperator.cpp
+++ b/relational_operators/DestroyAggregationStateOperator.cpp
@@ -58,6 +58,13 @@ bool DestroyAggregationStateOperator::getAllWorkOrderProtos(WorkOrderProtosConta
 }
 
 void DestroyAggregationStateWorkOrder::execute() {
+  // NOTE(harshad) : The destroyAggregationHashTablePayload call is separate
+  // from the destroyAggregationState call. The reason is that the aggregation
+  // hash tables don't own the AggregationHandle objects. However the hash table
+  // class requires the handles for destroying the payload (see the
+  // destroyPayload methods in AggregationHandle classes). Therefore, we first
+  // destroy the payloads in the hash table and then destroy the hash table.
+  query_context_->destroyAggregationHashTablePayload(aggr_state_index_);
   query_context_->destroyAggregationState(aggr_state_index_);
 }
 

--- a/storage/AggregationOperationState.cpp
+++ b/storage/AggregationOperationState.cpp
@@ -166,8 +166,7 @@ AggregationOperationState::AggregationOperationState(
       }
 
       // Initialize the corresponding distinctify hash table if this is a
-      // DISTINCT
-      // aggregation.
+      // DISTINCT aggregation.
       if (*is_distinct_it) {
         std::vector<const Type *> key_types(group_by_types);
         key_types.insert(
@@ -593,6 +592,16 @@ void AggregationOperationState::finalizeHashTable(
 
   // Bulk-insert the complete result.
   output_destination->bulkInsertTuples(&complete_result);
+}
+
+void AggregationOperationState::destroyAggregationHashTablePayload() {
+  if (group_by_hashtable_pool_ != nullptr) {
+    auto all_hash_tables = group_by_hashtable_pool_->getAllHashTables();
+    DCHECK(all_hash_tables != nullptr);
+    for (std::size_t ht_index = 0; ht_index < all_hash_tables->size(); ++ht_index) {
+      (*all_hash_tables)[ht_index]->destroyPayload();
+    }
+  }
 }
 
 }  // namespace quickstep

--- a/storage/AggregationOperationState.hpp
+++ b/storage/AggregationOperationState.hpp
@@ -167,6 +167,11 @@ class AggregationOperationState {
    **/
   void finalizeAggregate(InsertDestination *output_destination);
 
+  /**
+   * @brief Destroy the payloads in the aggregation hash tables.
+   **/
+  void destroyAggregationHashTablePayload();
+
   static void mergeGroupByHashTables(AggregationStateHashTableBase *src,
                                      AggregationStateHashTableBase *dst);
 
@@ -185,6 +190,9 @@ class AggregationOperationState {
   void finalizeSingleState(InsertDestination *output_destination);
   void finalizeHashTable(InsertDestination *output_destination);
 
+  // A vector of group by hash table pools.
+  std::unique_ptr<HashTablePool> group_by_hashtable_pool_;
+
   // Common state for all aggregates in this operation: the input relation, the
   // filter predicate (if any), and the list of GROUP BY expressions (if any).
   const CatalogRelationSchema &input_relation_;
@@ -193,7 +201,6 @@ class AggregationOperationState {
 
   // Each individual aggregate in this operation has an AggregationHandle and
   // some number of Scalar arguments.
-  //  std::vector<std::unique_ptr<AggregationHandle>> handles_;
   std::vector<AggregationHandle *> handles_;
   std::vector<std::vector<std::unique_ptr<const Scalar>>> arguments_;
 
@@ -220,9 +227,6 @@ class AggregationOperationState {
   // hash table to prevent multiple lookups.
   std::vector<std::unique_ptr<AggregationStateHashTableBase>>
       group_by_hashtables_;
-
-  // A vector of group by hash table pools.
-  std::unique_ptr<HashTablePool> group_by_hashtable_pool_;
 
   StorageManager *storage_manager_;
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -660,6 +660,7 @@ target_link_libraries(quickstep_storage_FastHashTableFactory
                       quickstep_types_TypeFactory
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_FastSeparateChainingHashTable
+                      quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_FastHashTable
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableBase

--- a/storage/HashTableBase.hpp
+++ b/storage/HashTableBase.hpp
@@ -99,6 +99,12 @@ class HashTableBase {
     return false;
   }
 
+  /**
+   * @brief Destroy the payload stored in the hash table.
+   **/
+  virtual void destroyPayload() {
+  }
+
  protected:
   HashTableBase() {}
 


### PR DESCRIPTION
- Destruction of payload in hash table.
- Separate phases of payload destruction of aggregation hash tables.
- First the payloads will be destructed by respective aggregation
  handles.
- Second the hash table itself will be destructed.
- Remove FastSeparateChaining::DestroyValues function.