### PR TITLE
Refactored SplitRowStore bulk insertion

### DIFF
--- a/storage/SplitRowStoreTupleStorageSubBlock.hpp
+++ b/storage/SplitRowStoreTupleStorageSubBlock.hpp
@@ -45,6 +45,150 @@ class ValueAccessor;
 
 QUICKSTEP_DECLARE_SUB_BLOCK_TYPE_REGISTERED(SplitRowStoreTupleStorageSubBlock);
 
+namespace splitrow_internal {
+// A CopyGroup contains information about ane run of attributes in the source
+// ValueAccessor that can be copied into the output block. The
+// getCopyGroupsForAttributeMap function below takes an attribute map for a source
+// and converts it into a sequence of runs. The goal is to minimize the number
+// of memcpy calls and address calculations that occur during bulk insertion.
+// Contiguous attributes from a rowstore source can be merged into a single copy group.
+//
+// A single ContiguousAttrs CopyGroup consists of contiguous attributes, nullable
+// or not. "Contiguous" here means that their attribute IDs are successive in both
+// the source and destination relations.
+//
+// A NullAttr refers to exactly one nullable attribute. Nullable columns are
+// represented using fixed length inline data as well as a null bitmap.
+// In a particular tuple, if the attribute has a null value, the inline data
+// has no meaning. So it is safe to copy it or not. We use this fact to merge
+// runs together aggressively, i.e., a ContiguousAttrs group may include a
+// nullable attribute. However, we also create a NullableAttr in that case in
+// order to check the null bitmap.
+//
+// A gap is a run of destination (output) attributes that don't come from a
+// particular source. This occurs during bulkInsertPartialTuples. They must be
+// skipped during the insert (not copied over). They are indicated by a
+// kInvalidCatalogId in the attribute map. For efficiency, the gap size
+// is merged into the bytes_to_advance_ of previous ContiguousAttrs copy group.
+// For gaps at the start of the attribute map, we just create a ContiguousAttrs
+// copy group with 0 bytes to copy and dummy (0) source attribute id.
+//
+// eg. For 4B integer attrs, from a row store source,
+// if the input attribute_map is {-1,0,5,6,7,-1,2,4,9,10,-1}
+// with input/output attributes 4 and 7 being nullable,
+// we will create the following ContiguousAttrs copy groups
+//
+//  ----------------------------------------------------
+//  |src_id_      |bytes_to_advance_| bytes_to_copy_   |
+//  |-------------|-----------------|------------------|
+//  |            0|                4|                 4|
+//  |            5|                4|                12|
+//  |            2|               16|                 4|
+//  |            4|                4|                 4|
+//  |            9|                4|                 8|
+//  ----------------------------------------------------
+// and two NullableAttrs with src_attr_id_ set to 4 and 7.
+//
+// In this example, we do 6 memcpy calls and 6 address calculations
+// as well as 2 bitvector lookups for each tuple. A naive copy algorithm
+// would do 11 memcpy calls and address calculations, along with the
+// bitvector lookups, not to mention the schema lookups,
+// all interspersed in a complex loop with lots of branches.
+//
+// If the source was a column store, then we can't merge contiguous
+// attributes (or gaps). So we would have 11 ContigousAttrs copy groups with
+// three of them having bytes_to_copy = 0 (corresponding to the gaps) and
+// the rest having bytes_to_copy_ = 4.
+//
+// SplitRowStore supports variable length attributes. Since the layout of the
+// tuple is like: [null bitmap][fixed length attributes][variable length offsets]
+// we do all the variable length copies after the fixed length copies.
+//
+struct CopyGroup {
+  attribute_id src_attr_id_;  // The attr_id of starting input attribute for run.
+
+  explicit CopyGroup(const attribute_id source_attr_id)
+    : src_attr_id_(source_attr_id) {}
+};
+
+struct ContiguousAttrs : public CopyGroup {
+  std::size_t bytes_to_advance_;  // Number of bytes to advance destination ptr
+                                  // to get to the location where we copy THIS attribute.
+  std::size_t bytes_to_copy_;     // Number of bytes to copy from source.
+
+  ContiguousAttrs(
+    const attribute_id source_attr_id,
+    const std::size_t bytes_to_copy,
+    const std::size_t bytes_to_advance)
+    : CopyGroup(source_attr_id),
+      bytes_to_advance_(bytes_to_advance),
+      bytes_to_copy_(bytes_to_copy) { }
+};
+
+struct VarLenAttr : public CopyGroup {
+  std::size_t bytes_to_advance_;
+  attribute_id dst_attr_id_;
+  VarLenAttr(const attribute_id source_attr_id,
+             const attribute_id dst_attr_id,
+             const std::size_t bytes_to_advance)
+    : CopyGroup(source_attr_id),
+      bytes_to_advance_(bytes_to_advance),
+      dst_attr_id_(dst_attr_id) {}
+};
+
+struct NullableAttr : public CopyGroup {
+  int nullable_attr_idx_;  // index into null bitmap
+
+  NullableAttr(attribute_id source_attr_id_,
+               int nullable_attr_idx)
+    : CopyGroup(source_attr_id_),
+      nullable_attr_idx_(nullable_attr_idx) {}
+};
+
+struct CopyGroupList {
+  CopyGroupList()
+    : contiguous_attrs_(),
+      nullable_attrs_(),
+      varlen_attrs_() {}
+
+  /**
+   * @brief Attributes which are exactly sequential are merged to a single copy.
+   */
+  void merge_contiguous() {
+    if (contiguous_attrs_.size() < 2) {
+      return;
+    }
+
+    int add_to_advance = 0;
+    for (std::size_t idx = 1; idx < contiguous_attrs_.size(); ++idx) {
+      ContiguousAttrs *current_attr = &contiguous_attrs_[idx];
+      ContiguousAttrs *previous_attr = &contiguous_attrs_[idx - 1];
+      if (add_to_advance > 0) {
+        current_attr->bytes_to_advance_ += add_to_advance;
+        add_to_advance = 0;
+      }
+      // The merge step:
+      if (previous_attr->src_attr_id_ + 1 == current_attr->src_attr_id_ &&
+            previous_attr->bytes_to_copy_ == current_attr->bytes_to_advance_) {
+        previous_attr->bytes_to_copy_ += current_attr->bytes_to_copy_;
+        add_to_advance += current_attr->bytes_to_advance_;
+        contiguous_attrs_.erase(contiguous_attrs_.begin() + idx);
+        idx--;
+      }
+    }
+
+    if (varlen_attrs_.size() > 0) {
+      varlen_attrs_[0].bytes_to_advance_ += add_to_advance;
+    }
+  }
+
+  std::vector<ContiguousAttrs> contiguous_attrs_;
+  std::vector<NullableAttr> nullable_attrs_;
+  std::vector<VarLenAttr> varlen_attrs_;
+};
+
+}  // namespace splitrow_internal
+
 /** \addtogroup Storage
  *  @{
  */
@@ -60,6 +204,8 @@ QUICKSTEP_DECLARE_SUB_BLOCK_TYPE_REGISTERED(SplitRowStoreTupleStorageSubBlock);
  *       storage can be reclaimed by calling rebuild().
  **/
 class SplitRowStoreTupleStorageSubBlock: public TupleStorageSubBlock {
+  static const std::size_t kVarLenSlotSize;
+
  public:
   SplitRowStoreTupleStorageSubBlock(const CatalogRelationSchema &relation,
                                     const TupleStorageSubBlockDescription &description,
@@ -155,6 +301,13 @@ class SplitRowStoreTupleStorageSubBlock: public TupleStorageSubBlock {
       const std::vector<attribute_id> &attribute_map,
       ValueAccessor *accessor) override;
 
+  tuple_id bulkInsertPartialTuples(
+    const std::vector<attribute_id> &attribute_map,
+    ValueAccessor *accessor,
+    const tuple_id max_num_tuples_to_insert);
+
+  void bulkInsertPartialTuplesFinalize(const tuple_id num_tuples_inserted);
+
   const void* getAttributeValue(const tuple_id tuple,
                                 const attribute_id attr) const override;
 
@@ -213,6 +366,33 @@ class SplitRowStoreTupleStorageSubBlock: public TupleStorageSubBlock {
   template <bool nullable_attrs, bool variable_length_attrs>
   InsertResult insertTupleImpl(const Tuple &tuple);
 
+  template<bool copy_nulls, bool copy_varlen, bool fill_to_capacity>
+  tuple_id bulkInsertPartialTuplesImpl(
+    const splitrow_internal::CopyGroupList &copy_groups,
+    ValueAccessor *accessor,
+    std::size_t max_num_tuples_to_insert);
+
+  tuple_id bulkInsertDispatcher(
+    const std::vector<attribute_id> &attribute_map,
+    ValueAccessor *accessor,
+    tuple_id max_num_tuples_to_insert,
+    bool finalize);
+
+  void getCopyGroupsForAttributeMap(
+    const std::vector<attribute_id> &attribute_map,
+    splitrow_internal::CopyGroupList *copy_groups);
+
+  std::size_t getInsertLowerBound() const;
+
+  // When varlen attributes are bulk inserted, the difference between the maximum
+  // possible size and the actual size of the tuples will cause an underestimate of
+  // the number of tuples we can insert. This threshold puts a limit on the number
+  // of tuples to attempt to insert. A smaller number will give more rounds of insertion
+  // and a more-packed block, but at the cost of insertion speed.
+  std::size_t getInsertLowerBoundThreshold() const {
+    return 10;
+  }
+
   Header *header_;
 
   std::unique_ptr<BitVector<false>> occupancy_bitmap_;
@@ -221,12 +401,18 @@ class SplitRowStoreTupleStorageSubBlock: public TupleStorageSubBlock {
   void *tuple_storage_;
   std::size_t tuple_storage_bytes_;
   std::size_t tuple_slot_bytes_;
+  std::vector<std::size_t> fixed_len_attr_sizes_;
+
+  std::size_t num_null_attrs_;
+  std::size_t num_fixed_attrs_;
+  std::size_t num_var_attrs_;
 
   std::size_t per_tuple_null_bitmap_bytes_;
 
   friend class SplitRowStoreTupleStorageSubBlockTest;
   friend class SplitRowStoreValueAccessor;
   FRIEND_TEST(SplitRowStoreTupleStorageSubBlockTest, InitializeTest);
+  FRIEND_TEST(SplitRowStoreTupleStorageSubBlockTest, GetCopyGroupsForAttributeMapTest);
 
   DISALLOW_COPY_AND_ASSIGN(SplitRowStoreTupleStorageSubBlock);
 };

--- a/utility/BitVector.hpp
+++ b/utility/BitVector.hpp
@@ -192,6 +192,7 @@ class BitVector {
    *            as this BitVector.
    **/
   inline void setMemory(void *ptr) {
+    DCHECK(!owned_);
     this->data_array_ = static_cast<std::size_t*>(ptr);
   }
 

--- a/utility/BitVector.hpp
+++ b/utility/BitVector.hpp
@@ -183,6 +183,19 @@ class BitVector {
   }
 
   /**
+   * @brief Assign this BitVector's contents to the pointed-to memory.
+   *
+   * @warning caller is responsible for ensuring the Bitvector has the correct
+   *          ownership and size.
+   *
+   * @param ptr Pointer to data representing a BitVector with the same parameters
+   *            as this BitVector.
+   **/
+  inline void setMemory(void *ptr) {
+    this->data_array_ = static_cast<std::size_t*>(ptr);
+  }
+
+  /**
    * @brief Similar to assignFrom(), but the other BitVector to assign from is
    *        allowed to be longer than this one.
    * @warning Only available when enable_short_version is false.


### PR DESCRIPTION
The inner loop of the insert algorithm has been changed to reduce function calls to only those that are absolutely necessary. Also, we merge copies which come from other rowstore source, speeding up insertion time. 

Also adds support for the idea of 'partial inserts'. Partial inserts are when you are only inserting a subset of the columns at a time. Partial inserts will be used in a later commit.

*Testing*
Unit tests have been updated. The old bulkInsert tests needed to be modified because now we have situations where a block will not be filled up completely- only to a threshold value. This reduces the runtime of the costly inner loop at the cost of a few tuples.

*Performance*
I had a [similar PR-100 open](https://github.com/apache/incubator-quickstep/pull/100) last week. I ran TPCH SF100 queries 1-17 with this branch and with the branch from PR-100. They performed within a 1% margin of each other so it is safe to say that this branch is as fast as the last branch (which was 2x the base).

**Best times for contrived 1gb relation, 50% selectivity selection test**
(See PR100)
master: 1602.358 ms
splitrow_insert_refactor: 469.664 ms

**TPCH runtime Queries 1-16 (sum of the average of middle 3 runs of 5 runs total per query**
master: 10.61 minutes
splitrow_insert_refactor: 10.48 minutes

**TLDR** this is an incremental improvement.
