### PR TITLE
Initiated query execution data structure in all Shiftbosses.

### DIFF
--- a/query_execution/ForemanDistributed.hpp
+++ b/query_execution/ForemanDistributed.hpp
@@ -18,6 +18,8 @@
 #include <cstddef>
 #include <cstdio>
 #include <memory>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -119,6 +121,9 @@ class ForemanDistributed final : public ForemanBase {
   CatalogDatabaseLite *catalog_database_;
 
   std::unique_ptr<PolicyEnforcerDistributed> policy_enforcer_;
+
+  // From a query id to a set of Shiftbosses that save query result.
+  std::unordered_map<std::size_t, std::unordered_set<std::size_t>> query_result_saved_shiftbosses_;
 
   DISALLOW_COPY_AND_ASSIGN(ForemanDistributed);
 };

--- a/query_execution/PolicyEnforcerBase.cpp
+++ b/query_execution/PolicyEnforcerBase.cpp
@@ -142,6 +142,8 @@ void PolicyEnforcerBase::removeQuery(const std::size_t query_id) {
                  << " that hasn't finished its execution";
   }
   admitted_queries_.erase(query_id);
+
+  removed_query_ids_.insert(query_id);
 }
 
 bool PolicyEnforcerBase::admitQueries(

--- a/query_execution/PolicyEnforcerBase.hpp
+++ b/query_execution/PolicyEnforcerBase.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <queue>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_execution/QueryExecutionTypedefs.hpp"
@@ -106,6 +107,16 @@ class PolicyEnforcerBase {
   void processMessage(const TaggedMessage &tagged_message);
 
   /**
+   * @brief Check if the given query id ever exists.
+   *
+   * @return True if the query ever exists, otherwise false.
+   **/
+  inline bool existQuery(const std::size_t query_id) const {
+    return admitted_queries_.find(query_id) != admitted_queries_.end() ||
+           removed_query_ids_.find(query_id) != removed_query_ids_.end();
+  }
+
+  /**
    * @brief Check if there are any queries to be executed.
    *
    * @return True if there is at least one active or waiting query, false if
@@ -162,6 +173,10 @@ class PolicyEnforcerBase {
 
   // Key = query ID, value = QueryManagerBase* for the key query.
   std::unordered_map<std::size_t, std::unique_ptr<QueryManagerBase>> admitted_queries_;
+
+  // TODO(quickstep-team): Delete a 'query_id' after receiving all
+  // 'QueryInitiateResponseMessage's for the 'query_id'.
+  std::unordered_set<std::size_t> removed_query_ids_;
 
   // The queries which haven't been admitted yet.
   std::queue<QueryHandle*> waiting_queries_;

--- a/query_execution/QueryExecutionMessages.proto
+++ b/query_execution/QueryExecutionMessages.proto
@@ -128,8 +128,10 @@ message SaveQueryResultMessage {
 }
 
 message SaveQueryResultResponseMessage {
-  required int32 relation_id = 1;
-  required uint32 cli_id = 2;  // tmb::client_id.
+  required uint64 query_id = 1;
+  required int32 relation_id = 2;
+  required uint32 cli_id = 3;  // tmb::client_id.
+  required uint64 shiftboss_index = 4;
 }
 
 message QueryExecutionSuccessMessage {

--- a/query_execution/QueryExecutionUtil.hpp
+++ b/query_execution/QueryExecutionUtil.hpp
@@ -121,6 +121,19 @@ class QueryExecutionUtil {
     DCHECK_EQ(kWorkloadCompletionMessage, tagged_message.message_type());
   }
 
+  static void BroadcastMessage(const tmb::client_id sender_id,
+                               const tmb::Address &addresses,
+                               tmb::TaggedMessage &&tagged_message,  // NOLINT(whitespace/operators)
+                               tmb::MessageBus *bus) {
+    // The sender broadcasts the given message to all 'addresses'.
+    tmb::MessageStyle style;
+    style.Broadcast(true);
+
+    const tmb::MessageBus::SendStatus send_status =
+        bus->Send(sender_id, addresses, style, std::move(tagged_message));
+    CHECK(send_status == tmb::MessageBus::SendStatus::kOK);
+  }
+
   static void BroadcastPoisonMessage(const tmb::client_id sender_id, tmb::MessageBus *bus) {
     // Terminate all threads.
     // The sender thread broadcasts poison message to the workers and foreman.

--- a/query_execution/Shiftboss.cpp
+++ b/query_execution/Shiftboss.cpp
@@ -189,8 +189,10 @@ void Shiftboss::run() {
         query_contexts_.erase(proto.query_id());
 
         serialization::SaveQueryResultResponseMessage proto_response;
+        proto_response.set_query_id(proto.query_id());
         proto_response.set_relation_id(proto.relation_id());
         proto_response.set_cli_id(proto.cli_id());
+        proto_response.set_shiftboss_index(shiftboss_index_);
 
         const size_t proto_response_length = proto_response.ByteSize();
         char *proto_response_bytes = static_cast<char*>(malloc(proto_response_length));

--- a/query_optimizer/tests/DistributedExecutionGeneratorTestRunner.hpp
+++ b/query_optimizer/tests/DistributedExecutionGeneratorTestRunner.hpp
@@ -49,7 +49,7 @@ namespace quickstep {
 namespace optimizer {
 
 namespace {
-constexpr int kNumInstances = 1;
+constexpr int kNumInstances = 3;
 }  // namespace
 
 /**


### PR DESCRIPTION
Assigned to @hbdeshmukh. Thanks!

This PR initiates (and tears down) all `Shiftboss`es to execute an admitting query, although we limit to only use the single `Shiftboss` for now. The next step is to schedule `WorkOrder`s on any available `Shiftboss`es.

Note that the current implementation is not fault tolerant to `Shiftboss` failures, nor scale-up and down.