### PR TITLE
Update travis to run only single thread while building release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - BUILD_TYPE=Release VECTOR_COPY_ELISION_LEVEL=selection
 
 install:
-  - if [ "$CC" = "gcc" ] || [[ "$BUILD_TYPE" = "Release" &&  "$VECTOR_COPY_ELISION_LEVEL" = "selection" ]]; then
+  - if [ "$CC" = "gcc" ] || [[ "$BUILD_TYPE" = "Release" ]]; then
       export MAKE_JOBS=1;
     else
       export MAKE_JOBS=2;


### PR DESCRIPTION
This a one-line change PR that fixes Travis build job failures due to compiler out-of-memory errors by running a single thread while building a release version.