### PR TITLE
Add backend support for LIPFilters.

### DIFF
--- a/expressions/scalar/ScalarAttribute.cpp
+++ b/expressions/scalar/ScalarAttribute.cpp
@@ -168,7 +168,7 @@ ColumnVector* ScalarAttribute::getAllValuesForJoin(
   ValueAccessor *accessor = using_left_relation ? left_accessor
                                                 : right_accessor;
 
-  return InvokeOnValueAccessorNotAdapter(
+  return InvokeOnAnyValueAccessor(
       accessor,
       [&joined_tuple_ids,
        &attr_id,

--- a/query_execution/QueryContext.hpp
+++ b/query_execution/QueryContext.hpp
@@ -88,7 +88,7 @@ class QueryContext {
   /**
    * @brief A unique identifier for a LIPFilterDeployment per query.
    **/
-  typedef std::uint32_t lip_deployment_id;
+  typedef std::int32_t lip_deployment_id;
   static constexpr lip_deployment_id kInvalidLIPDeploymentId = static_cast<lip_deployment_id>(-1);
 
   /**
@@ -315,7 +315,7 @@ class QueryContext {
    * @return True if valid, otherwise false.
    **/
   bool isValidLIPDeploymentId(const lip_deployment_id id) const {
-    return id < lip_deployments_.size();
+    return static_cast<std::size_t>(id) < lip_deployments_.size();
   }
 
   /**
@@ -328,7 +328,7 @@ class QueryContext {
    **/
   inline const LIPFilterDeployment* getLIPDeployment(
       const lip_deployment_id id) const {
-    DCHECK_LT(id, lip_deployments_.size());
+    DCHECK_LT(static_cast<std::size_t>(id), lip_deployments_.size());
     return lip_deployments_[id].get();
   }
 
@@ -338,7 +338,7 @@ class QueryContext {
    * @param id The id of the LIPFilterDeployment to destroy.
    **/
   inline void destroyLIPDeployment(const lip_deployment_id id) {
-    DCHECK_LT(id, lip_deployments_.size());
+    DCHECK_LT(static_cast<std::size_t>(id), lip_deployments_.size());
     lip_deployments_[id].reset();
   }
 

--- a/query_optimizer/PhysicalGenerator.cpp
+++ b/query_optimizer/PhysicalGenerator.cpp
@@ -50,7 +50,7 @@ DEFINE_bool(reorder_hash_joins, true,
             "cardinality and selective tables to be joined first, which is suitable "
             "for queries on star-schema tables.");
 
-DEFINE_bool(use_lip_filters, false,
+DEFINE_bool(use_lip_filters, true,
             "If true, use LIP (Lookahead Information Passing) filters to accelerate "
             "query processing. LIP filters are effective for queries on star schema "
             "tables (e.g. the SSB benchmark) and snowflake schema tables (e.g. the "

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_AttachLIPFilters
                       quickstep_queryoptimizer_physical_Selection
                       quickstep_queryoptimizer_physical_TopLevelPlan
                       quickstep_queryoptimizer_rules_Rule
+                      quickstep_types_TypedValue
                       quickstep_utility_Macros
                       quickstep_utility_lipfilter_LIPFilter)
 target_link_libraries(quickstep_queryoptimizer_rules_BottomUpRule

--- a/query_optimizer/tests/OptimizerTextTest.cpp
+++ b/query_optimizer/tests/OptimizerTextTest.cpp
@@ -32,6 +32,7 @@ namespace quickstep {
 namespace optimizer {
 
 DECLARE_bool(reorder_hash_joins);
+DECLARE_bool(use_lip_filters);
 
 }
 }
@@ -57,9 +58,10 @@ int main(int argc, char** argv) {
   test_driver->registerOptions(
       quickstep::optimizer::OptimizerTextTestRunner::kTestOptions);
 
-  // Turn off join order optimization for optimizer test since it is up to change
-  // and affects a large number of test cases.
+  // Turn off join order optimization and LIPFilter for optimizer test since
+  // it is up to change and affects a large number of test cases.
   quickstep::optimizer::FLAGS_reorder_hash_joins = false;
+  quickstep::optimizer::FLAGS_use_lip_filters = false;
 
   ::testing::InitGoogleTest(&argc, argv);
   int success = RUN_ALL_TESTS();

--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -30,6 +30,7 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+#include "utility/lip_filter/LIPFilterAdaptiveProber.hpp"
 
 #include "glog/logging.h"
 
@@ -137,13 +138,16 @@ class AggregationWorkOrder : public WorkOrder {
    * @param query_id The ID of this query.
    * @param input_block_id The block id.
    * @param state The AggregationState to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   AggregationWorkOrder(const std::size_t query_id,
                        const block_id input_block_id,
-                       AggregationOperationState *state)
+                       AggregationOperationState *state,
+                       LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         input_block_id_(input_block_id),
-        state_(DCHECK_NOTNULL(state)) {}
+        state_(DCHECK_NOTNULL(state)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   ~AggregationWorkOrder() override {}
 
@@ -152,6 +156,8 @@ class AggregationWorkOrder : public WorkOrder {
  private:
   const block_id input_block_id_;
   AggregationOperationState *state_;
+
+  std::unique_ptr<LIPFilterAdaptiveProber> lip_filter_adaptive_prober_;
 
   DISALLOW_COPY_AND_ASSIGN(AggregationWorkOrder);
 };

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -20,6 +20,7 @@
 #ifndef QUICKSTEP_RELATIONAL_OPERATORS_BUILD_HASH_OPERATOR_HPP_
 #define QUICKSTEP_RELATIONAL_OPERATORS_BUILD_HASH_OPERATOR_HPP_
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -31,6 +32,7 @@
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+#include "utility/lip_filter/LIPFilterBuilder.hpp"
 
 #include "glog/logging.h"
 
@@ -162,6 +164,7 @@ class BuildHashWorkOrder : public WorkOrder {
    * @param build_block_id The block id.
    * @param hash_table The JoinHashTable to use.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_builder The attached LIP filter builer.
    **/
   BuildHashWorkOrder(const std::size_t query_id,
                      const CatalogRelationSchema &input_relation,
@@ -169,14 +172,16 @@ class BuildHashWorkOrder : public WorkOrder {
                      const bool any_join_key_attributes_nullable,
                      const block_id build_block_id,
                      JoinHashTable *hash_table,
-                     StorageManager *storage_manager)
+                     StorageManager *storage_manager,
+                     LIPFilterBuilder *lip_filter_builder = nullptr)
       : WorkOrder(query_id),
         input_relation_(input_relation),
         join_key_attributes_(join_key_attributes),
         any_join_key_attributes_nullable_(any_join_key_attributes_nullable),
         build_block_id_(build_block_id),
         hash_table_(DCHECK_NOTNULL(hash_table)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_builder_(lip_filter_builder) {}
 
   /**
    * @brief Constructor for the distributed version.
@@ -189,6 +194,7 @@ class BuildHashWorkOrder : public WorkOrder {
    * @param build_block_id The block id.
    * @param hash_table The JoinHashTable to use.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_builder The attached LIP filter builer.
    **/
   BuildHashWorkOrder(const std::size_t query_id,
                      const CatalogRelationSchema &input_relation,
@@ -196,14 +202,16 @@ class BuildHashWorkOrder : public WorkOrder {
                      const bool any_join_key_attributes_nullable,
                      const block_id build_block_id,
                      JoinHashTable *hash_table,
-                     StorageManager *storage_manager)
+                     StorageManager *storage_manager,
+                     LIPFilterBuilder *lip_filter_builder = nullptr)
       : WorkOrder(query_id),
         input_relation_(input_relation),
         join_key_attributes_(std::move(join_key_attributes)),
         any_join_key_attributes_nullable_(any_join_key_attributes_nullable),
         build_block_id_(build_block_id),
         hash_table_(DCHECK_NOTNULL(hash_table)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_builder_(lip_filter_builder) {}
 
   ~BuildHashWorkOrder() override {}
 
@@ -221,6 +229,8 @@ class BuildHashWorkOrder : public WorkOrder {
 
   JoinHashTable *hash_table_;
   StorageManager *storage_manager_;
+
+  std::unique_ptr<LIPFilterBuilder> lip_filter_builder_;
 
   DISALLOW_COPY_AND_ASSIGN(BuildHashWorkOrder);
 };

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -92,6 +92,8 @@ target_link_libraries(quickstep_relationaloperators_AggregationOperator
                       quickstep_storage_AggregationOperationState
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilterAdaptiveProber
+                      quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
 target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       glog
@@ -111,6 +113,8 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       quickstep_storage_TupleStorageSubBlock
                       quickstep_storage_ValueAccessor
                       quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilterBuilder
+                      quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
 target_link_libraries(quickstep_relationaloperators_CreateIndexOperator
                       glog
@@ -223,6 +227,8 @@ target_link_libraries(quickstep_relationaloperators_HashJoinOperator
                       quickstep_types_containers_ColumnVector
                       quickstep_types_containers_ColumnVectorsValueAccessor
                       quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilterAdaptiveProber
+                      quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
 target_link_libraries(quickstep_relationaloperators_InsertOperator
                       glog
@@ -322,7 +328,11 @@ target_link_libraries(quickstep_relationaloperators_SelectOperator
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
+                      quickstep_storage_TupleIdSequence
+                      quickstep_storage_ValueAccessor
                       quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilterAdaptiveProber
+                      quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
 if(QUICKSTEP_HAVE_LIBNUMA)
 target_link_libraries(quickstep_relationaloperators_SelectOperator
@@ -492,6 +502,7 @@ target_link_libraries(quickstep_relationaloperators_WorkOrderFactory
                       quickstep_relationaloperators_WorkOrder_proto
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
 target_link_libraries(quickstep_relationaloperators_WorkOrder_proto
                       quickstep_relationaloperators_SortMergeRunOperator_proto

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -35,6 +35,7 @@
 #include "storage/HashTable.hpp"
 #include "storage/StorageBlockInfo.hpp"
 #include "utility/Macros.hpp"
+#include "utility/lip_filter/LIPFilterAdaptiveProber.hpp"
 
 #include "glog/logging.h"
 
@@ -295,6 +296,7 @@ class HashInnerJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashInnerJoinWorkOrder(
       const std::size_t query_id,
@@ -307,7 +309,8 @@ class HashInnerJoinWorkOrder : public WorkOrder {
       const std::vector<std::unique_ptr<const Scalar>> &selection,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -318,7 +321,8 @@ class HashInnerJoinWorkOrder : public WorkOrder {
         selection_(selection),
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   /**
    * @brief Constructor for the distributed version.
@@ -342,6 +346,7 @@ class HashInnerJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashInnerJoinWorkOrder(
       const std::size_t query_id,
@@ -354,7 +359,8 @@ class HashInnerJoinWorkOrder : public WorkOrder {
       const std::vector<std::unique_ptr<const Scalar>> &selection,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -365,7 +371,8 @@ class HashInnerJoinWorkOrder : public WorkOrder {
         selection_(selection),
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   ~HashInnerJoinWorkOrder() override {}
 
@@ -391,6 +398,8 @@ class HashInnerJoinWorkOrder : public WorkOrder {
 
   InsertDestination *output_destination_;
   StorageManager *storage_manager_;
+
+  std::unique_ptr<LIPFilterAdaptiveProber> lip_filter_adaptive_prober_;
 
   DISALLOW_COPY_AND_ASSIGN(HashInnerJoinWorkOrder);
 };
@@ -423,6 +432,7 @@ class HashSemiJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashSemiJoinWorkOrder(
       const std::size_t query_id,
@@ -435,7 +445,8 @@ class HashSemiJoinWorkOrder : public WorkOrder {
       const std::vector<std::unique_ptr<const Scalar>> &selection,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -446,7 +457,8 @@ class HashSemiJoinWorkOrder : public WorkOrder {
         selection_(selection),
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   /**
    * @brief Constructor for the distributed version.
@@ -470,6 +482,7 @@ class HashSemiJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashSemiJoinWorkOrder(
       const std::size_t query_id,
@@ -482,7 +495,8 @@ class HashSemiJoinWorkOrder : public WorkOrder {
       const std::vector<std::unique_ptr<const Scalar>> &selection,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -493,7 +507,8 @@ class HashSemiJoinWorkOrder : public WorkOrder {
         selection_(selection),
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   ~HashSemiJoinWorkOrder() override {}
 
@@ -515,6 +530,8 @@ class HashSemiJoinWorkOrder : public WorkOrder {
 
   InsertDestination *output_destination_;
   StorageManager *storage_manager_;
+
+  std::unique_ptr<LIPFilterAdaptiveProber> lip_filter_adaptive_prober_;
 
   DISALLOW_COPY_AND_ASSIGN(HashSemiJoinWorkOrder);
 };
@@ -547,6 +564,7 @@ class HashAntiJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashAntiJoinWorkOrder(
       const std::size_t query_id,
@@ -559,7 +577,8 @@ class HashAntiJoinWorkOrder : public WorkOrder {
       const std::vector<std::unique_ptr<const Scalar>> &selection,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -570,7 +589,8 @@ class HashAntiJoinWorkOrder : public WorkOrder {
         selection_(selection),
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   /**
    * @brief Constructor for the distributed version.
@@ -594,6 +614,7 @@ class HashAntiJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashAntiJoinWorkOrder(
       const std::size_t query_id,
@@ -606,7 +627,8 @@ class HashAntiJoinWorkOrder : public WorkOrder {
       const std::vector<std::unique_ptr<const Scalar>> &selection,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -617,7 +639,8 @@ class HashAntiJoinWorkOrder : public WorkOrder {
         selection_(selection),
         hash_table_(hash_table),
         output_destination_(DCHECK_NOTNULL(output_destination)),
-        storage_manager_(DCHECK_NOTNULL(storage_manager)) {}
+        storage_manager_(DCHECK_NOTNULL(storage_manager)),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   ~HashAntiJoinWorkOrder() override {}
 
@@ -645,6 +668,8 @@ class HashAntiJoinWorkOrder : public WorkOrder {
 
   InsertDestination *output_destination_;
   StorageManager *storage_manager_;
+
+  std::unique_ptr<LIPFilterAdaptiveProber> lip_filter_adaptive_prober_;
 
   DISALLOW_COPY_AND_ASSIGN(HashAntiJoinWorkOrder);
 };
@@ -675,6 +700,7 @@ class HashOuterJoinWorkOrder : public WorkOrder {
    * @param hash_table The JoinHashTable to use.
    * @param output_destination The InsertDestination to insert the join results.
    * @param storage_manager The StorageManager to use.
+   * @param lip_filter_adaptive_prober The attached LIP filter prober.
    **/
   HashOuterJoinWorkOrder(
       const std::size_t query_id,
@@ -687,7 +713,8 @@ class HashOuterJoinWorkOrder : public WorkOrder {
       const std::vector<bool> &is_selection_on_build,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -698,7 +725,8 @@ class HashOuterJoinWorkOrder : public WorkOrder {
         is_selection_on_build_(is_selection_on_build),
         hash_table_(hash_table),
         output_destination_(output_destination),
-        storage_manager_(storage_manager) {}
+        storage_manager_(storage_manager),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   /**
    * @brief Constructor for the distributed version.
@@ -733,7 +761,8 @@ class HashOuterJoinWorkOrder : public WorkOrder {
       std::vector<bool> &&is_selection_on_build,
       const JoinHashTable &hash_table,
       InsertDestination *output_destination,
-      StorageManager *storage_manager)
+      StorageManager *storage_manager,
+      LIPFilterAdaptiveProber *lip_filter_adaptive_prober)
       : WorkOrder(query_id),
         build_relation_(build_relation),
         probe_relation_(probe_relation),
@@ -744,7 +773,8 @@ class HashOuterJoinWorkOrder : public WorkOrder {
         is_selection_on_build_(std::move(is_selection_on_build)),
         hash_table_(hash_table),
         output_destination_(output_destination),
-        storage_manager_(storage_manager) {}
+        storage_manager_(storage_manager),
+        lip_filter_adaptive_prober_(lip_filter_adaptive_prober) {}
 
   ~HashOuterJoinWorkOrder() override {}
 
@@ -762,6 +792,8 @@ class HashOuterJoinWorkOrder : public WorkOrder {
 
   InsertDestination *output_destination_;
   StorageManager *storage_manager_;
+
+  std::unique_ptr<LIPFilterAdaptiveProber> lip_filter_adaptive_prober_;
 
   DISALLOW_COPY_AND_ASSIGN(HashOuterJoinWorkOrder);
 };

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -59,6 +59,7 @@ message AggregationWorkOrder {
     // All required.
     optional uint32 aggr_state_index = 16;
     optional fixed64 block_id = 17;
+    optional int32 lip_deployment_index = 18;
   }
 }
 
@@ -70,6 +71,7 @@ message BuildHashWorkOrder {
     optional bool any_join_key_attributes_nullable = 34;
     optional uint32 join_hash_table_index = 35;
     optional fixed64 block_id = 36;
+    optional int32 lip_deployment_index = 37;
   }
 }
 
@@ -131,6 +133,8 @@ message HashJoinWorkOrder {
     optional int32 residual_predicate_index = 169;
     // Used by HashOuterJoinWorkOrder only.
     repeated bool is_selection_on_build = 170;
+
+    optional int32 lip_deployment_index = 171;
   }
 }
 
@@ -185,9 +189,10 @@ message SelectWorkOrder {
 
     // When 'simple_projection' is true.
     repeated int32 simple_selection = 245;
-
     // Otherwise.
     optional int32 selection_index = 246;
+
+    optional int32 lip_deployment_index = 247;
   }
 }
 

--- a/storage/AggregationOperationState.hpp
+++ b/storage/AggregationOperationState.hpp
@@ -41,6 +41,7 @@ class AggregateFunction;
 class CatalogDatabaseLite;
 class CatalogRelationSchema;
 class InsertDestination;
+class LIPFilterAdaptiveProber;
 class StorageManager;
 
 /** \addtogroup Storage
@@ -155,8 +156,11 @@ class AggregationOperationState {
    *
    * @param input_block The block ID of the storage block where the aggreates
    *        are going to be computed.
+   * @param lip_filter_adaptive_prober The LIPFilter prober for pre-filtering
+   *        the block.
    **/
-  void aggregateBlock(const block_id input_block);
+  void aggregateBlock(const block_id input_block,
+                      LIPFilterAdaptiveProber *lip_filter_adaptive_prober = nullptr);
 
   /**
    * @brief Generate the final results for the aggregates managed by this
@@ -185,7 +189,8 @@ class AggregationOperationState {
 
   // Aggregate on input block.
   void aggregateBlockSingleState(const block_id input_block);
-  void aggregateBlockHashTable(const block_id input_block);
+  void aggregateBlockHashTable(const block_id input_block,
+                               LIPFilterAdaptiveProber *lip_filter_adaptive_prober);
 
   void finalizeSingleState(InsertDestination *output_destination);
   void finalizeHashTable(InsertDestination *output_destination);

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -292,11 +292,14 @@ target_link_libraries(quickstep_storage_AggregationOperationState
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
+                      quickstep_storage_TupleIdSequence
+                      quickstep_storage_ValueAccessor
                       quickstep_types_TypedValue
                       quickstep_types_containers_ColumnVector
                       quickstep_types_containers_ColumnVectorsValueAccessor
                       quickstep_types_containers_Tuple
-                      quickstep_utility_Macros)
+                      quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilterAdaptiveProber)
 target_link_libraries(quickstep_storage_AggregationOperationState_proto
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_aggregation_AggregateFunction_proto

--- a/storage/StorageBlock.cpp
+++ b/storage/StorageBlock.cpp
@@ -340,7 +340,7 @@ void StorageBlock::sample(const bool is_block_sample,
 }
 
 void StorageBlock::select(const vector<unique_ptr<const Scalar>> &selection,
-                          const Predicate *predicate,
+                          const TupleIdSequence *filter,
                           InsertDestinationInterface *destination) const {
   ColumnVectorsValueAccessor temp_result;
   {
@@ -348,14 +348,8 @@ void StorageBlock::select(const vector<unique_ptr<const Scalar>> &selection,
                                       indices_,
                                       indices_consistent_);
 
-    std::unique_ptr<TupleIdSequence> matches;
-    std::unique_ptr<ValueAccessor> accessor;
-    if (predicate == nullptr) {
-      accessor.reset(tuple_store_->createValueAccessor());
-    } else {
-      matches.reset(getMatchesForPredicate(predicate));
-      accessor.reset(tuple_store_->createValueAccessor(matches.get()));
-    }
+    std::unique_ptr<ValueAccessor> accessor(
+        tuple_store_->createValueAccessor(filter));
 
     for (vector<unique_ptr<const Scalar>>::const_iterator selection_cit = selection.begin();
          selection_cit != selection.end();
@@ -370,16 +364,10 @@ void StorageBlock::select(const vector<unique_ptr<const Scalar>> &selection,
 }
 
 void StorageBlock::selectSimple(const std::vector<attribute_id> &selection,
-                                const Predicate *predicate,
+                                const TupleIdSequence *filter,
                                 InsertDestinationInterface *destination) const {
-  std::unique_ptr<ValueAccessor> accessor;
-  std::unique_ptr<TupleIdSequence> matches;
-  if (predicate == nullptr) {
-    accessor.reset(tuple_store_->createValueAccessor());
-  } else {
-    matches.reset(getMatchesForPredicate(predicate));
-    accessor.reset(tuple_store_->createValueAccessor(matches.get()));
-  }
+  std::unique_ptr<ValueAccessor> accessor(
+      tuple_store_->createValueAccessor(filter));
 
   destination->bulkInsertTuplesWithRemappedAttributes(selection,
                                                       accessor.get());
@@ -389,37 +377,28 @@ AggregationState* StorageBlock::aggregate(
     const AggregationHandle &handle,
     const std::vector<std::unique_ptr<const Scalar>> &arguments,
     const std::vector<attribute_id> *arguments_as_attributes,
-    const Predicate *predicate,
-    std::unique_ptr<TupleIdSequence> *reuse_matches) const {
-  // If there is a filter predicate that hasn't already been evaluated,
-  // evaluate it now and save the results for other aggregates on this same
-  // block.
-  if (predicate && !*reuse_matches) {
-    reuse_matches->reset(getMatchesForPredicate(predicate));
-  }
-
+    const TupleIdSequence *filter) const {
 #ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
   // If all the arguments to this aggregate are plain relation attributes,
   // aggregate directly on a ValueAccessor from this block to avoid a copy.
   if ((arguments_as_attributes != nullptr) && (!arguments_as_attributes->empty())) {
     DCHECK_EQ(arguments.size(), arguments_as_attributes->size())
         << "Mismatch between number of arguments and number of attribute_ids";
-    return aggregateHelperValueAccessor(handle, *arguments_as_attributes, reuse_matches->get());
+    return aggregateHelperValueAccessor(handle, *arguments_as_attributes, filter);
   }
   // TODO(shoban): We may want to optimize for ScalarLiteral here.
 #endif
 
   // Call aggregateHelperColumnVector() to materialize each argument as a
   // ColumnVector, then aggregate over those.
-  return aggregateHelperColumnVector(handle, arguments, reuse_matches->get());
+  return aggregateHelperColumnVector(handle, arguments, filter);
 }
 
 void StorageBlock::aggregateGroupBy(
     const std::vector<std::vector<std::unique_ptr<const Scalar>>> &arguments,
     const std::vector<std::unique_ptr<const Scalar>> &group_by,
-    const Predicate *predicate,
+    const TupleIdSequence *filter,
     AggregationStateHashTableBase *hash_table,
-    std::unique_ptr<TupleIdSequence> *reuse_matches,
     std::vector<std::unique_ptr<ColumnVector>> *reuse_group_by_vectors) const {
   DCHECK_GT(group_by.size(), 0u)
       << "Called aggregateGroupBy() with zero GROUP BY expressions";
@@ -438,23 +417,7 @@ void StorageBlock::aggregateGroupBy(
   // this aggregate, as well as the GROUP BY expression values.
   ColumnVectorsValueAccessor temp_result;
   {
-    std::unique_ptr<ValueAccessor> accessor;
-    if (predicate) {
-      if (!*reuse_matches) {
-        // If there is a filter predicate that hasn't already been evaluated,
-        // evaluate it now and save the results for other aggregates on this
-        // same block.
-        reuse_matches->reset(getMatchesForPredicate(predicate));
-      }
-
-      // Create a filtered ValueAccessor that only iterates over predicate
-      // matches.
-      accessor.reset(tuple_store_->createValueAccessor(reuse_matches->get()));
-    } else {
-      // Create a ValueAccessor that iterates over all tuples in this block
-      accessor.reset(tuple_store_->createValueAccessor());
-    }
-
+    std::unique_ptr<ValueAccessor> accessor(tuple_store_->createValueAccessor(filter));
     attribute_id attr_id = 0;
 
     // First, put GROUP BY keys into 'temp_result'.
@@ -503,9 +466,8 @@ void StorageBlock::aggregateDistinct(
     const std::vector<std::unique_ptr<const Scalar>> &arguments,
     const std::vector<attribute_id> *arguments_as_attributes,
     const std::vector<std::unique_ptr<const Scalar>> &group_by,
-    const Predicate *predicate,
+    const TupleIdSequence *filter,
     AggregationStateHashTableBase *distinctify_hash_table,
-    std::unique_ptr<TupleIdSequence> *reuse_matches,
     std::vector<std::unique_ptr<ColumnVector>> *reuse_group_by_vectors) const {
   DCHECK_GT(arguments.size(), 0u)
       << "Called aggregateDistinct() with zero argument expressions";
@@ -517,22 +479,7 @@ void StorageBlock::aggregateDistinct(
   // this aggregate, as well as the GROUP BY expression values.
   ColumnVectorsValueAccessor temp_result;
   {
-    std::unique_ptr<ValueAccessor> accessor;
-    if (predicate) {
-      if (!*reuse_matches) {
-        // If there is a filter predicate that hasn't already been evaluated,
-        // evaluate it now and save the results for other aggregates on this
-        // same block.
-        reuse_matches->reset(getMatchesForPredicate(predicate));
-      }
-
-      // Create a filtered ValueAccessor that only iterates over predicate
-      // matches.
-      accessor.reset(tuple_store_->createValueAccessor(reuse_matches->get()));
-    } else {
-      // Create a ValueAccessor that iterates over all tuples in this block
-      accessor.reset(tuple_store_->createValueAccessor());
-    }
+    std::unique_ptr<ValueAccessor> accessor(tuple_store_->createValueAccessor(filter));
 
 #ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
     // If all the arguments to this aggregate are plain relation attributes,
@@ -1246,23 +1193,36 @@ bool StorageBlock::rebuildIndexes(bool short_circuit) {
   return all_indices_consistent_;
 }
 
-TupleIdSequence* StorageBlock::getMatchesForPredicate(const Predicate *predicate) const {
+TupleIdSequence* StorageBlock::getMatchesForPredicate(const Predicate *predicate,
+                                                      const TupleIdSequence *filter) const {
   if (predicate == nullptr) {
-    return tuple_store_->getExistenceMap();
+    TupleIdSequence *matches = tuple_store_->getExistenceMap();
+    if (filter != nullptr) {
+      matches->intersectWith(*filter);
+    }
+    return matches;
   }
 
   std::unique_ptr<ValueAccessor> value_accessor(tuple_store_->createValueAccessor());
-  std::unique_ptr<TupleIdSequence> existence_map;
-  if (!tuple_store_->isPacked()) {
-    existence_map.reset(tuple_store_->getExistenceMap());
-  }
   SubBlocksReference sub_blocks_ref(*tuple_store_,
                                     indices_,
                                     indices_consistent_);
-  return predicate->getAllMatches(value_accessor.get(),
-                                  &sub_blocks_ref,
-                                  nullptr,
-                                  existence_map.get());
+
+  if (!tuple_store_->isPacked()) {
+    std::unique_ptr<TupleIdSequence> existence_map(tuple_store_->getExistenceMap());
+    if (filter != nullptr) {
+      existence_map->intersectWith(*filter);
+    }
+    return predicate->getAllMatches(value_accessor.get(),
+                                    &sub_blocks_ref,
+                                    nullptr,
+                                    existence_map.get());
+  } else {
+    return predicate->getAllMatches(value_accessor.get(),
+                                    &sub_blocks_ref,
+                                    nullptr,
+                                    filter);
+  }
 }
 
 std::unordered_map<attribute_id, TypedValue>* StorageBlock::generateUpdatedValues(

--- a/utility/PlanVisualizer.cpp
+++ b/utility/PlanVisualizer.cpp
@@ -132,9 +132,7 @@ void PlanVisualizer::visit(const P::PhysicalPtr &input) {
 
     for (const auto &attr : child->getOutputAttributes()) {
       if (referenced_ids.find(attr->id()) != referenced_ids.end()) {
-        edge_info.labels.emplace_back(
-            attr->attribute_alias() + ", est # distinct = " +
-            std::to_string(cost_model_->estimateNumDistinctValues(attr->id(), child)));
+        edge_info.labels.emplace_back(attr->attribute_alias());
       }
     }
   }

--- a/utility/lip_filter/CMakeLists.txt
+++ b/utility/lip_filter/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(quickstep_utility_lipfilter_LIPFilterAdaptiveProber ../../empty_src.
 add_library(quickstep_utility_lipfilter_LIPFilterBuilder ../../empty_src.cpp LIPFilterBuilder.hpp)
 add_library(quickstep_utility_lipfilter_LIPFilterDeployment LIPFilterDeployment.cpp LIPFilterDeployment.hpp)
 add_library(quickstep_utility_lipfilter_LIPFilterFactory LIPFilterFactory.cpp LIPFilterFactory.hpp)
+add_library(quickstep_utility_lipfilter_LIPFilterUtil ../../empty_src.cpp LIPFilterUtil.hpp)
 add_library(quickstep_utility_lipfilter_LIPFilter_proto
             ${utility_lipfilter_LIPFilter_proto_srcs})
 add_library(quickstep_utility_lipfilter_SingleIdentityHashFilter ../../empty_src.cpp SingleIdentityHashFilter.hpp)
@@ -58,6 +59,9 @@ target_link_libraries(quickstep_utility_lipfilter_LIPFilterFactory
                       quickstep_utility_lipfilter_LIPFilter_proto
                       quickstep_utility_lipfilter_SingleIdentityHashFilter
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_utility_lipfilter_LIPFilterUtil
+                      quickstep_queryexecution_QueryContext
+                      quickstep_utility_lipfilter_LIPFilterDeployment)
 target_link_libraries(quickstep_utility_lipfilter_LIPFilter_proto
                       ${PROTOBUF_LIBRARY}
                       quickstep_types_Type_proto)

--- a/utility/lip_filter/LIPFilterBuilder.hpp
+++ b/utility/lip_filter/LIPFilterBuilder.hpp
@@ -39,9 +39,6 @@ class ValueAccessor;
  *  @{
  */
 
-class LIPFilterBuilder;
-typedef std::shared_ptr<LIPFilterBuilder> LIPFilterBuilderPtr;
-
 /**
  * @brief Helper class for building LIPFilters from a relation (i.e. ValueAccessor).
  */

--- a/utility/lip_filter/LIPFilterUtil.hpp
+++ b/utility/lip_filter/LIPFilterUtil.hpp
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_UTILITY_LIP_FILTER_LIP_FILTER_UTIL_HPP_
+#define QUICKSTEP_UTILITY_LIP_FILTER_LIP_FILTER_UTIL_HPP_
+
+#include "query_execution/QueryContext.hpp"
+#include "utility/lip_filter/LIPFilterDeployment.hpp"
+
+namespace quickstep {
+
+class LIPFilterBuilder;
+class LIPFilterAdaptiveProber;
+
+/** \addtogroup Utility
+ *  @{
+ */
+
+/**
+ * @brief Create a LIPFilterBuilder for the given LIPFilterDeployment in QueryContext.
+ *
+ * @param lip_deployment_index The id of the LIPFilterDeployment in QueryContext.
+ * @param query_context The QueryContext.
+ * @return A LIPFilterBuilder object, or nullptr if \p lip_deployment_index is invalid.
+ */
+inline LIPFilterBuilder* CreateLIPFilterBuilderHelper(
+    const QueryContext::lip_deployment_id lip_deployment_index,
+    const QueryContext *query_context) {
+  if (lip_deployment_index == QueryContext::kInvalidLIPDeploymentId) {
+    return nullptr;
+  } else {
+    const LIPFilterDeployment *lip_filter_deployment =
+        query_context->getLIPDeployment(lip_deployment_index);
+    return lip_filter_deployment->createLIPFilterBuilder();
+  }
+}
+
+/**
+ * @brief Create a LIPFilterAdaptiveProber for the given LIPFilterDeployment
+ *        in QueryContext.
+ *
+ * @param lip_deployment_index The id of the LIPFilterDeployment in QueryContext.
+ * @param query_context The QueryContext.
+ * @return A LIPFilterAdaptiveProber object, or nullptr if \p lip_deployment_index
+ *         is invalid.
+ */
+inline LIPFilterAdaptiveProber* CreateLIPFilterAdaptiveProberHelper(
+    const QueryContext::lip_deployment_id lip_deployment_index,
+    const QueryContext *query_context) {
+  if (lip_deployment_index == QueryContext::kInvalidLIPDeploymentId) {
+    return nullptr;
+  } else {
+    const LIPFilterDeployment *lip_filter_deployment =
+        query_context->getLIPDeployment(lip_deployment_index);
+    return lip_filter_deployment->createLIPFilterAdaptiveProber();
+  }
+}
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_UTILITY_LIP_FILTER_LIP_FILTER_UTIL_HPP_


### PR DESCRIPTION
This PR follows #113 and #118 and adds backend support for LIPFilters.
- `BuildHashOperator` supports building of LIPFilters.
- `SelectOperator`, `HashJoinOperator` and `AggregateOperator` support probing of LIPFilters. 

For `SelectOperator` and `AggregateOperator`, if an filter predicate is present, then the LIPFilters will be applied AFTER the filter predicate.

The latest physical plans w/ LIPFilters for SSB/TPC-H SF100:
[SSB_physical_plans.pdf](https://github.com/apache/incubator-quickstep/files/547240/SSB_physical_plans.pdf)
[TPCH_physical_plans.pdf](https://github.com/apache/incubator-quickstep/files/547241/TPCH_physical_plans.pdf)

Here are performance results for SSB/TPC-H SF100.
<table>
  <tr>
    <td><b>SSB SF100</b></td>
    <td><b>master (ms)</b></td>
    <td><b>w/ LIPFilter (ms)</b></td>
  </tr>
  <tr>
    <td>Q01</td>
    <td>885</td>
    <td>955</td>
  </tr>
  <tr>
    <td>Q02</td>
    <td>738</td>
    <td>821</td>
  </tr>
  <tr>
    <td>Q03</td>
    <td>707</td>
    <td>835</td>
  </tr>
  <tr>
    <td>Q04</td>
    <td>1240</td>
    <td>1114</td>
  </tr>
  <tr>
    <td>Q05</td>
    <td>853</td>
    <td>835</td>
  </tr>
  <tr>
    <td>Q06</td>
    <td>751</td>
    <td>975</td>
  </tr>
  <tr>
    <td>Q07</td>
    <td>3109</td>
    <td>2116</td>
  </tr>
  <tr>
    <td>Q08</td>
    <td>1042</td>
    <td>581</td>
  </tr>
  <tr>
    <td>Q09</td>
    <td>786</td>
    <td>710</td>
  </tr>
  <tr>
    <td>Q10</td>
    <td>603</td>
    <td>558</td>
  </tr>
  <tr>
    <td>Q11</td>
    <td>2851</td>
    <td>1410</td>
  </tr>
  <tr>
    <td>Q12</td>
    <td>3279</td>
    <td>908</td>
  </tr>
  <tr>
    <td>Q13</td>
    <td>1122</td>
    <td>904</td>
  </tr>
  <tr>
    <td>Total</td>
    <td>17967</td>
    <td>12721</td>
  </tr>
</table>

For TPC-H queries, there is an issue with Q21 that two hash tables on the `lineitem` relation are required. Since all the `HashTable`s are constructed in `QueryContext` at the beginning of query execution, so that 75% of the available memory slots (48569 out of 64385) are occupied which can not be swapped out by `StorageManager`'s `EvictionPolicy`. This incurs heavy _spilling_ behavior and results in over 120 seconds running time for Q21 in master branch / occasional DNF in LIPFilter branch. One quick solution to bypass this problem is to relax the buffer pool size (set `-buffer_pool_slots=100000`). As a long term solution, we may
(1) reduce hash table sizes by using untyped values;
(2) delay the allocation of hash table memory unless the hash table is actually used + add support from scheduler to satisfy resource constraints.

(**master** branch's performance is from Harshad's experiment #121)
<table>
  <tr>
    <td><b>TPCH SF100</b></td>
    <td><b>master (ms)</b></td>
    <td><b>w/ LIPFilter (ms)</b></td>
    <td><b>w/ LIPFilter (ms)<br />-buffer_pool_slots=100000</b></td>
  </tr>
  <tr>
    <td>Q01</td>
    <td>16,046</td>
    <td>15180</td>
    <td>15238</td>
  </tr>
  <tr>
    <td>Q02</td>
    <td>5,625</td>
    <td>710</td>
    <td>744</td>
  </tr>
  <tr>
    <td>Q03</td>
    <td>6,861</td>
    <td>5069</td>
    <td>4907</td>
  </tr>
  <tr>
    <td>Q04</td>
    <td>2,662</td>
    <td>2617</td>
    <td>2448</td>
  </tr>
  <tr>
    <td>Q05</td>
    <td>4,364</td>
    <td>5966</td>
    <td>4499</td>
  </tr>
  <tr>
    <td>Q06</td>
    <td>398</td>
    <td>401</td>
    <td>395</td>
  </tr>
  <tr>
    <td>Q07</td>
    <td>23,367</td>
    <td>25836</td>
    <td>24860</td>
  </tr>
  <tr>
    <td>Q08</td>
    <td>3,274</td>
    <td>1714</td>
    <td>1733</td>
  </tr>
  <tr>
    <td>Q09</td>
    <td>10,050</td>
    <td>13707</td>
    <td>7789</td>
  </tr>
  <tr>
    <td>Q10</td>
    <td>15,296</td>
    <td>13038</td>
    <td>12934</td>
  </tr>
  <tr>
    <td>Q11</td>
    <td>2,110</td>
    <td>2344</td>
    <td>2221</td>
  </tr>
  <tr>
    <td>Q12</td>
    <td>1,805</td>
    <td>2049</td>
    <td>1969</td>
  </tr>
  <tr>
    <td>Q13</td>
    <td>34,220</td>
    <td>35116</td>
    <td>34915</td>
  </tr>
  <tr>
    <td>Q14</td>
    <td>771</td>
    <td>942</td>
    <td>852</td>
  </tr>
  <tr>
    <td>Q15</td>
    <td>4,435</td>
    <td>4882</td>
    <td>4832</td>
  </tr>
  <tr>
    <td>Q16</td>
    <td>8,661</td>
    <td>8062</td>
    <td>9522</td>
  </tr>
  <tr>
    <td>Q17</td>
    <td>160,707</td>
    <td>1749</td>
    <td>1684</td>
  </tr>
  <tr>
    <td>Q18</td>
    <td>66,309</td>
    <td>82505</td>
    <td>86376</td>
  </tr>
  <tr>
    <td>Q19</td>
    <td>1,475</td>
    <td>1871</td>
    <td>1515</td>
  </tr>
  <tr>
    <td>Q20</td>
    <td>55,381</td>
    <td>1591</td>
    <td>1491</td>
  </tr>
  <tr>
    <td>Q21</td>
    <td>121,310</td>
    <td>DNF</td>
    <td>13205</td>
  </tr>
  <tr>
    <td>Q22</td>
    <td>6,792</td>
    <td>6746</td>
    <td>7098</td>
  </tr>
  <tr>
    <td></td>
    <td>551,921</td>
    <td>232096 (w/o Q21)</td>
    <td>241228</td>
  </tr>
</table>

Note that some improvements are not orthogonal to Harshad's partitioned aggregation #121 since LIPFilters also speed up some aggregations. Roughly speaking, when both PRs are merged, we will have an estimated overall running time of ~150s for TPC-H SF100. 