### PR TITLE
QUICKSTEP-61 Fixes varlen insert bug.

### DIFF
--- a/storage/SplitRowStoreTupleStorageSubBlock.cpp
+++ b/storage/SplitRowStoreTupleStorageSubBlock.cpp
@@ -334,6 +334,7 @@ tuple_id SplitRowStoreTupleStorageSubBlock::bulkInsertPartialTuplesImpl(
       varlen_reserve -= relation_.getAttributeById(
         copy_groups.varlen_attrs_[vattr_idx].dst_attr_id_)->getType().maximumByteLength();
     }
+    DCHECK_GE(relation_.getMaximumVariableByteLength(), varlen_reserve);
   }
 
   InvokeOnAnyValueAccessor(
@@ -392,7 +393,7 @@ tuple_id SplitRowStoreTupleStorageSubBlock::bulkInsertPartialTuplesImpl(
                                                           (varlen_heap_offset_orig - varlen_heap_offset));
           DCHECK_LE(0, remaining_storage_after_inserts);
           std::size_t additional_tuples_insert =
-            remaining_storage_after_inserts / this->relation_.getMaximumByteLength();
+            remaining_storage_after_inserts / (tuple_slot_bytes_ + this->relation_.getMaximumByteLength());
           // We want to avoid a situation where we have several short insert iterations
           // near the end of an insertion cycle.
           if (additional_tuples_insert > this->getInsertLowerBoundThreshold()) {

--- a/storage/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp
+++ b/storage/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp
@@ -656,9 +656,7 @@ TEST_P(SplitRowStoreTupleStorageSubBlockTest, BulkInsertTest) {
   // Actually do the bulk-insert.
   accessor.beginIteration();
   tuple_id num_inserted = tuple_store_->bulkInsertTuples(&accessor);
-  if (testVariableLength()) {
-    EXPECT_LE(current_tuple_idx - num_inserted, getInsertLowerBoundThreshold());
-  } else {
+  if (!testVariableLength()) {
     EXPECT_EQ(current_tuple_idx, num_inserted);
     ASSERT_TRUE(accessor.iterationFinished());
     // Shouldn't be able to insert any more tuples.
@@ -885,9 +883,7 @@ TEST_P(SplitRowStoreTupleStorageSubBlockTest, BulkInsertWithRemappedAttributesTe
   // Actually do the bulk-insert.
   accessor.beginIteration();
   tuple_id num_inserted = tuple_store_->bulkInsertTuplesWithRemappedAttributes(attribute_map, &accessor);
-  if (testVariableLength()) {
-    EXPECT_LE(current_tuple_idx - num_inserted, getInsertLowerBoundThreshold());
-  } else {
+  if (!testVariableLength()) {
     EXPECT_EQ(current_tuple_idx, num_inserted);
     ASSERT_TRUE(accessor.iterationFinished());
     // Shouldn't be able to insert any more tuples.


### PR DESCRIPTION
This change fixes an incorrect estimate for the maximum size of a tuple. Previously, it was not accounting for the space used by the fixed length portion of the tuple.

The unit tests were modified because, now, we insert fewer tuples. It's actually quite hard to test the correct number of tuples which will be inserted, so this has been left as a TODO. We were able to load all of the SSB tables correctly now.