### PR TITLE
Use BlockLocator and DataExchangerAsync in the distributed tests.

### DIFF
--- a/query_optimizer/tests/CMakeLists.txt
+++ b/query_optimizer/tests/CMakeLists.txt
@@ -79,6 +79,10 @@ target_link_libraries(quickstep_queryoptimizer_tests_TestDatabaseLoader
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros
                       tmb)
+if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_queryoptimizer_tests_TestDatabaseLoader
+                        quickstep_storage_StorageBlockInfo)
+endif(ENABLE_DISTRIBUTED)
 
 if (ENABLE_DISTRIBUTED)
   add_executable(quickstep_queryoptimizer_tests_DistributedExecutionGeneratorTest
@@ -110,7 +114,9 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_cli_PrintToScreen
                         quickstep_parser_ParseStatement
                         quickstep_parser_SqlParserWrapper
+                        quickstep_queryexecution_BlockLocator
                         quickstep_queryexecution_ForemanDistributed
+                        quickstep_queryexecution_QueryExecutionMessages_proto
                         quickstep_queryexecution_QueryExecutionTypedefs
                         quickstep_queryexecution_QueryExecutionUtil
                         quickstep_queryexecution_Shiftboss
@@ -120,6 +126,8 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_queryoptimizer_OptimizerContext
                         quickstep_queryoptimizer_QueryHandle
                         quickstep_queryoptimizer_tests_TestDatabaseLoader
+                        quickstep_storage_DataExchangerAsync
+                        quickstep_storage_StorageBlockInfo
                         quickstep_utility_Macros
                         quickstep_utility_MemStream
                         quickstep_utility_SqlError

--- a/query_optimizer/tests/DistributedExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/DistributedExecutionGeneratorTestRunner.cpp
@@ -20,18 +20,26 @@
 #include "query_optimizer/tests/DistributedExecutionGeneratorTestRunner.hpp"
 
 #include <cstdio>
+#include <cstdlib>
+#include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "cli/DropRelation.hpp"
 #include "cli/PrintToScreen.hpp"
 #include "parser/ParseStatement.hpp"
+#include "query_execution/BlockLocator.hpp"
 #include "query_execution/ForemanDistributed.hpp"
+#include "query_execution/QueryExecutionMessages.pb.h"
 #include "query_execution/QueryExecutionTypedefs.hpp"
+#include "query_execution/QueryExecutionUtil.hpp"
 #include "query_optimizer/OptimizerContext.hpp"
 #include "query_optimizer/QueryHandle.hpp"
+#include "storage/DataExchangerAsync.hpp"
+#include "storage/StorageBlockInfo.hpp"
 #include "utility/MemStream.hpp"
 #include "utility/SqlError.hpp"
 
@@ -41,9 +49,14 @@
 #include "tmb/message_bus.h"
 #include "tmb/tagged_message.h"
 
-using std::string;
+using std::free;
 using std::make_unique;
+using std::malloc;
+using std::move;
+using std::string;
 using std::vector;
+
+using tmb::TaggedMessage;
 
 namespace quickstep {
 
@@ -56,10 +69,7 @@ const char *DistributedExecutionGeneratorTestRunner::kResetOption =
 
 DistributedExecutionGeneratorTestRunner::DistributedExecutionGeneratorTestRunner(const string &storage_path)
     : query_id_(0),
-      test_database_loader_(storage_path) {
-  test_database_loader_.createTestRelation(false /* allow_vchar */);
-  test_database_loader_.loadTestRelation();
-
+      data_exchangers_(kNumInstances) {
   bus_.Initialize();
 
   cli_id_ = bus_.Connect();
@@ -67,9 +77,27 @@ DistributedExecutionGeneratorTestRunner::DistributedExecutionGeneratorTestRunner
   bus_.RegisterClientAsSender(cli_id_, kPoisonMessage);
   bus_.RegisterClientAsReceiver(cli_id_, kQueryExecutionSuccessMessage);
 
+  bus_.RegisterClientAsSender(cli_id_, kBlockDomainRegistrationMessage);
+  bus_.RegisterClientAsReceiver(cli_id_, kBlockDomainRegistrationResponseMessage);
+
+  block_locator_ = make_unique<BlockLocator>(&bus_);
+  locator_client_id_ = block_locator_->getBusClientID();
+  block_locator_->start();
+
+  test_database_loader_ = make_unique<TestDatabaseLoader>(
+      storage_path,
+      getBlockDomain(test_database_loader_data_exchanger_.network_address()),
+      locator_client_id_,
+      &bus_);
+  test_database_loader_data_exchanger_.set_storage_manager(test_database_loader_->storage_manager());
+  test_database_loader_data_exchanger_.start();
+
+  test_database_loader_->createTestRelation(false /* allow_vchar */);
+  test_database_loader_->loadTestRelation();
+
   // NOTE(zuyu): Foreman should initialize before Shiftboss so that the former
   // could receive a registration message from the latter.
-  foreman_ = make_unique<ForemanDistributed>(&bus_, test_database_loader_.catalog_database());
+  foreman_ = make_unique<ForemanDistributed>(&bus_, test_database_loader_->catalog_database());
 
   // We don't use the NUMA aware version of worker code.
   const vector<numa_node_id> numa_nodes(1 /* Number of worker threads per instance */,
@@ -78,17 +106,24 @@ DistributedExecutionGeneratorTestRunner::DistributedExecutionGeneratorTestRunner
   for (int i = 0; i < kNumInstances; ++i) {
     workers_.push_back(make_unique<Worker>(0 /* worker_thread_index */, &bus_));
 
-    const vector<tmb::client_id> worker_client_ids(1, workers_[i]->getBusClientID());
+    const vector<tmb::client_id> worker_client_ids(1, workers_.back()->getBusClientID());
     worker_directories_.push_back(
         make_unique<WorkerDirectory>(worker_client_ids.size(), worker_client_ids, numa_nodes));
 
+    auto storage_manager = make_unique<StorageManager>(
+        storage_path, getBlockDomain(data_exchangers_[i].network_address()), locator_client_id_, &bus_);
+
+    data_exchangers_[i].set_storage_manager(storage_manager.get());
     shiftbosses_.push_back(
-        make_unique<Shiftboss>(&bus_, test_database_loader_.storage_manager(), worker_directories_[i].get()));
+        make_unique<Shiftboss>(&bus_, storage_manager.get(), worker_directories_.back().get()));
+
+    storage_managers_.push_back(move(storage_manager));
   }
 
   foreman_->start();
 
   for (int i = 0; i < kNumInstances; ++i) {
+    data_exchangers_[i].start();
     shiftbosses_[i]->start();
     workers_[i]->start();
   }
@@ -101,9 +136,9 @@ void DistributedExecutionGeneratorTestRunner::runTestCase(
   VLOG(4) << "Test SQL(s): " << input;
 
   if (options.find(kResetOption) != options.end()) {
-    test_database_loader_.clear();
-    test_database_loader_.createTestRelation(false /* allow_vchar */);
-    test_database_loader_.loadTestRelation();
+    test_database_loader_->clear();
+    test_database_loader_->createTestRelation(false /* allow_vchar */);
+    test_database_loader_->loadTestRelation();
   }
 
   MemStream output_stream;
@@ -125,7 +160,7 @@ void DistributedExecutionGeneratorTestRunner::runTestCase(
       QueryHandle query_handle(query_id_++, cli_id_);
 
       optimizer_.generateQueryHandle(parse_statement,
-                                     test_database_loader_.catalog_database(),
+                                     test_database_loader_->catalog_database(),
                                      &optimizer_context,
                                      &query_handle);
 
@@ -141,11 +176,11 @@ void DistributedExecutionGeneratorTestRunner::runTestCase(
       const CatalogRelation *query_result_relation = query_handle.getQueryResultRelation();
       if (query_result_relation) {
           PrintToScreen::PrintRelation(*query_result_relation,
-                                       test_database_loader_.storage_manager(),
+                                       test_database_loader_->storage_manager(),
                                        output_stream.file());
           DropRelation::Drop(*query_result_relation,
-                             test_database_loader_.catalog_database(),
-                             test_database_loader_.storage_manager());
+                             test_database_loader_->catalog_database(),
+                             test_database_loader_->storage_manager());
       }
     } catch (const SqlError &error) {
       *output = error.formatMessage(input);
@@ -156,6 +191,45 @@ void DistributedExecutionGeneratorTestRunner::runTestCase(
   if (output->empty()) {
     *output = output_stream.str();
   }
+}
+
+block_id_domain DistributedExecutionGeneratorTestRunner::getBlockDomain(
+    const string &network_address) {
+  serialization::BlockDomainRegistrationMessage proto;
+  proto.set_domain_network_address(network_address);
+
+  const int proto_length = proto.ByteSize();
+  char *proto_bytes = static_cast<char*>(malloc(proto_length));
+  CHECK(proto.SerializeToArray(proto_bytes, proto_length));
+
+  TaggedMessage message(static_cast<const void*>(proto_bytes),
+                        proto_length,
+                        kBlockDomainRegistrationMessage);
+  free(proto_bytes);
+
+  DLOG(INFO) << "Client (id '" << cli_id_
+             << "') sent BlockDomainRegistrationMessage (typed '" << kBlockDomainRegistrationMessage
+             << "') to BlockLocator (id '" << locator_client_id_ << "')";
+
+  CHECK(MessageBus::SendStatus::kOK ==
+      QueryExecutionUtil::SendTMBMessage(&bus_,
+                                         cli_id_,
+                                         locator_client_id_,
+                                         move(message)));
+
+  const tmb::AnnotatedMessage annotated_message(bus_.Receive(cli_id_, 0, true));
+  const TaggedMessage &tagged_message = annotated_message.tagged_message;
+  CHECK_EQ(locator_client_id_, annotated_message.sender);
+  CHECK_EQ(kBlockDomainRegistrationResponseMessage, tagged_message.message_type());
+  DLOG(INFO) << "Client (id '" << cli_id_
+             << "') received BlockDomainRegistrationResponseMessage (typed '"
+             << kBlockDomainRegistrationResponseMessage
+             << "') from BlockLocator";
+
+  serialization::BlockDomainMessage response_proto;
+  CHECK(response_proto.ParseFromArray(tagged_message.message(), tagged_message.message_bytes()));
+
+  return static_cast<block_id_domain>(response_proto.block_domain());
 }
 
 }  // namespace optimizer

--- a/storage/DataExchangerAsync.cpp
+++ b/storage/DataExchangerAsync.cpp
@@ -155,11 +155,11 @@ void DataExchangerAsync::run() {
       if (ok) {
         call_context->Proceed();
       } else {
-        LOG(WARNING) << "Not ok\n";
+        LOG(WARNING) << "DataExchangerAsync " << server_address_ << " is not ok";
         delete call_context;
       }
     } else {
-      LOG(INFO) << "Shutdown\n";
+      LOG(INFO) << "DataExchangerAsync " << server_address_ << " shuts down";
       return;
     }
   }


### PR DESCRIPTION
Assigned to @hbdeshmukh. Thanks.

This goal of the distributed unit test is to simulate a distributed query execution engine that uses multiple separate execution sites (`Shiftboss`). In particular, this PR uses `BlockLocator` and `DataExchangerAsync`, to locate all the blocks, and fetch a remote block in an async manner, respectively.

In other words, this PR archives the goal above by enabling that `StorageManager` in `Shiftboss` fetches a remote block from a peer on demand during the query execution.