### PR TITLE
Refine estimates for estimateCardinality for TableReference

### DIFF
--- a/query_optimizer/cost_model/CMakeLists.txt
+++ b/query_optimizer/cost_model/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(quickstep_queryoptimizer_costmodel_CostModel
 target_link_libraries(quickstep_queryoptimizer_costmodel_SimpleCostModel
                       glog
                       quickstep_catalog_CatalogRelation
+                      quickstep_catalog_CatalogRelationStatistics
                       quickstep_queryoptimizer_costmodel_CostModel
                       quickstep_queryoptimizer_physical_Aggregate
                       quickstep_queryoptimizer_physical_HashJoin

--- a/query_optimizer/cost_model/SimpleCostModel.cpp
+++ b/query_optimizer/cost_model/SimpleCostModel.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "catalog/CatalogRelation.hpp"
+#include "catalog/CatalogRelationStatistics.hpp"
 #include "query_optimizer/physical/Aggregate.hpp"
 #include "query_optimizer/physical/NestedLoopsJoin.hpp"
 #include "query_optimizer/physical/HashJoin.hpp"
@@ -92,7 +93,13 @@ std::size_t SimpleCostModel::estimateCardinalityForTopLevelPlan(
 
 std::size_t SimpleCostModel::estimateCardinalityForTableReference(
     const P::TableReferencePtr &physical_plan) {
-  return physical_plan->relation()->estimateTupleCardinality();
+  const std::size_t num_tuples_in_relation =
+      physical_plan->relation()->getStatistics().getNumTuples();
+  if (num_tuples_in_relation == 0) {
+    return physical_plan->relation()->estimateTupleCardinality();
+  } else {
+    return num_tuples_in_relation;
+  }
 }
 
 std::size_t SimpleCostModel::estimateCardinalityForSelection(


### PR DESCRIPTION
- Use exact CatalogRelation statistics in SimpleCostModel's
  estimateCardinality method, whenever stats on that relation are available.

This feature particularly helps in TPC-H Q21 (100 scale factor), in which there are two large hash tables built on the lineitem (cardinality: 600M) table. Such large hash tables leave very little room in the buffer pool for other operators, causing evictions and resulting in a large execution time. 

In the original branch, the estimate for the number of entries in the hash table, as provided by the cost model is 1.09B. After this PR, we can reduce that estimate to 600M. Running Q21 the CloudLab machine, gave the following results: (time in milliseconds).

| Original | After changes | Speed-up |
|----------|---------------|----------|
| 178,787  | 12,043        | 14.85    |