### PR TITLE
Unified WorkOrderCompletionMessage proto.

### DIFF
--- a/query_execution/PolicyEnforcerBase.cpp
+++ b/query_execution/PolicyEnforcerBase.cpp
@@ -45,7 +45,7 @@ void PolicyEnforcerBase::processMessage(const TaggedMessage &tagged_message) {
 
   switch (tagged_message.message_type()) {
     case kWorkOrderCompleteMessage: {
-      serialization::NormalWorkOrderCompletionMessage proto;
+      serialization::WorkOrderCompletionMessage proto;
       // Note: This proto message contains the time it took to execute the
       // WorkOrder. It can be accessed in this scope.
       CHECK(proto.ParseFromArray(tagged_message.message(),
@@ -64,7 +64,7 @@ void PolicyEnforcerBase::processMessage(const TaggedMessage &tagged_message) {
       break;
     }
     case kRebuildWorkOrderCompleteMessage: {
-      serialization::RebuildWorkOrderCompletionMessage proto;
+      serialization::WorkOrderCompletionMessage proto;
       // Note: This proto message contains the time it took to execute the
       // rebuild WorkOrder. It can be accessed in this scope.
       CHECK(proto.ParseFromArray(tagged_message.message(),
@@ -157,7 +157,7 @@ bool PolicyEnforcerBase::admitQueries(
 }
 
 void PolicyEnforcerBase::recordTimeForWorkOrder(
-    const serialization::NormalWorkOrderCompletionMessage &proto) {
+    const serialization::WorkOrderCompletionMessage &proto) {
   const std::size_t query_id = proto.query_id();
   std::vector<WorkOrderTimeEntry> &workorder_time_entries
       = workorder_time_recorder_[query_id];

--- a/query_execution/PolicyEnforcerBase.hpp
+++ b/query_execution/PolicyEnforcerBase.hpp
@@ -38,7 +38,7 @@ namespace quickstep {
 class CatalogDatabaseLite;
 class QueryHandle;
 
-namespace serialization { class NormalWorkOrderCompletionMessage; }
+namespace serialization { class WorkOrderCompletionMessage; }
 
 /** \addtogroup QueryExecution
  *  @{
@@ -165,7 +165,7 @@ class PolicyEnforcerBase {
    *        execution.
    **/
   void recordTimeForWorkOrder(
-      const serialization::NormalWorkOrderCompletionMessage &proto);
+      const serialization::WorkOrderCompletionMessage &proto);
 
   CatalogDatabaseLite *catalog_database_;
 

--- a/query_execution/QueryExecutionMessages.proto
+++ b/query_execution/QueryExecutionMessages.proto
@@ -31,31 +31,21 @@ import "relational_operators/WorkOrder.proto";
 // order completion message, we may be interested in adding the compression
 // ratio or dictionary size of the rebuilt block.
 
-// TODO(harshad) : If there are different fields in the two message types below,
-// create a base message class called WorkOrderCompletionMessage and make the
-// two classes below extend the base class. All the common fields in both the
-// classes can be moved to the base class.
+message WorkOrderCompletionMessage {
+  enum WorkOrderType {
+    NORMAL = 0;
+    REBUILD = 1;
+  }
 
-// A message sent upon completion of a normal (not rebuild) WorkOrder execution.
-message NormalWorkOrderCompletionMessage {
-  required uint64 operator_index = 1;
-  required uint64 worker_thread_index = 2;
-  required uint64 query_id = 3;
+  required WorkOrderType work_order_type = 1;
 
-  // Epoch time in microseconds.
-  optional uint64 execution_start_time = 4;
-  optional uint64 execution_end_time = 5;
-}
-
-// A message sent upon completion of a rebuild WorkOrder execution.
-message RebuildWorkOrderCompletionMessage {
-  required uint64 operator_index = 1;
-  required uint64 worker_thread_index = 2;
-  required uint64 query_id = 3;
+  required uint64 operator_index = 2;
+  required uint64 worker_thread_index = 3;
+  required uint64 query_id = 4;
 
   // Epoch time in microseconds.
-  optional uint64 execution_start_time = 4;
-  optional uint64 execution_end_time = 5;
+  optional uint64 execution_start_time = 5;
+  optional uint64 execution_end_time = 6;
 }
 
 message CatalogRelationNewBlockMessage {

--- a/query_execution/Worker.hpp
+++ b/query_execution/Worker.hpp
@@ -34,6 +34,8 @@ namespace tmb { class TaggedMessge; }
 
 namespace quickstep {
 
+namespace serialization { class WorkOrderCompletionMessage; }
+
 /** \addtogroup QueryExecution
  *  @{
  */
@@ -100,7 +102,6 @@ class Worker : public Thread {
    * @brief A helper method to execute the WorkOrder and construct a
    *        completion message.
    *
-   * @note CompletionMessageProtoT is the type of the completion message.
    * @note Right now a single helper method works for all message types.
    *       If different message types need to collect different statistics for
    *       the WorkOrder execution, we need to create different helper methods,
@@ -108,23 +109,21 @@ class Worker : public Thread {
    *
    * @param tagged_message The TaggedMessage which consists of the WorkOrder.
    * @param proto The proto message to be sent.
+   * @param is_rebuild_work_order Whether it is used for a RebuildWorkOrder.
    **/
-  template <typename CompletionMessageProtoT>
   void executeWorkOrderHelper(const TaggedMessage &tagged_message,
-                              CompletionMessageProtoT *proto);
+                              serialization::WorkOrderCompletionMessage *proto,
+                              const bool is_rebuild_work_order = false);
 
   /**
    * @brief A helper method to send the WorkOrder completion message.
-   *
-   * @note CompletionMessageProtoT is the type of the completion message.
    *
    * @param receiver The TMB client ID of the receiver.
    * @param proto The proto message to be sent.
    * @param message_type The ID of the type of the message being sent.
    **/
-  template <typename CompletionMessageProtoT>
   void sendWorkOrderCompleteMessage(const tmb::client_id receiver,
-                                    const CompletionMessageProtoT &proto,
+                                    const serialization::WorkOrderCompletionMessage &proto,
                                     const message_type_id message_type);
 
   const std::size_t worker_thread_index_;


### PR DESCRIPTION
Assigned to @hbdeshmukh.

This PR combined `WorkOrderCompletionMessage` for both normal and rebuild work orders. And it is required for the distributed version to refactor `PolicyEnforcerBase::decrementNumQueuedWorkOrders` to use `WorkOrderCompletionMessage` as the argument instead.