### PR TITLE
Added an util method to get the ip address.

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -15,6 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+if (BUILD_SHARED_LIBS)
+  set(GFLAGS_LIB_NAME gflags_nothreads-shared)
+else()
+  set(GFLAGS_LIB_NAME gflags_nothreads-static)
+endif()
+
 include(CheckCXXSourceCompiles)
 
 # Look for GCC-style builtins (also in clang, ICC, and possibly others) that
@@ -180,6 +186,7 @@ add_library(quickstep_utility_Glob Glob.cpp Glob.hpp)
 add_library(quickstep_utility_HashPair ../empty_src.cpp HashPair.hpp)
 add_library(quickstep_utility_Macros ../empty_src.cpp Macros.hpp)
 add_library(quickstep_utility_MemStream ../empty_src.cpp MemStream.hpp)
+add_library(quickstep_utility_NetworkUtil NetworkUtil.cpp NetworkUtil.hpp)
 add_library(quickstep_utility_PlanVisualizer PlanVisualizer.cpp PlanVisualizer.hpp)
 add_library(quickstep_utility_PrimeNumber PrimeNumber.cpp PrimeNumber.hpp)
 add_library(quickstep_utility_PtrList ../empty_src.cpp PtrList.hpp)
@@ -257,6 +264,9 @@ target_link_libraries(quickstep_utility_Glob
 target_link_libraries(quickstep_utility_MemStream
                       glog
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_utility_NetworkUtil
+                      glog
+                      ${GFLAGS_LIB_NAME})
 target_link_libraries(quickstep_utility_PrimeNumber
                       glog)
 target_link_libraries(quickstep_utility_PlanVisualizer
@@ -339,6 +349,7 @@ target_link_libraries(quickstep_utility
                       quickstep_utility_HashPair
                       quickstep_utility_Macros
                       quickstep_utility_MemStream
+                      quickstep_utility_NetworkUtil
                       quickstep_utility_PlanVisualizer
                       quickstep_utility_PrimeNumber
                       quickstep_utility_PtrList
@@ -403,6 +414,15 @@ target_link_libraries(EqualsAnyConstant_unittest
                       quickstep_utility_EqualsAnyConstant
                       ${LIBS})
 add_test(EqualsAnyConstant_unittest EqualsAnyConstant_unittest)
+
+add_executable(NetworkUtil_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/NetworkUtil_unittest.cpp")
+target_link_libraries(NetworkUtil_unittest
+                      gtest
+                      gtest_main
+                      quickstep_utility_NetworkUtil
+                      ${GFLAGS_LIB_NAME}
+                      ${LIBS})
+add_test(NetworkUtil_unittest NetworkUtil_unittest)
 
 add_executable(PrimeNumber_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/PrimeNumber_unittest.cpp")
 target_link_libraries(PrimeNumber_unittest

--- a/utility/NetworkUtil.cpp
+++ b/utility/NetworkUtil.cpp
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "utility/NetworkUtil.hpp"
+
+#include "utility/UtilityConfig.h"  // For QUICKSTEP_HAVE_WINDOWS.
+
+#ifndef QUICKSTEP_HAVE_WINDOWS
+#include <arpa/inet.h>
+#include <net/if.h>  // Need to include before <ifaddrs.h> for NetBSD.
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+
+#include <cstring>
+#endif  // QUICKSTEP_HAVE_WINDOWS
+
+#include <string>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+namespace quickstep {
+
+DEFINE_bool(use_ethernet_ip, false,
+            "Use the Ethernet ip address, instead of the loopback.");
+
+std::string GetIpv4Address() {
+#ifndef QUICKSTEP_HAVE_WINDOWS
+  struct ifaddrs *ifaddrs;
+  CHECK_EQ(0, getifaddrs(&ifaddrs));
+
+  char ip_address[NI_MAXHOST] = { '\0' };
+
+  for (struct ifaddrs *ifa = ifaddrs; ifa; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr ||
+        ifa->ifa_addr->sa_family != AF_INET ||
+        (ifa->ifa_flags & IFF_UP) == 0) {
+      continue;
+    }
+
+    if (FLAGS_use_ethernet_ip && !std::strncmp(ifa->ifa_name, "lo", 2)) {
+      // NOTE: On Linux it starts with 'eth', while on Mac OS X, 'en'.
+      continue;
+    }
+
+    struct sockaddr_in *s4 = (struct sockaddr_in *)(ifa->ifa_addr);
+    CHECK(inet_ntop(AF_INET, reinterpret_cast<void *>(&(s4->sin_addr)), ip_address, sizeof(ip_address)) != nullptr);
+    break;
+  }
+
+  freeifaddrs(ifaddrs);
+
+  return ip_address;
+#else
+  CHECK(!FLAGS_use_ethernet_ip);
+  return kLocalIpv4Address;
+#endif  // QUICKSTEP_HAVE_WINDOWS
+}
+
+}  // namespace quickstep

--- a/utility/NetworkUtil.hpp
+++ b/utility/NetworkUtil.hpp
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_UTILITY_NETWORK_UTIL_HPP_
+#define QUICKSTEP_UTILITY_NETWORK_UTIL_HPP_
+
+#include <string>
+
+namespace quickstep {
+
+/** \addtogroup Utility
+ *  @{
+ */
+
+constexpr char kLocalIpv4Address[] = "127.0.0.1";
+
+/**
+ * @brief Get the IPv4 network address in the text format, i.e., "127.0.0.1".
+ */
+extern std::string GetIpv4Address();
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_UTILITY_NETWORK_UTIL_HPP_

--- a/utility/tests/NetworkUtil_unittest.cpp
+++ b/utility/tests/NetworkUtil_unittest.cpp
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <string>
+
+#include "utility/NetworkUtil.hpp"
+
+#include "gflags/gflags_declare.h"
+#include "gtest/gtest.h"
+
+using std::string;
+
+namespace quickstep {
+
+DECLARE_bool(use_ethernet_ip);
+
+TEST(NetworkUtilTest, LoopbackTest) {
+  string lo_ip_address = GetIpv4Address();
+  EXPECT_STREQ(kLocalIpv4Address, lo_ip_address.c_str());
+}
+
+TEST(NetworkUtilTest, EthernetTest) {
+  FLAGS_use_ethernet_ip = true;
+  string ethernet_ip_address = GetIpv4Address();
+  EXPECT_STRNE(kLocalIpv4Address, ethernet_ip_address.c_str());
+}
+
+}  // namespace quickstep


### PR DESCRIPTION
This PR provides a method to get the ip address of the host machine. It will be used by `DataExchanger` in the distributed version.

Note that this util method does not have a `WINDOWS` implementation yet.