### PR TITLE
Decrement num queued work orders.

### DIFF
--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -160,6 +160,7 @@ target_link_libraries(quickstep_queryexecution_PolicyEnforcerSingleNode
                       glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_PolicyEnforcerBase
+                      quickstep_queryexecution_QueryExecutionMessages_proto
                       quickstep_queryexecution_QueryExecutionState
                       quickstep_queryexecution_QueryManagerBase
                       quickstep_queryexecution_QueryManagerSingleNode

--- a/query_execution/PolicyEnforcerBase.cpp
+++ b/query_execution/PolicyEnforcerBase.cpp
@@ -50,7 +50,7 @@ void PolicyEnforcerBase::processMessage(const TaggedMessage &tagged_message) {
       // WorkOrder. It can be accessed in this scope.
       CHECK(proto.ParseFromArray(tagged_message.message(),
                                  tagged_message.message_bytes()));
-      decrementNumQueuedWorkOrders(proto.worker_thread_index());
+      decrementNumQueuedWorkOrders(proto);
 
       if (profile_individual_workorders_) {
         recordTimeForWorkOrder(proto);
@@ -69,7 +69,7 @@ void PolicyEnforcerBase::processMessage(const TaggedMessage &tagged_message) {
       // rebuild WorkOrder. It can be accessed in this scope.
       CHECK(proto.ParseFromArray(tagged_message.message(),
                                  tagged_message.message_bytes()));
-      decrementNumQueuedWorkOrders(proto.worker_thread_index());
+      decrementNumQueuedWorkOrders(proto);
 
       query_id = proto.query_id();
       DCHECK(admitted_queries_.find(query_id) != admitted_queries_.end());

--- a/query_execution/PolicyEnforcerBase.hpp
+++ b/query_execution/PolicyEnforcerBase.hpp
@@ -196,9 +196,11 @@ class PolicyEnforcerBase {
   /**
    * @brief Decrement the number of queued workorders for the given worker by 1.
    *
-   * @param worker_index The logical ID of the given worker.
+   * @param proto The completion message proto received after the WorkOrder
+   *        execution.
    **/
-  virtual void decrementNumQueuedWorkOrders(const std::size_t worker_index) = 0;
+  virtual void decrementNumQueuedWorkOrders(
+      const serialization::WorkOrderCompletionMessage &proto) = 0;
 
   DISALLOW_COPY_AND_ASSIGN(PolicyEnforcerBase);
 };

--- a/query_execution/PolicyEnforcerDistributed.hpp
+++ b/query_execution/PolicyEnforcerDistributed.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "query_execution/PolicyEnforcerBase.hpp"
+#include "query_execution/QueryExecutionMessages.pb.h"
 #include "query_execution/ShiftbossDirectory.hpp"
 #include "utility/Macros.hpp"
 
@@ -89,8 +90,8 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
   void processInitiateRebuildResponseMessage(const tmb::TaggedMessage &tagged_message);
 
  private:
-  void decrementNumQueuedWorkOrders(const std::size_t shiftboss_index) override {
-    shiftboss_directory_->decrementNumQueuedWorkOrders(shiftboss_index);
+  void decrementNumQueuedWorkOrders(const serialization::WorkOrderCompletionMessage &proto) override {
+    shiftboss_directory_->decrementNumQueuedWorkOrders(proto.shiftboss_index());
   }
 
   void onQueryCompletion(QueryManagerBase *query_manager) override;

--- a/query_execution/PolicyEnforcerSingleNode.cpp
+++ b/query_execution/PolicyEnforcerSingleNode.cpp
@@ -108,8 +108,4 @@ bool PolicyEnforcerSingleNode::admitQuery(QueryHandle *query_handle) {
   }
 }
 
-void PolicyEnforcerSingleNode::decrementNumQueuedWorkOrders(const std::size_t worker_index) {
-  worker_directory_->decrementNumQueuedWorkOrders(worker_index);
-}
-
 }  // namespace quickstep

--- a/query_execution/PolicyEnforcerSingleNode.hpp
+++ b/query_execution/PolicyEnforcerSingleNode.hpp
@@ -25,6 +25,8 @@
 #include <vector>
 
 #include "query_execution/PolicyEnforcerBase.hpp"
+#include "query_execution/QueryExecutionMessages.pb.h"
+#include "query_execution/WorkerDirectory.hpp"
 #include "utility/Macros.hpp"
 
 #include "tmb/id_typedefs.h"
@@ -36,7 +38,6 @@ namespace quickstep {
 class CatalogDatabaseLite;
 class QueryHandle;
 class StorageManager;
-class WorkerDirectory;
 class WorkerMessage;
 
 /** \addtogroup QueryExecution
@@ -89,7 +90,9 @@ class PolicyEnforcerSingleNode final : public PolicyEnforcerBase {
       std::vector<std::unique_ptr<WorkerMessage>> *worker_messages);
 
  private:
-  void decrementNumQueuedWorkOrders(const std::size_t worker_index) override;
+  void decrementNumQueuedWorkOrders(const serialization::WorkOrderCompletionMessage &proto) override {
+    worker_directory_->decrementNumQueuedWorkOrders(proto.worker_thread_index());
+  }
 
   const tmb::client_id foreman_client_id_;
   const std::size_t num_numa_nodes_;

--- a/query_execution/QueryExecutionMessages.proto
+++ b/query_execution/QueryExecutionMessages.proto
@@ -46,6 +46,9 @@ message WorkOrderCompletionMessage {
   // Epoch time in microseconds.
   optional uint64 execution_start_time = 5;
   optional uint64 execution_end_time = 6;
+
+  // Required in the distributed version.
+  optional uint64 shiftboss_index = 7;
 }
 
 message CatalogRelationNewBlockMessage {

--- a/query_execution/QueryExecutionTypedefs.hpp
+++ b/query_execution/QueryExecutionTypedefs.hpp
@@ -79,7 +79,8 @@ enum QueryExecutionMessageType : message_type_id {
 
 #ifdef QUICKSTEP_DISTRIBUTED
   kShiftbossRegistrationMessage,  // From Shiftboss to Foreman.
-  kShiftbossRegistrationResponseMessage,  // From Foreman to Shiftboss.
+  kShiftbossRegistrationResponseMessage,  // From Foreman to Shiftboss, or from
+                                          // Shiftboss to Worker.
   kQueryInitiateMessage,  // From Foreman to Shiftboss.
   kQueryInitiateResponseMessage,  // From Shiftboss to Foreman.
 

--- a/query_execution/Shiftboss.cpp
+++ b/query_execution/Shiftboss.cpp
@@ -273,7 +273,7 @@ void Shiftboss::registerWithForeman() {
 }
 
 void Shiftboss::processShiftbossRegistrationResponseMessage() {
-  const AnnotatedMessage annotated_message(bus_->Receive(shiftboss_client_id_, 0, true));
+  AnnotatedMessage annotated_message(bus_->Receive(shiftboss_client_id_, 0, true));
   const TaggedMessage &tagged_message = annotated_message.tagged_message;
   DCHECK_EQ(kShiftbossRegistrationResponseMessage, tagged_message.message_type());
 
@@ -286,6 +286,12 @@ void Shiftboss::processShiftbossRegistrationResponseMessage() {
   CHECK(proto.ParseFromArray(tagged_message.message(), tagged_message.message_bytes()));
 
   shiftboss_index_ = proto.shiftboss_index();
+
+  // Forward this message to Workers regarding <shiftboss_index_>.
+  QueryExecutionUtil::BroadcastMessage(shiftboss_client_id_,
+                                       worker_addresses_,
+                                       move(annotated_message.tagged_message),
+                                       bus_);
 }
 
 void Shiftboss::processQueryInitiateMessage(

--- a/query_execution/Shiftboss.hpp
+++ b/query_execution/Shiftboss.hpp
@@ -102,6 +102,7 @@ class Shiftboss : public Thread {
     bus_->RegisterClientAsSender(shiftboss_client_id_, kSaveQueryResultResponseMessage);
 
     // Message sent to Worker.
+    bus_->RegisterClientAsSender(shiftboss_client_id_, kShiftbossRegistrationResponseMessage);
     bus_->RegisterClientAsSender(shiftboss_client_id_, kRebuildWorkOrderMessage);
 
     // Forward the following message types from Foreman to Workers.

--- a/query_execution/Worker.hpp
+++ b/query_execution/Worker.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 
 #include "query_execution/QueryExecutionTypedefs.hpp"
+#include "query_optimizer/QueryOptimizerConfig.h"  // For QUICKSTEP_DISTRIBUTED.
 #include "threading/Thread.hpp"
 #include "utility/Macros.hpp"
 
@@ -75,6 +76,10 @@ class Worker : public Thread {
     bus_->RegisterClientAsReceiver(worker_client_id_, kWorkOrderMessage);
     bus_->RegisterClientAsReceiver(worker_client_id_, kRebuildWorkOrderMessage);
     bus_->RegisterClientAsReceiver(worker_client_id_, kPoisonMessage);
+
+#ifdef QUICKSTEP_DISTRIBUTED
+    bus_->RegisterClientAsReceiver(worker_client_id_, kShiftbossRegistrationResponseMessage);
+#endif  // QUICKSTEP_DISTRIBUTED
   }
 
   ~Worker() override {}
@@ -131,6 +136,10 @@ class Worker : public Thread {
 
   const int cpu_id_;
   client_id worker_client_id_;
+
+#ifdef QUICKSTEP_DISTRIBUTED
+  std::size_t shiftboss_index_;
+#endif  // QUICKSTEP_DISTRIBUTED
 
   DISALLOW_COPY_AND_ASSIGN(Worker);
 };


### PR DESCRIPTION
Do not merge until #131 is merged.

This PR allows both the single-node and the distributed version to count `WorkOrder` in the different levels: per worker thread and per `Shiftboss` (or an execution site), respectively.