### PR TITLE
Ethernet data exchanger.

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -625,6 +625,7 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_storage_StorageManager
                         quickstep_threading_Thread
                         quickstep_utility_Macros
+                        quickstep_utility_NetworkUtil
                         ${GRPCPLUSPLUS_LIBRARIES})
 endif()
 

--- a/storage/DataExchangerAsync.cpp
+++ b/storage/DataExchangerAsync.cpp
@@ -28,6 +28,7 @@
 #include "storage/DataExchange.grpc.pb.h"
 #include "storage/DataExchange.pb.h"
 #include "storage/StorageManager.hpp"
+#include "utility/NetworkUtil.hpp"
 
 #include "glog/logging.h"
 
@@ -127,18 +128,18 @@ void CallContext::Proceed() {
 
 }  // namespace
 
-const char *DataExchangerAsync::kLocalNetworkAddress = "0.0.0.0:";
-
 DataExchangerAsync::DataExchangerAsync() {
+  const std::string ipv4_address(GetIpv4Address() + ':');
+
   grpc::ServerBuilder builder;
-  builder.AddListeningPort(kLocalNetworkAddress, grpc::InsecureServerCredentials(), &port_);
+  builder.AddListeningPort(ipv4_address, grpc::InsecureServerCredentials(), &port_);
   builder.RegisterService(&service_);
 
   queue_ = builder.AddCompletionQueue();
   server_ = builder.BuildAndStart();
 
   DCHECK_GT(port_, 0);
-  server_address_ = kLocalNetworkAddress + std::to_string(port_);
+  server_address_ = ipv4_address + std::to_string(port_);
   LOG(INFO) << "DataExchangerAsync Service listening on " << server_address_;
 }
 

--- a/storage/DataExchangerAsync.hpp
+++ b/storage/DataExchangerAsync.hpp
@@ -79,8 +79,6 @@ class DataExchangerAsync final : public Thread {
   void run() override;
 
  private:
-  static const char *kLocalNetworkAddress;
-
   DataExchange::AsyncService service_;
 
   int port_ = -1;


### PR DESCRIPTION
Do not merge until #132 is in.

This PR allows the `DataExchanger` to use the actual ip address, instead of the local `0.0.0.0`.