### PR TITLE
Refactor Shiftboss for better debug info.

### DIFF
--- a/query_execution/Shiftboss.hpp
+++ b/query_execution/Shiftboss.hpp
@@ -191,6 +191,8 @@ class Shiftboss : public Thread {
  private:
   void registerWithForeman();
 
+  void processShiftbossRegistrationResponseMessage();
+
   /**
    * @brief Process the Shiftboss initiate message and ack back.
    *


### PR DESCRIPTION
This PR also adds a new method `processShiftbossRegistrationResponseMessage` to handle the message once at the start-up time.