### PR TITLE
Maintained the catalog filename as a constant.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -190,15 +190,11 @@ number of jobs).
 Running Quickstep
 -----------------
 
-To use quickstep, just run `quickstep_cli_shell` in the build directory.
+To use quickstep, just run `quickstep_cli_shell` in the build directory. For the
+first time user, run once with `-initialize_db=true` to set up an empty catalog.
 Quickstep has number of command-line flags that control its behavior. Run
 `quickstep_cli_shell --help` to see a listing of the options and how to use
 them.
-
-The provided build directory has a skeleton qsstor directory with a fresh
-catalog.pb.bin file which is needed to run `quickstep_cli_shell`. If you want
-to wipe out your database and start fresh, delete all the files in qsstor and
-copy `catalog.pb.bin.orig` to `qsstor/catalog.pb.bin`.
 
 Running Tests
 -------------

--- a/cli/QuickstepCli.cpp
+++ b/cli/QuickstepCli.cpp
@@ -125,6 +125,7 @@ using quickstep::Worker;
 using quickstep::WorkerDirectory;
 using quickstep::WorkerMessage;
 using quickstep::kAdmitRequestMessage;
+using quickstep::kCatalogFilename;
 using quickstep::kPoisonMessage;
 using quickstep::kWorkloadCompletionMessage;
 
@@ -243,7 +244,7 @@ int main(int argc, char* argv[]) {
   quickstep::StorageManager storage_manager(fixed_storage_path);
 
   string catalog_path(fixed_storage_path);
-  catalog_path.append("catalog.pb.bin");
+  catalog_path.append(kCatalogFilename);
   if (quickstep::FLAGS_initialize_db) {  // Initialize the database
     // TODO(jmp): Refactor the code in this file!
     LOG(INFO) << "Initializing the database, creating a new catalog file and storage directory\n";
@@ -267,14 +268,14 @@ int main(int argc, char* argv[]) {
     // Create the default catalog file.
     std::ofstream catalog_file(catalog_path);
     if (!catalog_file.good()) {
-      LOG(FATAL) << "ERROR: Unable to open catalog.pb.bin for writing.\n";
+      LOG(FATAL) << "ERROR: Unable to open " << kCatalogFilename << " for writing.\n";
     }
 
     quickstep::Catalog catalog;
     catalog.addDatabase(new quickstep::CatalogDatabase(nullptr, "default"));
 
     if (!catalog.getProto().SerializeToOstream(&catalog_file)) {
-      LOG(FATAL) << "ERROR: Unable to serialize catalog proto to file catalog.pb.bin\n";
+      LOG(FATAL) << "ERROR: Unable to serialize catalog proto to file " << kCatalogFilename;
       return 1;
     }
 

--- a/storage/StorageConstants.hpp
+++ b/storage/StorageConstants.hpp
@@ -39,6 +39,8 @@ constexpr char kPathSeparator = '/';
 constexpr char kDefaultStoragePath[] = "qsstor/";
 #endif
 
+constexpr char kCatalogFilename[] = "catalog.pb.bin";
+
 // Size of a memory slot managed by the StorageManager. This is the smallest
 // quantum of allocation for StorageBlocks and StorageBlobs. 2 MB is the large
 // page size on x86.


### PR DESCRIPTION
This small PR keeps the catalog filename as a constant, so that Clis in the single-node and the distributed version could share it.