### PR TITLE
Transferred the ownership of QueryHandle to QueryManager.

### DIFF
--- a/query_execution/QueryManagerBase.hpp
+++ b/query_execution/QueryManagerBase.hpp
@@ -26,6 +26,7 @@
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "query_execution/QueryExecutionState.hpp"
+#include "query_optimizer/QueryHandle.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/StorageBlockInfo.hpp"
@@ -33,8 +34,6 @@
 #include "utility/Macros.hpp"
 
 namespace quickstep {
-
-class QueryHandle;
 
 /** \addtogroup QueryExecution
  *  @{
@@ -77,7 +76,7 @@ class QueryManagerBase {
    * @brief Get the query handle.
    **/
   const QueryHandle* query_handle() const {
-    return query_handle_;
+    return query_handle_.get();
   }
 
   /**
@@ -259,7 +258,7 @@ class QueryManagerBase {
     return query_exec_state_->hasRebuildInitiated(index);
   }
 
-  const QueryHandle *query_handle_;
+  std::unique_ptr<QueryHandle> query_handle_;
 
   const std::size_t query_id_;
 

--- a/query_execution/tests/QueryManagerSingleNode_unittest.cpp
+++ b/query_execution/tests/QueryManagerSingleNode_unittest.cpp
@@ -234,14 +234,14 @@ class QueryManagerTest : public ::testing::Test {
     db_.reset(new CatalogDatabase(nullptr /* catalog */, "database"));
     storage_manager_.reset(new StorageManager("./"));
     bus_.Initialize();
-    query_handle_.reset(new QueryHandle(0 /* dummy query ID */, tmb::kClientIdNone /* cli_id */));
+    query_handle_ = new QueryHandle(0 /* dummy query ID */, tmb::kClientIdNone /* cli_id */);
     query_plan_ = query_handle_->getQueryPlanMutable();
     query_handle_->getQueryContextProtoMutable()->set_query_id(query_handle_->query_id());
   }
 
   inline void constructQueryManager() {
     query_manager_.reset(new QueryManagerSingleNode(
-        0, 1, query_handle_.get(), db_.get(), storage_manager_.get(), &bus_));
+        0, 1, query_handle_, db_.get(), storage_manager_.get(), &bus_));
   }
 
   inline const int getNumWorkOrdersInExecution(const QueryPlan::DAGNodeIndex index) const {
@@ -291,8 +291,8 @@ class QueryManagerTest : public ::testing::Test {
   unique_ptr<CatalogDatabase> db_;
   unique_ptr<StorageManager> storage_manager_;
 
-  QueryPlan *query_plan_;
-  unique_ptr<QueryHandle> query_handle_;
+  QueryPlan *query_plan_;  // Owned by 'query_handle_'.
+  QueryHandle* query_handle_;  // Owned by 'query_manager_'.
   unique_ptr<QueryManagerSingleNode> query_manager_;
 
   MessageBusImpl bus_;


### PR DESCRIPTION
This PR allows the `QueryManager` to take over `QueryHandle` during the query execution, thus it is easier for the distributed version to execute the concurrent queries w/o worrying about the ownership of each `QueryHandle`.