### PR TITLE
Marked SingleNodeQuery for Insertions.

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -1096,6 +1096,9 @@ void ExecutionGenerator::convertDropTable(
 void ExecutionGenerator::convertInsertTuple(
     const P::InsertTuplePtr &physical_plan) {
   // InsertTuple is converted to an Insert and a SaveBlocks.
+#ifdef QUICKSTEP_DISTRIBUTED
+  query_handle_->set_is_single_node_query();
+#endif  // QUICKSTEP_DISTRIBUTED
 
   const CatalogRelationInfo *input_relation_info =
       findRelationInfoOutputByPhysical(physical_plan->input());


### PR DESCRIPTION
This PR avoids the following incorrect situation:

 1. An insert query has executed on Node 0, so the affected block is in the buffer pool.
 1. Another insert query on the same relation as above is supposed to be scheduled on Node 1, which will pull the block from Node 0, and do the insertion.
 1. A select query on the same relation may be scheduled on Node 0, but will miss the tuples inserted on Node 1.

