### PR TITLE
QUICKSTEP-65 Fix Quickstep build failure on Mac OSX 10.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,25 @@ else()
     endif()
   endif()
 
+  # OSX 10.12 has deprecated certain system-level APIs which causes protobuf & glog
+  # builds to fail. As a short-term workaround for now, we turn off deprecated
+  # warnings so that they do not cause build failures anymore.
+  # TODO: Remove this workaround by fixing the protobuf_cmake and glog_cmake.
+  if (${CMAKE_SYSTEM} MATCHES "Darwin-16.1.0")
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+      CHECK_CXX_COMPILER_FLAG("-Wno-error=deprecated-declarations" COMPILER_HAS_WNO_DEPRECATED)
+      if (COMPILER_HAS_WNO_DEPRECATED)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
+      endif()
+    endif()
+    if(CMAKE_COMPILER_IS_GNUCXX)
+      CHECK_CXX_COMPILER_FLAG("-Wno-deprecated-declarations" COMPILER_HAS_WNO_DEPRECATED)
+      if (COMPILER_HAS_WNO_DEPRECATED)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+      endif()
+    endif()
+  endif()
+
   # One of the protobuf headers includes a nested anonymous union within
   # another anonymous type. Ordinarily we work around this by compiling the
   # protobuf libraries themselves with "-Wno-nested-anon-types" and including


### PR DESCRIPTION
Quickstep build on Mac OSX 10.12 fails due to deprecation of certain system APIs in the new OSX version. The Quickstep code does not rely on these deprecated APIs, but it is the protobuf library which uses these deprecated APIs. [See: https://github.com/google/protobuf/issues/2182]
Although, this has been resolved in the latest master of protobuf [See: https://github.com/google/protobuf/pull/2337], Quickstep protobuf cmake integration file has to be updated resolve this.
As this is turning out to be a blocker for the dev environment, this JIRA proposes a quick short-term fix for this issue by specifically turning off deprecation errors on OSX 10.12 platform. The more stable long-term fix would be to port the protobuf_cmake to the newest protobuf version. However, that requires some non-trivial effort and will be done through a separate JIRA.