### PR TITLE
Quickstep-63 Fix PlanVisualizer's crashes on physical plans unsupported by StarSchemaSimpleCostModel.

### DIFF
--- a/query_optimizer/cost_model/CostModel.hpp
+++ b/query_optimizer/cost_model/CostModel.hpp
@@ -21,6 +21,8 @@
 #define QUERY_OPTIMIZER_COST_MODEL_COST_MODEL_HPP_
 
 #include <cstddef>
+#include <exception>
+#include <string>
 
 #include "query_optimizer/physical/Aggregate.hpp"
 #include "query_optimizer/physical/Physical.hpp"
@@ -33,6 +35,32 @@ namespace cost {
 /** \addtogroup CostModel
  *  @{
  */
+
+/**
+ * @brief Exception thrown for unsupported physical plan.
+ **/
+class UnsupportedPhysicalPlan : public std::exception {
+ public:
+  /**
+   * @brief Constructor.
+   *
+   * @param physical_plan The physical plan that is not supported by the cost
+   *        model.
+   **/
+  explicit UnsupportedPhysicalPlan(const physical::PhysicalPtr &physical_plan)
+      : message_("UnsupportedPhysicalPlan: \n" + physical_plan->toString()) {
+  }
+
+  ~UnsupportedPhysicalPlan() throw() {
+  }
+
+  virtual const char* what() const throw() {
+    return message_.c_str();
+  }
+
+ private:
+  std::string message_;
+};
 
 /**
  * @brief Interface to a cost model of physical plans.

--- a/query_optimizer/cost_model/SimpleCostModel.cpp
+++ b/query_optimizer/cost_model/SimpleCostModel.cpp
@@ -24,6 +24,7 @@
 
 #include "catalog/CatalogRelation.hpp"
 #include "catalog/CatalogRelationStatistics.hpp"
+#include "query_optimizer/cost_model/CostModel.hpp"
 #include "query_optimizer/physical/Aggregate.hpp"
 #include "query_optimizer/physical/NestedLoopsJoin.hpp"
 #include "query_optimizer/physical/HashJoin.hpp"
@@ -82,7 +83,7 @@ std::size_t SimpleCostModel::estimateCardinality(
       return estimateCardinalityForWindowAggregate(
           std::static_pointer_cast<const P::WindowAggregate>(physical_plan));
     default:
-      LOG(FATAL) << "Unsupported physical plan:" << physical_plan->toString();
+      throw UnsupportedPhysicalPlan(physical_plan);
   }
 }
 

--- a/query_optimizer/cost_model/StarSchemaSimpleCostModel.cpp
+++ b/query_optimizer/cost_model/StarSchemaSimpleCostModel.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
+#include "query_optimizer/cost_model/CostModel.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/ComparisonExpression.hpp"
 #include "query_optimizer/expressions/ExprId.hpp"
@@ -93,7 +94,7 @@ std::size_t StarSchemaSimpleCostModel::estimateCardinality(
       return estimateCardinalityForWindowAggregate(
           std::static_pointer_cast<const P::WindowAggregate>(physical_plan));
     default:
-      LOG(FATAL) << "Unsupported physical plan:" << physical_plan->toString();
+      throw UnsupportedPhysicalPlan(physical_plan);
   }
 }
 


### PR DESCRIPTION
`PlanVisualizer` would result in crashes on some queries (i.e., `CreateTable`) which do not have corresponding physical plan support in `StarSchemaSimpleCostModel::estimateCardinality`.

This PR fixes this problem by:
(1) Let the cost models throw `UnsupportedPhysicalPlan` exception for unsupported plans.
(2) `PlanVisualizer` simply catches the exceptions and omits the cardinality info for unsupported physical nodes.

Assigned to @zuyu 