### PR TITLE
Fixed the distributed unit test failures in resetting exactness for InsertSelect.

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -1243,7 +1243,7 @@ void ExecutionGenerator::convertInsertSelection(
   insert_destination_proto->set_relational_op_index(insert_selection_index);
 
   CatalogRelation *mutable_relation =
-      catalog_database_->getRelationByIdMutable(selection_relation->getID());
+      catalog_database_->getRelationByIdMutable(destination_relation.getID());
   const QueryPlan::DAGNodeIndex save_blocks_index =
       execution_plan_->addRelationalOperator(
           new SaveBlocksOperator(query_handle_->query_id(), mutable_relation));

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -61,9 +61,9 @@ class SaveBlocksOperator : public RelationalOperator {
    * @param force If true, force writing of all blocks to disk, otherwise only
    *        write dirty blocks.
    **/
-  explicit SaveBlocksOperator(const std::size_t query_id,
-                              CatalogRelation *relation,
-                              const bool force = false)
+  SaveBlocksOperator(const std::size_t query_id,
+                     CatalogRelation *relation,
+                     const bool force = false)
       : RelationalOperator(query_id),
         force_(force),
         relation_(relation),


### PR DESCRIPTION
Fixed the distributed unit test failures introduced in #155.

Assigned to @jianqiao.