### PR TITLE
Refactored the method to reconstruct PartitionSchemeHeader.

### DIFF
--- a/catalog/CMakeLists.txt
+++ b/catalog/CMakeLists.txt
@@ -168,6 +168,9 @@ target_link_libraries(quickstep_catalog_PartitionSchemeHeader
                       glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_Catalog_proto
+                      quickstep_types_Type
+                      quickstep_types_TypeFactory
+                      quickstep_types_Type_proto
                       quickstep_types_TypedValue
                       quickstep_types_TypedValue_proto
                       quickstep_types_operations_comparisons_Comparison

--- a/catalog/Catalog.proto
+++ b/catalog/Catalog.proto
@@ -49,7 +49,8 @@ message PartitionSchemeHeader {
 message RangePartitionSchemeHeader {
   extend PartitionSchemeHeader {
     // All required.
-    repeated TypedValue partition_range_boundaries = 32;
+    optional Type partition_attr_type = 32;
+    repeated TypedValue partition_range_boundaries = 33;
   }
 }
 

--- a/catalog/CatalogRelation.cpp
+++ b/catalog/CatalogRelation.cpp
@@ -43,8 +43,6 @@
 
 namespace quickstep {
 
-class Type;
-
 bool CatalogRelation::ProtoIsValid(const serialization::CatalogRelationSchema &proto) {
   // Check that proto is fully initialized.
   if (!CatalogRelationSchema::ProtoIsValid(proto) ||
@@ -90,11 +88,9 @@ CatalogRelation::CatalogRelation(const serialization::CatalogRelationSchema &pro
     const serialization::PartitionScheme &proto_partition_scheme =
         proto.GetExtension(serialization::CatalogRelation::partition_scheme);
 
-    const attribute_id partition_attribute_id = proto_partition_scheme.header().partition_attribute_id();
-    DCHECK(hasAttributeWithId(partition_attribute_id));
-    const Type &attr_type = attr_vec_[partition_attribute_id].getType();
+    DCHECK(hasAttributeWithId(proto_partition_scheme.header().partition_attribute_id()));
 
-    setPartitionScheme(PartitionScheme::ReconstructFromProto(proto_partition_scheme, attr_type));
+    setPartitionScheme(PartitionScheme::ReconstructFromProto(proto_partition_scheme));
 
     // Deserializing the NUMA placement scheme for the relation.
 #ifdef QUICKSTEP_HAVE_LIBNUMA

--- a/catalog/PartitionScheme.cpp
+++ b/catalog/PartitionScheme.cpp
@@ -55,8 +55,7 @@ bool PartitionScheme::ProtoIsValid(
   return true;
 }
 
-PartitionScheme* PartitionScheme::ReconstructFromProto(const serialization::PartitionScheme &proto,
-                                                       const Type &attr_type) {
+PartitionScheme* PartitionScheme::ReconstructFromProto(const serialization::PartitionScheme &proto) {
   DCHECK(ProtoIsValid(proto))
       << "Attempted to create PartitionScheme from an invalid proto description:\n"
       << proto.DebugString();
@@ -74,7 +73,7 @@ PartitionScheme* PartitionScheme::ReconstructFromProto(const serialization::Part
   }
 
   return new PartitionScheme(
-      PartitionSchemeHeader::ReconstructFromProto(proto.header(), attr_type),
+      PartitionSchemeHeader::ReconstructFromProto(proto.header()),
       move(blocks_in_partition));
 }
 

--- a/catalog/PartitionScheme.hpp
+++ b/catalog/PartitionScheme.hpp
@@ -39,8 +39,6 @@
 
 namespace quickstep {
 
-class Type;
-
 /** \addtogroup Catalog
  *  @{
  */
@@ -82,11 +80,9 @@ class PartitionScheme {
    *
    * @param proto The Protocol Buffer serialization of a Partition Scheme,
    *        previously produced by getProto().
-   * @param attr_type The attribute type of the partitioning attribute.
    * @return The deserialized partition scheme object.
    **/
-  static PartitionScheme* ReconstructFromProto(const serialization::PartitionScheme &proto,
-                                               const Type &attr_type);
+  static PartitionScheme* ReconstructFromProto(const serialization::PartitionScheme &proto);
 
   /**
    * @brief Check whether a serialization::PartitionScheme is fully-formed and

--- a/catalog/PartitionSchemeHeader.hpp
+++ b/catalog/PartitionSchemeHeader.hpp
@@ -65,12 +65,10 @@ class PartitionSchemeHeader {
    *
    * @param proto The Protocol Buffer serialization of a PartitionSchemeHeader,
    *        previously produced by getProto().
-   * @param attr_type The attribute type of the partitioning attribute.
    * @return The reconstructed PartitionSchemeHeader object.
    **/
   static PartitionSchemeHeader* ReconstructFromProto(
-      const serialization::PartitionSchemeHeader &proto,
-      const Type &attr_type);
+      const serialization::PartitionSchemeHeader &proto);
 
   /**
    * @brief Check whether a serialization::PartitionSchemeHeader is fully-formed
@@ -227,6 +225,7 @@ class RangePartitionSchemeHeader : public PartitionSchemeHeader {
                              const attribute_id attribute,
                              std::vector<TypedValue> &&partition_range)
       : PartitionSchemeHeader(PartitionType::kRange, num_partitions, attribute),
+        partition_attr_type_(&partition_attribute_type),
         partition_range_boundaries_(std::move(partition_range)) {
     DCHECK_EQ(num_partitions - 1, partition_range_boundaries_.size());
 
@@ -297,6 +296,8 @@ class RangePartitionSchemeHeader : public PartitionSchemeHeader {
       }
     }
   }
+
+  const Type* partition_attr_type_;
 
   // The boundaries for each range in the RangePartitionSchemeHeader.
   // The upper bound of the range is stored here.

--- a/catalog/tests/PartitionScheme_unittest.cpp
+++ b/catalog/tests/PartitionScheme_unittest.cpp
@@ -511,7 +511,7 @@ TEST(PartitionSchemeTest, CheckHashPartitionSchemeSerialization) {
   }
   std::unique_ptr<PartitionScheme> part_scheme_from_proto;
   part_scheme_from_proto.reset(
-      PartitionScheme::ReconstructFromProto(part_scheme->getProto(), TypeFactory::GetType(kInt)));
+      PartitionScheme::ReconstructFromProto(part_scheme->getProto()));
 
   const PartitionSchemeHeader &header = part_scheme->getPartitionSchemeHeader();
   const PartitionSchemeHeader &header_from_proto = part_scheme_from_proto->getPartitionSchemeHeader();
@@ -561,7 +561,7 @@ TEST(PartitionSchemeTest, CheckRangePartitionSchemeSerialization) {
   std::unique_ptr<PartitionScheme> part_scheme_from_proto;
 
   part_scheme_from_proto.reset(
-      PartitionScheme::ReconstructFromProto(part_scheme->getProto(), type));
+      PartitionScheme::ReconstructFromProto(part_scheme->getProto()));
 
   const PartitionSchemeHeader &header = part_scheme->getPartitionSchemeHeader();
   const PartitionSchemeHeader &header_from_proto = part_scheme_from_proto->getPartitionSchemeHeader();

--- a/storage/InsertDestination.cpp
+++ b/storage/InsertDestination.cpp
@@ -56,8 +56,6 @@ using std::vector;
 
 namespace quickstep {
 
-class Type;
-
 InsertDestination::InsertDestination(const CatalogRelationSchema &relation,
                                      const StorageBlockLayout *layout,
                                      StorageManager *storage_manager,
@@ -132,11 +130,8 @@ InsertDestination* InsertDestination::ReconstructFromProto(
         partitions.push_back(move(partition));
       }
 
-      const serialization::PartitionSchemeHeader &proto_partition_scheme_header = proto_partition_scheme.header();
-      const Type &attr_type =
-          relation.getAttributeById(proto_partition_scheme_header.partition_attribute_id())->getType();
       return new PartitionAwareInsertDestination(
-          PartitionSchemeHeader::ReconstructFromProto(proto_partition_scheme_header, attr_type),
+          PartitionSchemeHeader::ReconstructFromProto(proto_partition_scheme.header()),
           relation,
           layout,
           storage_manager,


### PR DESCRIPTION
This small PR simplified the `PartitionSchemeHeader` reconstruction method, which will be used in `Resolver` for the `CreateTable` statement, by moving `type` used for `RangePartition` only into its proto.