### PR TITLE
Refactored SelectOperator::getAllWorkOrders.

### DIFF
--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -248,20 +248,6 @@ class SelectOperator : public RelationalOperator {
     return output_relation_.getID();
   }
 
-  void addWorkOrders(WorkOrdersContainer *container,
-                     QueryContext *query_context,
-                     StorageManager *storage_manager,
-                     const Predicate *predicate,
-                     const std::vector<std::unique_ptr<const Scalar>> *selection,
-                     InsertDestination *output_destination);
-
-  void addPartitionAwareWorkOrders(WorkOrdersContainer *container,
-                                   QueryContext *query_context,
-                                   StorageManager *storage_manager,
-                                   const Predicate *predicate,
-                                   const std::vector<std::unique_ptr<const Scalar>> *selection,
-                                   InsertDestination *output_destination);
-
  private:
   /**
    * @brief Create Work Order proto.


### PR DESCRIPTION
Assigned to @hbdeshmukh.

This PR simplified `SelectOperator::getAllWorkOrders`, and allows to generate `WorkOrder`s when the input relation has data partitions, but not in the `NUMA` case.