### PR TITLE
Removed the unused feedInputBlocks.

### DIFF
--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -102,12 +102,6 @@ class AggregationOperator : public RelationalOperator {
     input_relation_block_ids_.push_back(input_block_id);
   }
 
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-    input_relation_block_ids_.insert(input_relation_block_ids_.end(),
-                                     partially_filled_blocks->begin(),
-                                     partially_filled_blocks->end());
-  }
-
  private:
   /**
    * @brief Create Work Order proto.

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -119,13 +119,6 @@ class BuildHashOperator : public RelationalOperator {
     input_relation_block_ids_.push_back(input_block_id);
   }
 
-  void feedInputBlocks(const relation_id rel_id,
-                       std::vector<block_id> *partially_filled_blocks) override {
-    input_relation_block_ids_.insert(input_relation_block_ids_.end(),
-                                     partially_filled_blocks->begin(),
-                                     partially_filled_blocks->end());
-  }
-
  private:
   /**
    * @brief Create Work Order proto.

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -105,13 +105,6 @@ class DeleteOperator : public RelationalOperator {
     relation_block_ids_.push_back(input_block_id);
   }
 
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-    DCHECK(!relation_is_stored_);
-    relation_block_ids_.insert(relation_block_ids_.end(),
-                               partially_filled_blocks->begin(),
-                               partially_filled_blocks->end());
-  }
-
  private:
   /**
    * @brief Create Work Order proto.

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -196,14 +196,6 @@ class HashJoinOperator : public RelationalOperator {
     probe_relation_block_ids_.push_back(input_block_id);
   }
 
-  void feedInputBlocks(const relation_id rel_id,
-                       std::vector<block_id> *partially_filled_blocks) override {
-    DCHECK(rel_id == probe_relation_.getID());
-    probe_relation_block_ids_.insert(probe_relation_block_ids_.end(),
-                                     partially_filled_blocks->begin(),
-                                     partially_filled_blocks->end());
-  }
-
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;
   }

--- a/relational_operators/NestedLoopsJoinOperator.cpp
+++ b/relational_operators/NestedLoopsJoinOperator.cpp
@@ -48,26 +48,6 @@ using std::vector;
 
 namespace quickstep {
 
-void NestedLoopsJoinOperator::feedInputBlocks(const relation_id rel_id,
-                                              std::vector<block_id> *partially_filled_blocks) {
-  for (std::vector<block_id>::const_iterator it = partially_filled_blocks->begin();
-       it != partially_filled_blocks->end();
-       ++it) {
-    feedInputBlock(*it, rel_id);
-  }
-}
-
-void NestedLoopsJoinOperator::feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) {
-  if (input_relation_id == left_input_relation_.getID()) {
-    left_relation_block_ids_.push_back(input_block_id);
-  } else if (input_relation_id == right_input_relation_.getID()) {
-    right_relation_block_ids_.push_back(input_block_id);
-  } else {
-    FATAL_ERROR("The input block sent to the NestedLoopsJoinOperator belongs "
-                "to a different relation than the left and right relations");
-  }
-}
-
 bool NestedLoopsJoinOperator::getAllWorkOrders(
     WorkOrdersContainer *container,
     QueryContext *query_context,

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -141,9 +141,16 @@ class NestedLoopsJoinOperator : public RelationalOperator {
     }
   }
 
-  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override;
-
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override;
+  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
+    if (input_relation_id == left_input_relation_.getID()) {
+      left_relation_block_ids_.push_back(input_block_id);
+    } else if (input_relation_id == right_input_relation_.getID()) {
+      right_relation_block_ids_.push_back(input_block_id);
+    } else {
+      LOG(FATAL) << "The input block sent to the NestedLoopsJoinOperator belongs "
+                 << "to a different relation than the left and right relations";
+    }
+  }
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -145,20 +145,6 @@ class RelationalOperator {
                               const relation_id input_relation_id) {}
 
   /**
-   * @brief Receive partially filled input blocks for this RelationalOperator.
-   *
-   * @note The blocks in partially_filled_blocks may not be fully filled.
-   *
-   * @param rel_id ID of the relation to which all the partially filled blocks
-   *               belong to.
-   * @param partially_filled_blocks A pointer to the vector of block IDs of the
-   *                                partially filled input blocks.
-   **/
-  virtual void feedInputBlocks(
-      const relation_id rel_id,
-      std::vector<block_id> *partially_filled_blocks) {}
-
-  /**
    * @brief Signal the end of feeding of input blocks for this
    * RelationalOperator.
    *

--- a/relational_operators/SampleOperator.hpp
+++ b/relational_operators/SampleOperator.hpp
@@ -112,12 +112,6 @@ class SampleOperator : public RelationalOperator {
     input_relation_block_ids_.push_back(input_block_id);
   }
 
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-    input_relation_block_ids_.insert(input_relation_block_ids_.end(),
-                                     partially_filled_blocks->begin(),
-                                     partially_filled_blocks->end());
-  }
-
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;
   }

--- a/relational_operators/SaveBlocksOperator.cpp
+++ b/relational_operators/SaveBlocksOperator.cpp
@@ -67,10 +67,6 @@ bool SaveBlocksOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *contain
   return done_feeding_input_relation_;
 }
 
-void SaveBlocksOperator::feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) {
-  destination_block_ids_.push_back(input_block_id);
-}
-
 void SaveBlocksOperator::updateCatalogOnCompletion() {
   // Note(jianqiao): We need to reset the exactness flag whenever a stored
   // relation gets changed. Given the pre-condition that all the data manipulation

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -83,14 +83,8 @@ class SaveBlocksOperator : public RelationalOperator {
 
   bool getAllWorkOrderProtos(WorkOrderProtosContainer *container) override;
 
-  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override;
-
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-    for (std::vector<block_id>::const_iterator it = partially_filled_blocks->begin();
-         it != partially_filled_blocks->end();
-         ++it) {
-      feedInputBlock(*it, rel_id);
-    }
+  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
+    destination_block_ids_.push_back(input_block_id);
   }
 
   void updateCatalogOnCompletion() override;

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -220,26 +220,6 @@ class SelectOperator : public RelationalOperator {
     }
   }
 
-  // TODO(gerald): Each call to getPartitionForBlock() involves grabbing shared
-  // locks on each partition's mutex, checking if the block belongs to the
-  // partition. Instead, we can provide a method getPartitionsForBlocks() which
-  // accepts a list of blocks and returns corresponding list of their partition IDs.
-  // Therefore, once we grab a lock for a partition, we search for all the blocks
-  // and then release the lock.
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-    if (input_relation_.hasPartitionScheme()) {
-      for (auto it = partially_filled_blocks->begin(); it != partially_filled_blocks->end(); ++it) {
-        const partition_id part_id = input_relation_.getPartitionScheme().getPartitionForBlock((*it));
-        input_relation_block_ids_in_partition_[part_id].insert(input_relation_block_ids_in_partition_[part_id].end(),
-                                                               *it);
-      }
-    } else {
-      input_relation_block_ids_.insert(input_relation_block_ids_.end(),
-                                       partially_filled_blocks->begin(),
-                                       partially_filled_blocks->end());
-    }
-  }
-
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;
   }

--- a/relational_operators/SortMergeRunOperator.hpp
+++ b/relational_operators/SortMergeRunOperator.hpp
@@ -152,17 +152,6 @@ class SortMergeRunOperator : public RelationalOperator {
     }
   }
 
-  void feedInputBlocks(
-      const relation_id rel_id,
-      std::vector<block_id> *partially_filled_blocks) override {
-    input_relation_block_ids_.insert(input_relation_block_ids_.end(),
-                                     partially_filled_blocks->begin(),
-                                     partially_filled_blocks->end());
-    if (started_) {
-      initializeInputRuns();
-    }
-  }
-
   void doneFeedingInputBlocks(const relation_id input_relation_id) override;
 
   void receiveFeedbackMessage(const WorkOrder::FeedbackMessage &msg) override;

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -129,13 +129,6 @@ class SortRunGenerationOperator : public RelationalOperator {
     input_relation_block_ids_.push_back(input_block_id);
   }
 
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-    DCHECK(rel_id == input_relation_.getID());
-    input_relation_block_ids_.insert(input_relation_block_ids_.end(),
-                                     partially_filled_blocks->begin(),
-                                     partially_filled_blocks->end());
-  }
-
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;
   }

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -90,12 +90,6 @@ class TableGeneratorOperator : public RelationalOperator {
 
   bool getAllWorkOrderProtos(WorkOrderProtosContainer *container) override;
 
-  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id) override {
-  }
-
-  void feedInputBlocks(const relation_id rel_id, std::vector<block_id> *partially_filled_blocks) override {
-  }
-
   QueryContext::insert_destination_id getInsertDestinationID() const override {
     return output_destination_index_;
   }

--- a/relational_operators/tests/SortMergeRunOperator_unittest.cpp
+++ b/relational_operators/tests/SortMergeRunOperator_unittest.cpp
@@ -1601,7 +1601,9 @@ class SortMergeRunOperatorTest : public ::testing::Test {
 
     // Feed blocks.
     DVLOG(1) << "Feeding " << to_feed.size() << " blocks.";
-    merge_op_->feedInputBlocks(input_table_->getID(), &to_feed);
+    for (const block_id block : to_feed) {
+      merge_op_->feedInputBlock(block, input_table_->getID());
+    }
 
     // Remove fed blocks.
     blocks->erase(blocks->begin() + blocks->size() - count, blocks->end());


### PR DESCRIPTION
Assigned to @hbdeshmukh.

This small PR removed the unused `feedInputBlocks` in `RelationalOperator`s for passing partially filled blocks to the operator.

Even worse, there is a follow-up PR that adds `partition_id` in `feedInputBlock`, the existing `feedInputBlocks` would be hard to adapt w/ partition info.