### PR TITLE
Added DAGAnalyzer and Pipeline classes

### DIFF
--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -33,6 +33,7 @@ if (ENABLE_DISTRIBUTED)
   add_library(quickstep_queryexecution_BlockLocator BlockLocator.cpp BlockLocator.hpp)
   add_library(quickstep_queryexecution_BlockLocatorUtil BlockLocatorUtil.cpp BlockLocatorUtil.hpp)
 endif(ENABLE_DISTRIBUTED)
+add_library(quickstep_queryexecution_DAGAnalyzer DAGAnalyzer.cpp DAGAnalyzer.hpp) 
 add_library(quickstep_queryexecution_ForemanBase ../empty_src.cpp ForemanBase.hpp)
 if (ENABLE_DISTRIBUTED)
   add_library(quickstep_queryexecution_ForemanDistributed ForemanDistributed.cpp ForemanDistributed.hpp)
@@ -42,6 +43,7 @@ add_library(quickstep_queryexecution_PolicyEnforcerBase PolicyEnforcerBase.cpp P
 if (ENABLE_DISTRIBUTED)
   add_library(quickstep_queryexecution_PolicyEnforcerDistributed PolicyEnforcerDistributed.cpp PolicyEnforcerDistributed.hpp)
 endif(ENABLE_DISTRIBUTED)
+add_library(quickstep_queryexecution_Pipeline ../empty_src.cpp Pipeline.hpp)
 add_library(quickstep_queryexecution_PolicyEnforcerSingleNode PolicyEnforcerSingleNode.cpp PolicyEnforcerSingleNode.hpp)
 add_library(quickstep_queryexecution_QueryContext QueryContext.cpp QueryContext.hpp)
 add_library(quickstep_queryexecution_QueryContext_proto
@@ -92,6 +94,12 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_storage_StorageBlockInfo
                         tmb)
 endif(ENABLE_DISTRIBUTED)
+target_link_libraries(quickstep_queryexecution_DAGAnalyzer
+                      glog
+                      quickstep_queryexecution_Pipeline
+                      quickstep_relationaloperators_RelationalOperator
+                      quickstep_utility_DAG
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryexecution_ForemanBase
                       glog
                       quickstep_queryexecution_PolicyEnforcerBase
@@ -138,6 +146,9 @@ target_link_libraries(quickstep_queryexecution_ForemanSingleNode
                       quickstep_utility_Macros
                       tmb
                       ${GFLAGS_LIB_NAME})
+target_link_libraries(quickstep_queryexecution_Pipeline
+                      glog
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryexecution_PolicyEnforcerBase
                       glog
                       quickstep_catalog_CatalogDatabase
@@ -337,8 +348,10 @@ target_link_libraries(quickstep_queryexecution_WorkerSelectionPolicy
 add_library(quickstep_queryexecution ../empty_src.cpp QueryExecutionModule.hpp)
 target_link_libraries(quickstep_queryexecution
                       quickstep_queryexecution_AdmitRequestMessage
+                      quickstep_queryexecution_DAGAnalyzer
                       quickstep_queryexecution_ForemanBase
                       quickstep_queryexecution_ForemanSingleNode
+                      quickstep_queryexecution_Pipeline
                       quickstep_queryexecution_PolicyEnforcerBase
                       quickstep_queryexecution_PolicyEnforcerSingleNode
                       quickstep_queryexecution_QueryContext
@@ -367,6 +380,16 @@ if (ENABLE_DISTRIBUTED)
 endif(ENABLE_DISTRIBUTED)
 
 # Tests:
+add_library(quickstep_queryexecution_tests_MockOperator ../empty_src.cpp "${CMAKE_CURRENT_SOURCE_DIR}/tests/MockOperator.hpp")
+target_link_libraries(quickstep_queryexecution_tests_MockOperator
+                      glog
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_queryexecution_WorkOrdersContainer
+                      quickstep_queryoptimizer_QueryPlan
+                      quickstep_relationaloperators_RelationalOperator
+                      quickstep_relationaloperators_WorkOrder
+                      quickstep_utility_Macros
+                      tmb)
 if (ENABLE_DISTRIBUTED)
   add_executable(BlockLocator_unittest
                  "${CMAKE_CURRENT_SOURCE_DIR}/tests/BlockLocator_unittest.cpp")
@@ -393,6 +416,17 @@ if (ENABLE_DISTRIBUTED)
   add_test(BlockLocator_unittest BlockLocator_unittest)
 endif(ENABLE_DISTRIBUTED)
 
+add_executable(DAGAnalyzer_unittest
+  "${CMAKE_CURRENT_SOURCE_DIR}/tests/DAGAnalyzer_unittest.cpp")
+target_link_libraries(DAGAnalyzer_unittest
+                      glog
+                      gtest
+                      gtest_main
+                      quickstep_queryexecution_DAGAnalyzer
+                      quickstep_queryexecution_tests_MockOperator
+                      quickstep_utility_DAG)
+add_test(DAGAnalyzer_unittest DAGAnalyzer_unittest)
+
 add_executable(QueryManagerSingleNode_unittest
   "${CMAKE_CURRENT_SOURCE_DIR}/tests/QueryManagerSingleNode_unittest.cpp")
 target_link_libraries(QueryManagerSingleNode_unittest
@@ -411,6 +445,7 @@ target_link_libraries(QueryManagerSingleNode_unittest
                       quickstep_queryexecution_WorkOrdersContainer
                       quickstep_queryexecution_WorkerDirectory
                       quickstep_queryexecution_WorkerMessage
+                      quickstep_queryexecution_tests_MockOperator
                       quickstep_queryoptimizer_QueryHandle
                       quickstep_queryoptimizer_QueryPlan
                       quickstep_relationaloperators_RelationalOperator

--- a/query_execution/DAGAnalyzer.cpp
+++ b/query_execution/DAGAnalyzer.cpp
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "query_execution/DAGAnalyzer.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <queue>
+#include <utility>
+#include <vector>
+
+#include "utility/DAG.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+void DAGAnalyzer::findPipelines() {
+  // Key = node ID, value = whether the node has been visited or not.
+  std::unordered_map<std::size_t, bool> visited_nodes;
+  // Pair 1st element: Operator ID
+  // Pair 2nd element: The index of the pipeline in pipelines_ vector to which
+  // the 1st element belongs.
+  std::queue<std::pair<std::size_t, std::size_t>> to_be_checked_nodes;
+  // Traverse the DAG once. Find leaf nodes and create a pipeline with one node.
+  for (std::size_t node_id = 0; node_id < query_plan_dag_->size(); ++node_id) {
+    if (query_plan_dag_->getDependencies(node_id).empty()) {
+      pipelines_.push_back(std::unique_ptr<Pipeline>(new Pipeline(node_id)));
+      to_be_checked_nodes.emplace(node_id, pipelines_.size() - 1);
+      // No check needed here, as we are visiting these nodes for the first time.
+      visited_nodes[node_id] = true;
+    }
+  }
+  while (!to_be_checked_nodes.empty()) {
+    auto queue_front = to_be_checked_nodes.front();
+    to_be_checked_nodes.pop();
+    const std::size_t pipeline_id = queue_front.second;
+    const std::size_t operator_id = queue_front.first;
+    auto dependents = query_plan_dag_->getDependents(operator_id);
+    for (auto dependent_pair : dependents) {
+      const std::size_t dependent_id = dependent_pair.first;
+      const bool dependent_in_new_pipeline =
+          (query_plan_dag_->getDependencies(dependent_id).size() > 1u) ||
+          (dependent_pair.second);
+      if (dependent_in_new_pipeline) {
+        // Start a new pipeline.
+        if (visited_nodes.find(dependent_id) == visited_nodes.end()) {
+          pipelines_.push_back(std::unique_ptr<Pipeline>(new Pipeline(dependent_id)));
+          to_be_checked_nodes.emplace(dependent_id, pipelines_.size() - 1);
+          visited_nodes[dependent_id] = true;
+        }
+      } else {
+        // This means that pipelining is enabled on this link. Add this
+        // dependent to the current pipeline being processed.
+        if (visited_nodes.find(dependent_id) == visited_nodes.end()) {
+          pipelines_[pipeline_id]->addOperatorToPipeline(dependent_id);
+          to_be_checked_nodes.emplace(dependent_id, pipeline_id);
+          visited_nodes[dependent_id] = true;
+        }
+      }
+    }
+  }
+  // Assuming that we have a connected DAG, make sure that all nodes belong to
+  // some pipeline exactly once.
+  DCHECK_EQ(query_plan_dag_->size(), getTotalNodes());
+}
+
+const std::size_t DAGAnalyzer::getTotalNodes() {
+  std::size_t total = 0;
+  for (std::size_t i = 0; i < pipelines_.size(); ++i) {
+    total += pipelines_[i]->size();
+  }
+  return total;
+}
+
+}  // namespace quickstep

--- a/query_execution/DAGAnalyzer.hpp
+++ b/query_execution/DAGAnalyzer.hpp
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_EXECUTION_DAG_ANALYZER_HPP_
+#define QUICKSTEP_QUERY_EXECUTION_DAG_ANALYZER_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "query_execution/Pipeline.hpp"
+#include "relational_operators/RelationalOperator.hpp"
+#include "utility/DAG.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+/** \addtogroup QueryExecution
+ *  @{
+ */
+
+/**
+ * @brief A class that processes a query plan DAG and produces pipelines of
+ *        relational operators from the DAG.
+ **/
+class DAGAnalyzer {
+ public:
+  /**
+   * @brief Constructor. The invocation of the constructor triggers the DAG
+   *        analysis and the pipelines are produced.
+   *
+   * @param query_plan_dag The query plan DAG.
+   **/
+  explicit DAGAnalyzer(DAG<RelationalOperator, bool> *query_plan_dag)
+      : query_plan_dag_(query_plan_dag) {
+    findPipelines();
+  }
+
+  /**
+   * @brief Get the number of pipelines in the DAG.
+   **/
+  const std::size_t getNumPipelines() const {
+    return pipelines_.size();
+  }
+
+  /**
+   * @brief Get the pipeline ID of the given operator.
+   *
+   * @param operator_id The ID of the given operator.
+   *
+   * @return Pipeline ID if such a pipeline exists, otherwise -1.
+   **/
+  const int getPipelineID(const std::size_t operator_id) const {
+    for (std::size_t pipeline_id = 0;
+         pipeline_id < pipelines_.size();
+         ++pipeline_id) {
+      if (pipelines_[pipeline_id]->hasOperator(operator_id)) {
+        return pipeline_id;
+      }
+    }
+    return -1;
+  }
+
+ private:
+  DAG<RelationalOperator, bool> *query_plan_dag_;
+  std::vector<std::unique_ptr<Pipeline>> pipelines_;
+
+  /**
+   * @brief Find initial set of pipelines in the query plan DAG.
+   **/
+  void findPipelines();
+
+  /**
+   * @brief Find the total number of nodes in all pipelines.
+   **/
+  const std::size_t getTotalNodes();
+
+  DISALLOW_COPY_AND_ASSIGN(DAGAnalyzer);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_QUERY_EXECUTION_DAG_ANALYZER_HPP_

--- a/query_execution/Pipeline.hpp
+++ b/query_execution/Pipeline.hpp
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_EXECUTION_PIPELINE_HPP_
+#define QUICKSTEP_QUERY_EXECUTION_PIPELINE_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+
+/** \addtogroup QueryExecution
+ *  @{
+ */
+
+/**
+ * @brief A class that abstracts a pipeline of relational operators in a query
+ *        plan DAG.
+ **/
+class Pipeline {
+ public:
+  /**
+   * @brief Constructor.
+   *
+   * @param operator_ids The IDs of the operator belonging to the pipeline.
+   **/
+  explicit Pipeline(const std::vector<std::size_t> &operator_ids)
+      : operators_(operator_ids) {}
+
+  /**
+   * @brief Constructor for a single node pipeline.
+   *
+   * @param operator_id The ID of the operator belonging to the pipeline.
+   **/
+  explicit Pipeline(const std::size_t operator_id) {
+    operators_.emplace_back(operator_id);
+  }
+
+  /**
+   * @brief Get the IDs of the operators belonging to the pipeline.
+   **/
+  const std::vector<std::size_t>& getOperatorIDs() const {
+    return operators_;
+  }
+
+  /**
+   * @brief Add an operator to the pipeline.
+   *
+   * @param operator_id The ID of the operator.
+   **/
+  void addOperatorToPipeline(const std::size_t operator_id) {
+    DCHECK(!hasOperator(operator_id));
+    operators_.emplace_back(operator_id);
+  }
+
+  /**
+   * @brief Check if the given operator belongs to the pipeline.
+   **/
+  bool hasOperator(const std::size_t operator_id) const {
+    return std::find(operators_.begin(), operators_.end(), operator_id) !=
+           operators_.end();
+  }
+
+  /**
+   * @brief Get the size of the pipeline.
+   **/
+  std::size_t size() const {
+    return operators_.size();
+  }
+
+ private:
+  std::vector<std::size_t> operators_;
+
+  DISALLOW_COPY_AND_ASSIGN(Pipeline);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_QUERY_EXECUTION_PIPELINE_HPP_

--- a/query_execution/tests/DAGAnalyzer_unittest.cpp
+++ b/query_execution/tests/DAGAnalyzer_unittest.cpp
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "query_execution/DAGAnalyzer.hpp"
+#include "query_execution/tests/MockOperator.hpp"
+#include "utility/DAG.hpp"
+
+namespace quickstep {
+
+TEST(DAGAnalyzerTest, ZeroNodeDAGTest) {
+  std::unique_ptr<DAG<RelationalOperator, bool>> zero_node_dag;
+  zero_node_dag.reset(new DAG<RelationalOperator, bool>());
+  DAGAnalyzer analyzer(zero_node_dag.get());
+  EXPECT_EQ(0u, analyzer.getNumPipelines());
+}
+
+TEST(DAGAnalyzerTest, OneNodeDAGTest) {
+  std::unique_ptr<DAG<RelationalOperator, bool>> one_node_dag;
+  one_node_dag.reset(new DAG<RelationalOperator, bool>());
+  one_node_dag->createNode(new MockOperator(false, false));
+
+  DAGAnalyzer analyzer(one_node_dag.get());
+  EXPECT_EQ(1u, analyzer.getNumPipelines());
+}
+
+TEST(DAGAnalyzerTest, TwoNodesOnePipelineTest) {
+  std::unique_ptr<DAG<RelationalOperator, bool>> dag;
+  dag.reset(new DAG<RelationalOperator, bool>());
+  const std::size_t n0 = dag->createNode(new MockOperator(false, false));
+  const std::size_t n1 = dag->createNode(new MockOperator(false, false));
+
+  dag->createLink(n0, n1, false);
+  DAGAnalyzer analyzer(dag.get());
+  EXPECT_EQ(1u, analyzer.getNumPipelines());
+}
+
+TEST(DAGAnalyzerTest, TwoNodesTwoPipelinesTest) {
+  std::unique_ptr<DAG<RelationalOperator, bool>> dag;
+  dag.reset(new DAG<RelationalOperator, bool>());
+  const std::size_t n0 = dag->createNode(new MockOperator(false, false));
+  const std::size_t n1 = dag->createNode(new MockOperator(false, false));
+
+  dag->createLink(n0, n1, true);
+  DAGAnalyzer analyzer(dag.get());
+  EXPECT_EQ(2u, analyzer.getNumPipelines());
+}
+
+TEST(DAGAnalyzerTest, MultipleNodesOnePipelineTest) {
+  std::unique_ptr<DAG<RelationalOperator, bool>> dag;
+  // Create a long pipeline.
+  const std::size_t kNumNodes = 100;
+  dag.reset(new DAG<RelationalOperator, bool>());
+  std::vector<std::size_t> nodes;
+  nodes.resize(kNumNodes);
+  // Insert first node.
+  const std::size_t curr_node_id = dag->createNode(new MockOperator(false, false));
+  nodes.push_back(curr_node_id);
+  for (std::size_t i = 1; i < kNumNodes; ++i) {
+    const std::size_t node_id = dag->createNode(new MockOperator(false, false));
+    const std::size_t previous_node_id = nodes.back();
+    dag->createLink(node_id, previous_node_id, false);
+    nodes.push_back(node_id);
+  }
+
+  DAGAnalyzer analyzer(dag.get());
+  EXPECT_EQ(1u, analyzer.getNumPipelines());
+}
+
+TEST(DAGAnalyzerTest, VShapedDAGTest) {
+  // Test for three nodes in shape V.
+  std::unique_ptr<DAG<RelationalOperator, bool>> dag;
+  dag.reset(new DAG<RelationalOperator, bool>());
+  const std::size_t n0 = dag->createNode(new MockOperator(false, false));
+  const std::size_t n1 = dag->createNode(new MockOperator(false, false));
+  const std::size_t n2 = dag->createNode(new MockOperator(false, false));
+
+  dag->createLink(n0, n1, true);
+  dag->createLink(n2, n1, true);
+  DAGAnalyzer analyzer(dag.get());
+  // Expect three pipelines, one for each node. n1 is not part of either n0 or
+  // n1's pipeline, because it has more than one dependencies.
+  EXPECT_EQ(3u, analyzer.getNumPipelines());
+}
+
+}  // namespace quickstep

--- a/query_execution/tests/MockOperator.hpp
+++ b/query_execution/tests/MockOperator.hpp
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <cstdint>
+#include <cstddef>
+#include <ostream>
+#include <string>
+
+#include "catalog/CatalogTypedefs.hpp"
+#include "query_execution/WorkOrdersContainer.hpp"
+#include "query_optimizer/QueryPlan.hpp"
+#include "relational_operators/RelationalOperator.hpp"
+#include "relational_operators/WorkOrder.hpp"
+#include "utility/Macros.hpp"
+
+#include "glog/logging.h"
+
+#include "tmb/id_typedefs.h"
+
+namespace quickstep { class QueryContext; }
+namespace quickstep { class StorageManager; }
+namespace tmb { class MessageBus; }
+
+namespace quickstep {
+
+class WorkOrderProtosContainer;
+
+class MockWorkOrder : public WorkOrder {
+ public:
+  explicit MockWorkOrder(const int op_index)
+      : WorkOrder(0), op_index_(op_index) {}
+
+  void execute() override {
+    VLOG(3) << "WorkOrder[" << op_index_ << "] executing.";
+  }
+
+  inline QueryPlan::DAGNodeIndex getOpIndex() const {
+    return op_index_;
+  }
+
+ private:
+  const QueryPlan::DAGNodeIndex op_index_;
+
+  DISALLOW_COPY_AND_ASSIGN(MockWorkOrder);
+};
+
+class MockOperator: public RelationalOperator {
+ public:
+  enum function_name {
+    kFeedInputBlock = 0,
+    kDoneFeedingInputBlocks,
+    kGetAllWorkOrders
+  };
+
+  MockOperator(const bool produce_workorders,
+               const bool has_streaming_input,
+               const int max_getworkorder_iters = 1,
+               const int max_workorders = INT_MAX)
+      : RelationalOperator(0 /* Query Id */),
+        produce_workorders_(produce_workorders),
+        has_streaming_input_(has_streaming_input),
+        max_workorders_(max_workorders),
+        max_getworkorder_iters_(max_getworkorder_iters),
+        num_calls_get_workorders_(0),
+        num_workorders_generated_(0),
+        num_calls_feedblock_(0),
+        num_calls_donefeedingblocks_(0) {
+  }
+
+  std::string getName() const override {
+    return "MockOperator";
+  }
+
+#define MOCK_OP_LOG(x) VLOG(x) << "Op[" << op_index_ << "]: " << __func__ << ": "
+
+  // The methods below are used to check whether QueryManager calls the Relational
+  // operator, how many times it calls a particular method etc.
+  inline int getNumWorkOrders() const {
+    return num_workorders_generated_;
+  }
+
+  inline int getNumCalls(const function_name fname) const {
+    switch (fname) {
+      case kFeedInputBlock:
+        return num_calls_feedblock_;
+      case kDoneFeedingInputBlocks:
+        return num_calls_donefeedingblocks_;
+      case kGetAllWorkOrders:
+        return num_calls_get_workorders_;
+      default:
+        return -1;
+    }
+  }
+
+  inline bool getBlockingDependenciesMet() const {
+    MOCK_OP_LOG(3) << "met.";
+    return blocking_dependencies_met_;
+  }
+
+  void setInsertDestinationID(const QueryContext::insert_destination_id insert_destination_index) {
+    insert_destination_index_ = insert_destination_index;
+  }
+
+  // Mock to trigger doneFeedingInputBlocks for the dependent operators
+  // in QueryManager::markOperatorFinished.
+  void setOutputRelationID(const relation_id rel_id) {
+    output_relation_id_ = rel_id;
+  }
+
+  // Override methods from the base class.
+  bool getAllWorkOrders(
+      WorkOrdersContainer *container,
+      QueryContext *query_context,
+      StorageManager *storage_manager,
+      const tmb::client_id foreman_client_id,
+      tmb::MessageBus *bus) override {
+    ++num_calls_get_workorders_;
+    if (produce_workorders_) {
+      if (has_streaming_input_) {
+        if (num_calls_feedblock_ > 0 && (num_workorders_generated_ < max_workorders_)) {
+          MOCK_OP_LOG(3) << "[stream] generate WorkOrder";
+          container->addNormalWorkOrder(new MockWorkOrder(op_index_), op_index_);
+          ++num_workorders_generated_;
+        }
+      } else {
+        if (blocking_dependencies_met_ && (num_workorders_generated_ < max_workorders_)) {
+          MOCK_OP_LOG(3) << "[static] generate WorkOrder";
+          container->addNormalWorkOrder(new MockWorkOrder(op_index_), op_index_);
+          ++num_workorders_generated_;
+        }
+      }
+    }
+    MOCK_OP_LOG(3) << "count(" << num_calls_get_workorders_ << ") "
+                   << "return(" << (num_calls_get_workorders_ == max_getworkorder_iters_) << ")";
+    return num_calls_get_workorders_ == max_getworkorder_iters_;
+  }
+
+  bool getAllWorkOrderProtos(WorkOrderProtosContainer *container) override {
+    return true;
+  }
+
+  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id,
+                      const partition_id part_id) override {
+    ++num_calls_feedblock_;
+    MOCK_OP_LOG(3) << "count(" << num_calls_feedblock_ << ")";
+  }
+
+  void doneFeedingInputBlocks(const relation_id rel_id) override {
+    ++num_calls_donefeedingblocks_;
+    MOCK_OP_LOG(3) << "count(" << num_calls_donefeedingblocks_ << ")";
+  }
+
+  QueryContext::insert_destination_id getInsertDestinationID() const override {
+    return insert_destination_index_;
+  }
+
+  const relation_id getOutputRelationID() const override {
+    return output_relation_id_;
+  }
+
+ private:
+  const bool produce_workorders_;
+  const bool has_streaming_input_;
+  const int max_workorders_;
+  const int max_getworkorder_iters_;
+
+  int num_calls_get_workorders_;
+  int num_workorders_generated_;
+  int num_calls_feedblock_;
+  int num_calls_donefeedingblocks_;
+
+  QueryContext::insert_destination_id insert_destination_index_ = QueryContext::kInvalidInsertDestinationId;
+
+  relation_id output_relation_id_ = -1;
+
+#undef MOCK_OP_LOG
+
+  DISALLOW_COPY_AND_ASSIGN(MockOperator);
+};
+
+}  // namespace quickstep

--- a/query_execution/tests/QueryManagerSingleNode_unittest.cpp
+++ b/query_execution/tests/QueryManagerSingleNode_unittest.cpp
@@ -19,8 +19,6 @@
 
 #include <climits>
 #include <memory>
-#include <string>
-#include <utility>
 #include <vector>
 
 #include "catalog/CatalogDatabase.hpp"
@@ -36,6 +34,7 @@
 #include "query_execution/WorkerMessage.hpp"
 #include "query_optimizer/QueryHandle.hpp"
 #include "query_optimizer/QueryPlan.hpp"
+#include "query_execution/tests/MockOperator.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
 #include "storage/InsertDestination.hpp"
@@ -60,162 +59,6 @@ using std::vector;
 using tmb::client_id;
 
 namespace quickstep {
-
-class WorkOrderProtosContainer;
-
-class MockWorkOrder : public WorkOrder {
- public:
-  explicit MockWorkOrder(const int op_index)
-      : WorkOrder(0), op_index_(op_index) {}
-
-  void execute() override {
-    VLOG(3) << "WorkOrder[" << op_index_ << "] executing.";
-  }
-
-  inline QueryPlan::DAGNodeIndex getOpIndex() const {
-    return op_index_;
-  }
-
- private:
-  const QueryPlan::DAGNodeIndex op_index_;
-
-  DISALLOW_COPY_AND_ASSIGN(MockWorkOrder);
-};
-
-class MockOperator: public RelationalOperator {
- public:
-  enum function_name {
-    kFeedInputBlock = 0,
-    kDoneFeedingInputBlocks,
-    kGetAllWorkOrders
-  };
-
-  MockOperator(const bool produce_workorders,
-               const bool has_streaming_input,
-               const int max_getworkorder_iters = 1,
-               const int max_workorders = INT_MAX)
-      : RelationalOperator(0 /* Query Id */),
-        produce_workorders_(produce_workorders),
-        has_streaming_input_(has_streaming_input),
-        max_workorders_(max_workorders),
-        max_getworkorder_iters_(max_getworkorder_iters),
-        num_calls_get_workorders_(0),
-        num_workorders_generated_(0),
-        num_calls_feedblock_(0),
-        num_calls_donefeedingblocks_(0) {
-  }
-
-  std::string getName() const override {
-    return "MockOperator";
-  }
-
-#define MOCK_OP_LOG(x) VLOG(x) << "Op[" << op_index_ << "]: " << __func__ << ": "
-
-  // The methods below are used to check whether QueryManager calls the Relational
-  // operator, how many times it calls a particular method etc.
-  inline int getNumWorkOrders() const {
-    return num_workorders_generated_;
-  }
-
-  inline int getNumCalls(const function_name fname) const {
-    switch (fname) {
-      case kFeedInputBlock:
-        return num_calls_feedblock_;
-      case kDoneFeedingInputBlocks:
-        return num_calls_donefeedingblocks_;
-      case kGetAllWorkOrders:
-        return num_calls_get_workorders_;
-      default:
-        return -1;
-    }
-  }
-
-  inline bool getBlockingDependenciesMet() const {
-    MOCK_OP_LOG(3) << "met.";
-    return blocking_dependencies_met_;
-  }
-
-  void setInsertDestinationID(const QueryContext::insert_destination_id insert_destination_index) {
-    insert_destination_index_ = insert_destination_index;
-  }
-
-  // Mock to trigger doneFeedingInputBlocks for the dependent operators
-  // in QueryManager::markOperatorFinished.
-  void setOutputRelationID(const relation_id rel_id) {
-    output_relation_id_ = rel_id;
-  }
-
-  // Override methods from the base class.
-  bool getAllWorkOrders(
-      WorkOrdersContainer *container,
-      QueryContext *query_context,
-      StorageManager *storage_manager,
-      const tmb::client_id foreman_client_id,
-      tmb::MessageBus *bus) override {
-    ++num_calls_get_workorders_;
-    if (produce_workorders_) {
-      if (has_streaming_input_) {
-        if (num_calls_feedblock_ > 0 && (num_workorders_generated_ < max_workorders_)) {
-          MOCK_OP_LOG(3) << "[stream] generate WorkOrder";
-          container->addNormalWorkOrder(new MockWorkOrder(op_index_), op_index_);
-          ++num_workorders_generated_;
-        }
-      } else {
-        if (blocking_dependencies_met_ && (num_workorders_generated_ < max_workorders_)) {
-          MOCK_OP_LOG(3) << "[static] generate WorkOrder";
-          container->addNormalWorkOrder(new MockWorkOrder(op_index_), op_index_);
-          ++num_workorders_generated_;
-        }
-      }
-    }
-    MOCK_OP_LOG(3) << "count(" << num_calls_get_workorders_ << ") "
-                   << "return(" << (num_calls_get_workorders_ == max_getworkorder_iters_) << ")";
-    return num_calls_get_workorders_ == max_getworkorder_iters_;
-  }
-
-  bool getAllWorkOrderProtos(WorkOrderProtosContainer *container) override {
-    return true;
-  }
-
-  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id,
-                      const partition_id part_id) override {
-    ++num_calls_feedblock_;
-    MOCK_OP_LOG(3) << "count(" << num_calls_feedblock_ << ")";
-  }
-
-  void doneFeedingInputBlocks(const relation_id rel_id) override {
-    ++num_calls_donefeedingblocks_;
-    MOCK_OP_LOG(3) << "count(" << num_calls_donefeedingblocks_ << ")";
-  }
-
-  QueryContext::insert_destination_id getInsertDestinationID() const override {
-    return insert_destination_index_;
-  }
-
-  const relation_id getOutputRelationID() const override {
-    return output_relation_id_;
-  }
-
- private:
-  const bool produce_workorders_;
-  const bool has_streaming_input_;
-  const int max_workorders_;
-  const int max_getworkorder_iters_;
-
-  int num_calls_get_workorders_;
-  int num_workorders_generated_;
-  int num_calls_feedblock_;
-  int num_calls_donefeedingblocks_;
-
-  QueryContext::insert_destination_id insert_destination_index_ = QueryContext::kInvalidInsertDestinationId;
-
-  relation_id output_relation_id_ = -1;
-
-#undef MOCK_OP_LOG
-
-  DISALLOW_COPY_AND_ASSIGN(MockOperator);
-};
-
 
 class QueryManagerTest : public ::testing::Test {
  protected:


### PR DESCRIPTION
- It accepts input as a DAG and produces pipelines within the DAG.
- Support for unit tests.

Please note that this feature is not used elsewhere in the code right now. In the future if the scheduling strategy gets changed from an operator-basis to a pipeline-basis, this class should be useful. 