### PR TITLE
Added Operator support for Partitioned HashJoin.

### DIFF
--- a/query_execution/QueryContext.proto
+++ b/query_execution/QueryContext.proto
@@ -30,6 +30,11 @@ import "utility/SortConfiguration.proto";
 import "utility/lip_filter/LIPFilter.proto";
 
 message QueryContext {
+  message HashTableContext {
+    required HashTable join_hash_table = 1;
+    optional uint64 num_partitions = 2 [default = 1];
+  }
+
   message ScalarGroup {
     repeated Scalar scalars = 1;
   }
@@ -47,7 +52,7 @@ message QueryContext {
 
   repeated AggregationOperationState aggregation_states = 1;
   repeated GeneratorFunctionHandle generator_functions = 2;
-  repeated HashTable join_hash_tables = 3;
+  repeated HashTableContext join_hash_tables = 3;
   repeated InsertDestination insert_destinations = 4;
   repeated LIPFilter lip_filters = 5;
   repeated LIPFilterDeployment lip_filter_deployments = 6;

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -40,8 +40,8 @@ add_library(quickstep_relationaloperators_AggregationOperator AggregationOperato
 add_library(quickstep_relationaloperators_BuildHashOperator BuildHashOperator.cpp BuildHashOperator.hpp)
 add_library(quickstep_relationaloperators_CreateIndexOperator CreateIndexOperator.cpp CreateIndexOperator.hpp)
 add_library(quickstep_relationaloperators_CreateTableOperator CreateTableOperator.cpp CreateTableOperator.hpp)
-add_library(quickstep_relationaloperators_DestroyAggregationStateOperator 
-            DestroyAggregationStateOperator.cpp 
+add_library(quickstep_relationaloperators_DestroyAggregationStateOperator
+            DestroyAggregationStateOperator.cpp
             DestroyAggregationStateOperator.hpp)
 add_library(quickstep_relationaloperators_DeleteOperator DeleteOperator.cpp DeleteOperator.hpp)
 add_library(quickstep_relationaloperators_DestroyHashOperator DestroyHashOperator.cpp DestroyHashOperator.hpp)
@@ -99,6 +99,7 @@ target_link_libraries(quickstep_relationaloperators_BuildHashOperator
                       glog
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionScheme
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrderProtosContainer
                       quickstep_queryexecution_WorkOrdersContainer
@@ -162,6 +163,7 @@ target_link_libraries(quickstep_relationaloperators_DestroyAggregationStateOpera
                       tmb)
 target_link_libraries(quickstep_relationaloperators_DestroyHashOperator
                       glog
+                      quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrderProtosContainer
                       quickstep_queryexecution_WorkOrdersContainer
@@ -204,6 +206,7 @@ target_link_libraries(quickstep_relationaloperators_HashJoinOperator
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionScheme
                       quickstep_expressions_predicate_Predicate
                       quickstep_expressions_scalar_Scalar
                       quickstep_queryexecution_QueryContext

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -35,31 +35,36 @@ bool DestroyHashOperator::getAllWorkOrders(
     const tmb::client_id scheduler_client_id,
     tmb::MessageBus *bus) {
   if (blocking_dependencies_met_ && !work_generated_) {
+    for (std::size_t part_id = 0; part_id < num_partitions_; ++part_id) {
+      container->addNormalWorkOrder(
+          new DestroyHashWorkOrder(query_id_, hash_table_index_, part_id, query_context),
+          op_index_);
+    }
     work_generated_ = true;
-    container->addNormalWorkOrder(
-        new DestroyHashWorkOrder(query_id_, hash_table_index_, query_context),
-        op_index_);
   }
   return work_generated_;
 }
 
 bool DestroyHashOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *container) {
   if (blocking_dependencies_met_ && !work_generated_) {
+    for (std::size_t part_id = 0; part_id < num_partitions_; ++part_id) {
+      serialization::WorkOrder *proto = new serialization::WorkOrder;
+      proto->set_work_order_type(serialization::DESTROY_HASH);
+      proto->set_query_id(query_id_);
+      proto->SetExtension(serialization::DestroyHashWorkOrder::join_hash_table_index, hash_table_index_);
+      proto->SetExtension(serialization::DestroyHashWorkOrder::partition_id, part_id);
+
+      container->addWorkOrderProto(proto, op_index_);
+    }
+
     work_generated_ = true;
-
-    serialization::WorkOrder *proto = new serialization::WorkOrder;
-    proto->set_work_order_type(serialization::DESTROY_HASH);
-    proto->set_query_id(query_id_);
-    proto->SetExtension(serialization::DestroyHashWorkOrder::join_hash_table_index, hash_table_index_);
-
-    container->addWorkOrderProto(proto, op_index_);
   }
   return work_generated_;
 }
 
 
 void DestroyHashWorkOrder::execute() {
-  query_context_->destroyJoinHashTable(hash_table_index_);
+  query_context_->destroyJoinHashTable(hash_table_index_, part_id_);
 }
 
 }  // namespace quickstep

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -22,6 +22,7 @@
 
 #include <string>
 
+#include "catalog/CatalogTypedefs.hpp"
 #include "query_execution/QueryContext.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
@@ -52,11 +53,14 @@ class DestroyHashOperator : public RelationalOperator {
    * @brief Constructor.
    *
    * @param query_id The ID of the query to which this operator belongs.
+   * @param num_partitions The number of partitions.
    * @param hash_table_index The index of the JoinHashTable in QueryContext.
    **/
   DestroyHashOperator(const std::size_t query_id,
+                      const std::size_t num_partitions,
                       const QueryContext::join_hash_table_id hash_table_index)
       : RelationalOperator(query_id),
+        num_partitions_(num_partitions),
         hash_table_index_(hash_table_index),
         work_generated_(false) {}
 
@@ -75,6 +79,7 @@ class DestroyHashOperator : public RelationalOperator {
   bool getAllWorkOrderProtos(WorkOrderProtosContainer *container) override;
 
  private:
+  const std::size_t num_partitions_;
   const QueryContext::join_hash_table_id hash_table_index_;
   bool work_generated_;
 
@@ -91,13 +96,16 @@ class DestroyHashWorkOrder : public WorkOrder {
    *
    * @param query_id The ID of the query to which this WorkOrder belongs.
    * @param hash_table_index The index of the JoinHashTable in QueryContext.
+   * @param part_id The partition id.
    * @param query_context The QueryContext to use.
    **/
   DestroyHashWorkOrder(const std::size_t query_id,
                        const QueryContext::join_hash_table_id hash_table_index,
+                       const partition_id part_id,
                        QueryContext *query_context)
       : WorkOrder(query_id),
         hash_table_index_(hash_table_index),
+        part_id_(part_id),
         query_context_(DCHECK_NOTNULL(query_context)) {}
 
   ~DestroyHashWorkOrder() override {}
@@ -106,6 +114,7 @@ class DestroyHashWorkOrder : public WorkOrder {
 
  private:
   const QueryContext::join_hash_table_id hash_table_index_;
+  const partition_id part_id_;
   QueryContext *query_context_;
 
   DISALLOW_COPY_AND_ASSIGN(DestroyHashWorkOrder);

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -63,13 +63,16 @@ message AggregationWorkOrder {
   }
 }
 
+// Next tag: 40.
 message BuildHashWorkOrder {
   extend WorkOrder {
     // All required.
     optional int32 relation_id = 32;
     repeated int32 join_key_attributes = 33;
     optional bool any_join_key_attributes_nullable = 34;
+    optional uint64 num_partitions = 38;
     optional uint32 join_hash_table_index = 35;
+    optional uint64 partition_id = 39;
     optional fixed64 block_id = 36;
     optional int32 lip_deployment_index = 37;
   }
@@ -89,6 +92,7 @@ message DestroyHashWorkOrder {
   extend WorkOrder {
     // All required.
     optional uint32 join_hash_table_index = 112;
+    optional uint64 partition_id = 113;
   }
 }
 
@@ -109,6 +113,7 @@ message FinalizeAggregationWorkOrder {
   }
 }
 
+// Next tag: 174.
 message HashJoinWorkOrder {
   enum HashJoinWorkOrderType {
     HASH_ANTI_JOIN = 0;
@@ -124,8 +129,10 @@ message HashJoinWorkOrder {
     optional int32 probe_relation_id = 162;
     repeated int32 join_key_attributes = 163;
     optional bool any_join_key_attributes_nullable = 164;
+    optional uint64 num_partitions = 172;
     optional int32 insert_destination_index = 165;
     optional uint32 join_hash_table_index = 166;
+    optional uint64 partition_id = 173;
     optional int32 selection_index = 167;
     optional fixed64 block_id = 168;
 

--- a/storage/StorageBlockInfo.hpp
+++ b/storage/StorageBlockInfo.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <vector>
 
 #include "utility/Macros.hpp"
 
@@ -48,6 +49,8 @@ static constexpr block_id kInvalidBlockId = 0;
 static constexpr int kBlockIdDomainLengthInDigits = std::numeric_limits<block_id_domain>::digits10;
 static constexpr int kBlockIdCounterLengthInDigits = std::numeric_limits<block_id_counter>::digits10;
 static constexpr block_id_domain kMaxDomain = static_cast<block_id_domain>(0xFFFF);
+
+typedef std::vector<block_id> BlocksInPartition;
 
 /**
  * @brief All-static object that provides access to block_id.


### PR DESCRIPTION
Assigned to @hbdeshmukh or @jianqiao.

This PR allows `HashJoin` to accept partitioned info. If no partition, `num_partitions` is `1`.