### PR TITLE
Fix the bug with SingleIdentityHashFilter when filter_cardinality is 0.

### DIFF
--- a/query_optimizer/rules/AttachLIPFilters.cpp
+++ b/query_optimizer/rules/AttachLIPFilters.cpp
@@ -19,6 +19,7 @@
 
 #include "query_optimizer/rules/AttachLIPFilters.hpp"
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include <unordered_set>
@@ -128,7 +129,7 @@ void AttachLIPFilters::attachLIPFilters(
           lip_filter_configuration_->addBuildInfo(
               P::SingleIdentityHashFilterBuildInfo::Create(
                   pair.second->source_attribute,
-                  pair.second->estimated_cardinality * 8),
+                  std::max(64uL, pair.second->estimated_cardinality * 8u)),
               pair.second->source);
           lip_filter_configuration_->addProbeInfo(
               P::LIPFilterProbeInfo::Create(

--- a/utility/lip_filter/SingleIdentityHashFilter.hpp
+++ b/utility/lip_filter/SingleIdentityHashFilter.hpp
@@ -66,7 +66,7 @@ class SingleIdentityHashFilter : public LIPFilter {
       : LIPFilter(LIPFilterType::kSingleIdentityHashFilter),
         filter_cardinality_(filter_cardinality),
         bit_array_(GetByteSize(filter_cardinality)) {
-    DCHECK_GE(filter_cardinality, 0u);
+    DCHECK_GE(filter_cardinality, 1u);
     std::memset(bit_array_.data(),
                 0x0,
                 sizeof(std::atomic<std::uint8_t>) * GetByteSize(filter_cardinality));


### PR DESCRIPTION
This PR fixes the problem with `SingleIdentityHashFilter` when the estimated filter cardinality is 0 (by setting the filter cardinality to at least 64).