### PR TITLE
Adds regex to specify 16.+ versions of Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ else()
   # builds to fail. As a short-term workaround for now, we turn off deprecated
   # warnings so that they do not cause build failures anymore.
   # TODO: Remove this workaround by fixing the protobuf_cmake and glog_cmake.
-  if (${CMAKE_SYSTEM} MATCHES "Darwin-16.1.0")
+  if (${CMAKE_SYSTEM} MATCHES "Darwin-16.[0-9]*.[0-9]*")
     if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
       CHECK_CXX_COMPILER_FLAG("-Wno-error=deprecated-declarations" COMPILER_HAS_WNO_DEPRECATED)
       if (COMPILER_HAS_WNO_DEPRECATED)


### PR DESCRIPTION
Before this change, only one recent version of Darwin was correctly
having the compiler flags modified to allow for deprecated syscalls.
After this change, all versions of Darwin 16+ should correctly apply the
cxx flags. This is still a somewhat temporary fix because the real
issue (replacing the deprecated calls) has not been addressed.