### PR TITLE
Use BitVectorExactFilter as LIPFilter implementation when applicable

### DIFF
--- a/query_optimizer/rules/AttachLIPFilters.hpp
+++ b/query_optimizer/rules/AttachLIPFilters.hpp
@@ -21,6 +21,7 @@
 #define QUICKSTEP_QUERY_OPTIMIZER_RULES_ATTACH_LIP_FILTERS_HPP_
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>
@@ -134,6 +135,14 @@ class AttachLIPFilters : public Rule<physical::Physical> {
   const std::vector<LIPFilterInfoPtr>& getBuildSideInfo(const NodeList &path);
 
   const std::vector<LIPFilterInfoPtr>& getProbeSideInfo(const NodeList &path);
+
+  // TODO(jianqiao): refactor this method as it is a duplication of
+  // InjectJoinFilters::findExactMinMaxValuesForAttributeHelper().
+  bool findExactMinMaxValuesForAttributeHelper(
+      const physical::PhysicalPtr &physical_plan,
+      const expressions::AttributeReferencePtr &attribute,
+      std::int64_t *min_cpp_value,
+      std::int64_t *max_cpp_value) const;
 
   std::unique_ptr<cost::StarSchemaSimpleCostModel> cost_model_;
   std::map<physical::PhysicalPtr, std::vector<LIPFilterInfoPtr>> build_side_info_;

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_AttachLIPFilters
                       quickstep_queryoptimizer_physical_Selection
                       quickstep_queryoptimizer_physical_TopLevelPlan
                       quickstep_queryoptimizer_rules_Rule
+                      quickstep_types_TypeID
                       quickstep_types_TypedValue
                       quickstep_utility_Macros
                       quickstep_utility_lipfilter_LIPFilter)


### PR DESCRIPTION
In the previous exact-filter PR, it was not by default use `BitVectorExactFilter` as the LIPFilter implementation when applicable -- `BitVectorExactFilter` was only used for executing `FilterJoin` nodes.

This PR is a quick update that uses the `BitVectorExactFilter` when applicable.
