### PR TITLE
Fix gcc build error with PackedPayloadHashTable 

### DIFF
--- a/storage/PackedPayloadHashTable.cpp
+++ b/storage/PackedPayloadHashTable.cpp
@@ -251,7 +251,7 @@ bool PackedPayloadHashTable::upsertValueAccessorCompositeKey(
       [&](auto use_two_accessors,  // NOLINT(build/c++11)
           auto key_only,
           auto has_variable_size) -> bool {
-    return upsertValueAccessorCompositeKeyInternal<
+    return this->upsertValueAccessorCompositeKeyInternal<
         decltype(use_two_accessors)::value,
         decltype(key_only)::value,
         decltype(has_variable_size)::value>(


### PR DESCRIPTION
This PR fixes the gcc build error (missing `this` pointer for calling a method in a capture-all-by-reference lambda function).

Note: Modified `travis.yml` for testing, do not merge yet.