### PR TITLE
patch to fix gcc compile error gflags

### DIFF
--- a/third_party/download_and_patch_prerequisites.sh
+++ b/third_party/download_and_patch_prerequisites.sh
@@ -99,6 +99,7 @@ patch ${THIRD_PARTY_SRC_DIR}/linenoise/linenoise.c ${PATCH_DIR}/linenoise/lineno
 echo "Patching for gflags:"
 cd ${THIRD_PARTY_SRC_DIR}/gflags
 patch -p0 < ${PATCH_DIR}/gflags/CMakeLists.patch
+patch src/gflags_reporting.cc ${PATCH_DIR}/gflags/gflags_reporting.cc.patch
 cd ${THIRD_PARTY_SRC_DIR}
 
 # Apply re2 patch.

--- a/third_party/patches/gflags/gflags_reporting.cc.patch
+++ b/third_party/patches/gflags/gflags_reporting.cc.patch
@@ -1,0 +1,4 @@
+129c129
+<     assert(chars_left == strlen(c_string));  // Unless there's a \0 in there?
+---
+>     assert(static_cast<size_t>(chars_left) == strlen(c_string));  // Unless there's a \0 in there?


### PR DESCRIPTION
This fix adds a patch to the third party library `gflags` so that compilation will work with certain versions of GCC which were previously erroring on a warn->error for an unsigned to signed conversion.

@jianqiao 