### PR TITLE
Fix a bug with SelectOperator

### DIFF
--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -202,9 +202,12 @@ class SelectOperator : public RelationalOperator {
 
   bool getAllWorkOrderProtos(WorkOrderProtosContainer *container) override;
 
-  void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id,
+  void feedInputBlock(const block_id input_block_id,
+                      const relation_id input_relation_id,
                       const partition_id part_id) override {
-    input_relation_block_ids_[part_id].push_back(input_block_id);
+    if (input_relation_id == input_relation_.getID()) {
+      input_relation_block_ids_[part_id].push_back(input_block_id);
+    }
   }
 
   QueryContext::insert_destination_id getInsertDestinationID() const override {

--- a/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
+++ b/relational_operators/tests/SortRunGenerationOperator_unittest.cpp
@@ -622,7 +622,7 @@ TEST_F(SortRunGenerationOperatorTest, 3Column_NullLast_Asc) {
 
   // Comparator for null-col-1 ASC NULLS LAST, null-col-2 ASC NULLS LAST,
   // null-col-3 ASC NULLS LAST.
-  auto comparator = [this](const Tuple &left, const Tuple &right) -> bool {
+  auto comparator = [](const Tuple &left, const Tuple &right) -> bool {
     TestTupleAttrs l = TupleToTupleAttr(left);
     TestTupleAttrs r = TupleToTupleAttr(right);
     l.c1 = l.null_c4 ? std::numeric_limits<int>::max() : l.c1;


### PR DESCRIPTION
This PR fixes a bug that `SELECT ... LIMIT n;` may output more than `n` rows.

The cause is that `SortMergeRunOperator` creates two relations, where one relation is the output relation to a `SelectOperator` and the other is a _temporary_ relation. However, the generated blocks of the temporary relation are also fed into the `SelectOperator` via a _DataPipelineMessage_ -- thus we need to check that the input block to a `SelectOperator` is actually from its input relation.
