### PR TITLE
Cmake changes for default build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+      "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
 if (WIN32)
   # Make Windows compilers shut up about using standard libc functions.
   set_property(
@@ -49,7 +54,7 @@ else()
   option(ENABLE_HDFS "Enable HDFS FileManager" OFF)
 endif()
 
-if (UNIX AND NOT CYGWIN)
+if (UNIX AND NOT CYGWIN AND NOT APPLE)
   option(USE_TCMALLOC "Use tcmalloc (Google's thread-cacheing malloc) instead of system-provided malloc" ON)
 else()
   option(USE_TCMALLOC "Use tcmalloc (Google's thread-cacheing malloc) instead of system-provided malloc" OFF)


### PR DESCRIPTION
This fixes two annoying build issues

1. If the CMAKEBUILDTYPE is not set by the user, it previously defaulted to none-type which caused one of our tests to fail. It is now set to RelWithDebInfo if no build type is set. Code take from [link](https://github.com/miloyip/rapidjson/issues/319)
2. When building on Mac, the default setting of TCMALLOC would cause a compiler error. We fix this by disabling TCMALLOC on Mac

