### PR TITLE
QUICKSTEP-83 Measure memory consumption of a running query

### DIFF
--- a/catalog/CatalogRelation.hpp
+++ b/catalog/CatalogRelation.hpp
@@ -396,6 +396,20 @@ class CatalogRelation : public CatalogRelationSchema {
     return statistics_.get();
   }
 
+  /**
+   * @brief Get the size of this relation in bytes.
+   *
+   * @note The output signifies the amount of memory allocated for this
+   *       relation. The true memory footprint of this relation could be lower
+   *       than the output of this method.
+   **/
+  inline std::size_t getRelationSizeBytes() const {
+    SpinSharedMutexSharedLock<false> lock(blocks_mutex_);
+    return blocks_.size() *
+           getDefaultStorageBlockLayout().getDescription().num_slots() *
+           kSlotSizeBytes;
+  }
+
  private:
   // A list of blocks belonged to the relation.
   std::vector<block_id> blocks_;

--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -216,6 +216,7 @@ target_link_libraries(quickstep_queryexecution_QueryContext
                       quickstep_storage_InsertDestination
                       quickstep_storage_InsertDestination_proto
                       quickstep_storage_WindowAggregationOperationState
+                      quickstep_threading_SpinSharedMutex
                       quickstep_types_TypedValue
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros
@@ -281,6 +282,7 @@ if (ENABLE_DISTRIBUTED)
                         tmb)
 endif(ENABLE_DISTRIBUTED)
 target_link_libraries(quickstep_queryexecution_QueryManagerSingleNode
+                      quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_QueryExecutionState

--- a/query_execution/QueryManagerBase.hpp
+++ b/query_execution/QueryManagerBase.hpp
@@ -271,6 +271,15 @@ class QueryManagerBase {
     return query_exec_state_->hasRebuildInitiated(index);
   }
 
+  /**
+   * @brief Get the query's current memory consumption in bytes.
+   *
+   * @note This method returns a best guess consumption, at the time of the call.
+   **/
+  virtual std::size_t getQueryMemoryConsumptionBytes() const {
+    return 0;
+  }
+
   std::unique_ptr<QueryHandle> query_handle_;
 
   const std::size_t query_id_;

--- a/query_execution/QueryManagerSingleNode.hpp
+++ b/query_execution/QueryManagerSingleNode.hpp
@@ -36,6 +36,7 @@ namespace tmb { class MessageBus; }
 
 namespace quickstep {
 
+class CatalogDatabase;
 class CatalogDatabaseLite;
 class QueryHandle;
 class StorageManager;
@@ -94,6 +95,8 @@ class QueryManagerSingleNode final : public QueryManagerBase {
     return query_context_.get();
   }
 
+  std::size_t getQueryMemoryConsumptionBytes() const override;
+
  private:
   bool checkNormalExecutionOver(const dag_node_index index) const override {
     return (checkAllDependenciesMet(index) &&
@@ -123,6 +126,12 @@ class QueryManagerSingleNode final : public QueryManagerBase {
   void getRebuildWorkOrders(const dag_node_index index,
                             WorkOrdersContainer *container);
 
+  /**
+   * @brief Get the total memory (in bytes) occupied by temporary relations
+   *        created during the query execution.
+   **/
+  std::size_t getTotalTempRelationMemoryInBytes() const;
+
   const tmb::client_id foreman_client_id_;
 
   StorageManager *storage_manager_;
@@ -131,6 +140,8 @@ class QueryManagerSingleNode final : public QueryManagerBase {
   std::unique_ptr<QueryContext> query_context_;
 
   std::unique_ptr<WorkOrdersContainer> workorders_container_;
+
+  const CatalogDatabase &database_;
 
   DISALLOW_COPY_AND_ASSIGN(QueryManagerSingleNode);
 };

--- a/storage/AggregationOperationState.cpp
+++ b/storage/AggregationOperationState.cpp
@@ -946,4 +946,25 @@ void AggregationOperationState::finalizeHashTableImplThreadPrivate(
   output_destination->bulkInsertTuples(&complete_result);
 }
 
+std::size_t AggregationOperationState::getMemoryConsumptionBytes() const {
+  std::size_t memory = getMemoryConsumptionBytesHelper(distinctify_hashtables_);
+  memory += getMemoryConsumptionBytesHelper(group_by_hashtables_);
+  memory += collision_free_hashtable_->getMemoryConsumptionBytes();
+  memory += group_by_hashtable_pool_->getMemoryConsumptionPoolBytes();
+  memory += partitioned_group_by_hashtable_pool_->getMemoryConsumptionPoolBytes();
+  return memory;
+}
+
+std::size_t AggregationOperationState::getMemoryConsumptionBytesHelper(
+    const std::vector<std::unique_ptr<AggregationStateHashTableBase>>
+        &hashtables) const {
+  std::size_t memory = 0;
+  for (std::size_t ht_id = 0; ht_id < hashtables.size(); ++ht_id) {
+    if (hashtables[ht_id] != nullptr) {
+      memory += hashtables[ht_id]->getMemoryConsumptionBytes();
+    }
+  }
+  return memory;
+}
+
 }  // namespace quickstep

--- a/storage/AggregationOperationState.hpp
+++ b/storage/AggregationOperationState.hpp
@@ -207,6 +207,11 @@ class AggregationOperationState {
    */
   CollisionFreeVectorTable* getCollisionFreeVectorTable() const;
 
+  /**
+   * @brief Get the memory footprint of the AggregationOperationState.
+   **/
+  std::size_t getMemoryConsumptionBytes() const;
+
  private:
   // Check whether partitioned aggregation can be applied.
   bool checkAggregatePartitioned(
@@ -252,6 +257,10 @@ class AggregationOperationState {
                                         InsertDestination *output_destination);
 
   void finalizeHashTableImplThreadPrivate(InsertDestination *output_destination);
+
+  std::size_t getMemoryConsumptionBytesHelper(
+      const std::vector<std::unique_ptr<AggregationStateHashTableBase>>
+          &hashtables) const;
 
   // Common state for all aggregates in this operation: the input relation, the
   // filter predicate (if any), and the list of GROUP BY expressions (if any).

--- a/storage/CollisionFreeVectorTable.hpp
+++ b/storage/CollisionFreeVectorTable.hpp
@@ -169,6 +169,10 @@ class CollisionFreeVectorTable : public AggregationStateHashTableBase {
                      const std::size_t handle_id,
                      NativeColumnVector *output_cv) const;
 
+  std::size_t getMemoryConsumptionBytes() const override {
+    return memory_size_;
+  }
+
  private:
   inline static std::size_t CacheLineAlignedBytes(const std::size_t actual_bytes) {
     return (actual_bytes + kCacheLineBytes - 1) / kCacheLineBytes * kCacheLineBytes;

--- a/storage/HashTable.hpp
+++ b/storage/HashTable.hpp
@@ -541,6 +541,11 @@ class HashTable : public HashTableBase<resizable,
       FunctorT *functor);
 
   /**
+   * @brief Get the size of the hash table at the time this function is called.
+   **/
+  virtual std::size_t getHashTableMemorySizeBytes() const = 0;
+
+  /**
    * @brief Determine the number of entries (key-value pairs) contained in this
    *        HashTable.
    * @note For some HashTable implementations, this is O(1), but for others it

--- a/storage/HashTableBase.hpp
+++ b/storage/HashTableBase.hpp
@@ -115,6 +115,8 @@ class AggregationStateHashTableBase {
 
   virtual void destroyPayload() = 0;
 
+  virtual std::size_t getMemoryConsumptionBytes() const = 0;
+
  protected:
   AggregationStateHashTableBase() {}
 

--- a/storage/HashTablePool.hpp
+++ b/storage/HashTablePool.hpp
@@ -123,6 +123,19 @@ class HashTablePool {
     return &hash_tables_;
   }
 
+  /**
+   * @brief Get the total memory consumed by the hash tables in this pool.
+   **/
+  std::size_t getMemoryConsumptionPoolBytes() const {
+    std::size_t memory = 0;
+    for (std::size_t ht_id = 0; ht_id <  hash_tables_.size(); ++ht_id) {
+      if (hash_tables_[ht_id] != nullptr) {
+        memory += hash_tables_[ht_id]->getMemoryConsumptionBytes();
+      }
+    }
+    return memory;
+  }
+
  private:
   AggregationStateHashTableBase* createNewHashTable() {
     return AggregationStateHashTableFactory::CreateResizable(

--- a/storage/LinearOpenAddressingHashTable.hpp
+++ b/storage/LinearOpenAddressingHashTable.hpp
@@ -120,6 +120,10 @@ class LinearOpenAddressingHashTable : public HashTable<ValueT,
   void getAllCompositeKey(const std::vector<TypedValue> &key,
                           std::vector<const ValueT*> *values) const override;
 
+  std::size_t getHashTableMemorySizeBytes() const override {
+     return sizeof(Header) + numEntries() * bucket_size_;
+  }
+
  protected:
   HashTablePutResult putInternal(const TypedValue &key,
                                  const std::size_t variable_key_size,

--- a/storage/PackedPayloadHashTable.hpp
+++ b/storage/PackedPayloadHashTable.hpp
@@ -314,6 +314,10 @@ class PackedPayloadHashTable : public AggregationStateHashTableBase {
   inline std::size_t forEachCompositeKey(FunctorT *functor,
                                          const std::size_t index) const;
 
+  std::size_t getMemoryConsumptionBytes() const override {
+    return sizeof(Header) + numEntries() * bucket_size_;
+  }
+
  private:
   void resize(const std::size_t extra_buckets,
               const std::size_t extra_variable_storage,

--- a/storage/PartitionedHashTablePool.hpp
+++ b/storage/PartitionedHashTablePool.hpp
@@ -113,6 +113,19 @@ class PartitionedHashTablePool {
     return num_partitions_;
   }
 
+  /**
+   * @brief Get the total memory consumed by the hash tables in this pool.
+   **/
+  std::size_t getMemoryConsumptionPoolBytes() const {
+    std::size_t memory = 0;
+    for (std::size_t ht_id = 0; ht_id <  hash_tables_.size(); ++ht_id) {
+      if (hash_tables_[ht_id] != nullptr) {
+        memory += hash_tables_[ht_id]->getMemoryConsumptionBytes();
+      }
+    }
+    return memory;
+  }
+
  private:
   void initializeAllHashTables() {
     for (std::size_t part_num = 0; part_num < num_partitions_; ++part_num) {

--- a/storage/SeparateChainingHashTable.hpp
+++ b/storage/SeparateChainingHashTable.hpp
@@ -114,6 +114,10 @@ class SeparateChainingHashTable : public HashTable<ValueT,
   void getAllCompositeKey(const std::vector<TypedValue> &key,
                           std::vector<const ValueT*> *values) const override;
 
+  std::size_t getHashTableMemorySizeBytes() const override {
+    return sizeof(Header) + numEntries() * bucket_size_;
+  }
+
  protected:
   HashTablePutResult putInternal(const TypedValue &key,
                                  const std::size_t variable_key_size,

--- a/storage/SimpleScalarSeparateChainingHashTable.hpp
+++ b/storage/SimpleScalarSeparateChainingHashTable.hpp
@@ -135,6 +135,10 @@ class SimpleScalarSeparateChainingHashTable : public HashTable<ValueT,
     return getAll(key.front(), values);
   }
 
+  std::size_t getHashTableMemorySizeBytes() const override {
+    return sizeof(Header) + numEntries() * sizeof(Bucket);
+  }
+
  protected:
   HashTablePutResult putInternal(const TypedValue &key,
                                  const std::size_t variable_key_size,


### PR DESCRIPTION
- Methods to get memory footprints of join hash tables (for all of its
  implementations)
- Method to get the memory consumed by the active temporary relations
  during the query execution.
- Added methods for measuring memory consumed by hash tables used for
  aggregation.
- AggregationOperationState can provide total memory used for a single
  aggregation node.
- QueryContext can aggregate the memory consumed by all temporary data
  structures (e.g. join hash tables, aggregation hash tables).
- QueryManagerBase provides an API to get the total memory footprint of
  a query (only implemented for single node version).
- Mutex protection for hash join tables' list and insert destinations' list in
  the QueryContext class.