### PR TITLE
Fixed a pedantic warning.

### DIFF
--- a/query_execution/Shiftboss.hpp
+++ b/query_execution/Shiftboss.hpp
@@ -40,7 +40,7 @@
 #include "tmb/address.h"
 #include "tmb/id_typedefs.h"
 
-namespace tmb { class MessageBus; };
+namespace tmb { class MessageBus; }
 
 namespace quickstep {
 


### PR DESCRIPTION
This small PR removes `;` after the namespace scope.