### PR TITLE
Added an enum type for all relational operators

### DIFF
--- a/query_execution/tests/QueryManagerSingleNode_unittest.cpp
+++ b/query_execution/tests/QueryManagerSingleNode_unittest.cpp
@@ -105,6 +105,10 @@ class MockOperator: public RelationalOperator {
         num_calls_donefeedingblocks_(0) {
   }
 
+  OperatorType getOperatorType() const override {
+    return kMockOperator;
+  }
+
   std::string getName() const override {
     return "MockOperator";
   }

--- a/relational_operators/AggregationOperator.hpp
+++ b/relational_operators/AggregationOperator.hpp
@@ -82,6 +82,10 @@ class AggregationOperator : public RelationalOperator {
 
   ~AggregationOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kAggregation;
+  }
+
   std::string getName() const override {
     return "AggregationOperator";
   }

--- a/relational_operators/BuildAggregationExistenceMapOperator.hpp
+++ b/relational_operators/BuildAggregationExistenceMapOperator.hpp
@@ -88,6 +88,10 @@ class BuildAggregationExistenceMapOperator : public RelationalOperator {
 
   ~BuildAggregationExistenceMapOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kBuildAggregationExistenceMap;
+  }
+
   std::string getName() const override {
     return "BuildAggregationExistenceMapOperator";
   }

--- a/relational_operators/BuildHashOperator.hpp
+++ b/relational_operators/BuildHashOperator.hpp
@@ -118,6 +118,10 @@ class BuildHashOperator : public RelationalOperator {
     return input_relation_;
   }
 
+  OperatorType getOperatorType() const override {
+    return kBuildHash;
+  }
+
   std::string getName() const override {
     return "BuildHashOperator";
   }

--- a/relational_operators/BuildLIPFilterOperator.hpp
+++ b/relational_operators/BuildLIPFilterOperator.hpp
@@ -98,6 +98,10 @@ class BuildLIPFilterOperator : public RelationalOperator {
     return input_relation_;
   }
 
+  OperatorType getOperatorType() const override {
+    return kBuildLIPFilter;
+  }
+
   std::string getName() const override {
     return "BuildLIPFilterOperator";
   }

--- a/relational_operators/CreateIndexOperator.hpp
+++ b/relational_operators/CreateIndexOperator.hpp
@@ -70,6 +70,10 @@ class CreateIndexOperator : public RelationalOperator {
 
   ~CreateIndexOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kCreateIndex;
+  }
+
   std::string getName() const override {
     return "CreateIndexOperator";
   }

--- a/relational_operators/CreateTableOperator.hpp
+++ b/relational_operators/CreateTableOperator.hpp
@@ -69,6 +69,10 @@ class CreateTableOperator : public RelationalOperator {
 
   ~CreateTableOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kCreateTable;
+  }
+
   std::string getName() const override {
     return "CreateTableOperator";
   }

--- a/relational_operators/DeleteOperator.hpp
+++ b/relational_operators/DeleteOperator.hpp
@@ -84,6 +84,10 @@ class DeleteOperator : public RelationalOperator {
 
   ~DeleteOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kDelete;
+  }
+
   std::string getName() const override {
     return "DeleteOperator";
   }

--- a/relational_operators/DestroyAggregationStateOperator.hpp
+++ b/relational_operators/DestroyAggregationStateOperator.hpp
@@ -63,6 +63,10 @@ class DestroyAggregationStateOperator : public RelationalOperator {
 
   ~DestroyAggregationStateOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kDestroyAggregationState;
+  }
+
   std::string getName() const override {
     return "DestroyAggregationStateOperator";
   }

--- a/relational_operators/DestroyHashOperator.hpp
+++ b/relational_operators/DestroyHashOperator.hpp
@@ -66,6 +66,10 @@ class DestroyHashOperator : public RelationalOperator {
 
   ~DestroyHashOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kDestroyHash;
+  }
+
   std::string getName() const override {
     return "DestroyHashOperator";
   }

--- a/relational_operators/DropTableOperator.hpp
+++ b/relational_operators/DropTableOperator.hpp
@@ -77,6 +77,10 @@ class DropTableOperator : public RelationalOperator {
 
   ~DropTableOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kDropTable;
+  }
+
   std::string getName() const override {
     return "DropTableOperator";
   }

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -76,6 +76,10 @@ class FinalizeAggregationOperator : public RelationalOperator {
 
   ~FinalizeAggregationOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kFinalizeAggregation;
+  }
+
   std::string getName() const override {
     return "FinalizeAggregationOperator";
   }

--- a/relational_operators/HashJoinOperator.hpp
+++ b/relational_operators/HashJoinOperator.hpp
@@ -178,6 +178,21 @@ class HashJoinOperator : public RelationalOperator {
 
   ~HashJoinOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    switch (join_type_) {
+      case JoinType::kInnerJoin:
+        return kInnerJoin;
+      case JoinType::kLeftSemiJoin:
+        return kLeftSemiJoin;
+      case JoinType::kLeftAntiJoin:
+        return kLeftAntiJoin;
+      case JoinType::kLeftOuterJoin:
+        return kLeftOuterJoin;
+      default:
+        LOG(FATAL) << "Unknown join type in HashJoinOperator::getOperatorType()";
+    }
+  }
+
   std::string getName() const override {
     switch (join_type_) {
       case JoinType::kInnerJoin:

--- a/relational_operators/InitializeAggregationOperator.hpp
+++ b/relational_operators/InitializeAggregationOperator.hpp
@@ -65,6 +65,10 @@ class InitializeAggregationOperator : public RelationalOperator {
 
   ~InitializeAggregationOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kInitializeAggregation;
+  }
+
   std::string getName() const override {
     return "InitializeAggregationOperator";
   }

--- a/relational_operators/InsertOperator.hpp
+++ b/relational_operators/InsertOperator.hpp
@@ -76,6 +76,10 @@ class InsertOperator : public RelationalOperator {
 
   ~InsertOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kInsert;
+  }
+
   std::string getName() const override {
     return "InsertOperator";
   }

--- a/relational_operators/NestedLoopsJoinOperator.hpp
+++ b/relational_operators/NestedLoopsJoinOperator.hpp
@@ -119,6 +119,10 @@ class NestedLoopsJoinOperator : public RelationalOperator {
 
   ~NestedLoopsJoinOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kNestedLoopsJoin;
+  }
+
   std::string getName() const override {
     return "NestedLoopsJoinOperator";
   }

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -58,6 +58,45 @@ class RelationalOperator {
   virtual ~RelationalOperator() {}
 
   /**
+   * @brief Enumeration of the operator types.
+   **/
+  enum OperatorType {
+    kAggregation = 0,
+    kBuildAggregationExistenceMap,
+    kBuildHash,
+    kBuildLIPFilter,
+    kCreateIndex,
+    kCreateTable,
+    kDelete,
+    kDestroyAggregationState,
+    kDestroyHash,
+    kDropTable,
+    kFinalizeAggregation,
+    kInitializeAggregation,
+    kInnerJoin,
+    kInsert,
+    kLeftAntiJoin,
+    kLeftOuterJoin,
+    kLeftSemiJoin,
+    kNestedLoopsJoin,
+    kSample,
+    kSaveBlocks,
+    kSelect,
+    kSortMergeRun,
+    kSortRunGeneration,
+    kTableGenerator,
+    kTextScan,
+    kUpdate,
+    kWindowAggregation,
+    kMockOperator
+  };
+
+  /**
+   * @brief Get the type of the operator.
+   **/
+  virtual OperatorType getOperatorType() const = 0;
+
+  /**
    * @brief Get the name of this relational operator.
    *
    * @return The name of this relational operator.

--- a/relational_operators/SampleOperator.hpp
+++ b/relational_operators/SampleOperator.hpp
@@ -96,6 +96,10 @@ class SampleOperator : public RelationalOperator {
 
   ~SampleOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kSample;
+  }
+
   std::string getName() const override {
     return "SampleOperator";
   }

--- a/relational_operators/SaveBlocksOperator.hpp
+++ b/relational_operators/SaveBlocksOperator.hpp
@@ -71,6 +71,10 @@ class SaveBlocksOperator : public RelationalOperator {
 
   ~SaveBlocksOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kSaveBlocks;
+  }
+
   std::string getName() const override {
     return "SaveBlocksOperator";
   }

--- a/relational_operators/SelectOperator.hpp
+++ b/relational_operators/SelectOperator.hpp
@@ -186,6 +186,10 @@ class SelectOperator : public RelationalOperator {
 
   ~SelectOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kSelect;
+  }
+
   std::string getName() const override {
     return "SelectOperator";
   }

--- a/relational_operators/SortMergeRunOperator.hpp
+++ b/relational_operators/SortMergeRunOperator.hpp
@@ -132,6 +132,10 @@ class SortMergeRunOperator : public RelationalOperator {
    **/
   ~SortMergeRunOperator() {}
 
+  OperatorType getOperatorType() const override {
+    return kSortMergeRun;
+  }
+
   std::string getName() const override {
     return "SortMergeRunOperator";
   }

--- a/relational_operators/SortRunGenerationOperator.hpp
+++ b/relational_operators/SortRunGenerationOperator.hpp
@@ -112,6 +112,10 @@ class SortRunGenerationOperator : public RelationalOperator {
 
   ~SortRunGenerationOperator() {}
 
+  OperatorType getOperatorType() const override {
+    return kSortRunGeneration;
+  }
+
   std::string getName() const override {
     return "SortRunGenerationOperator";
   }

--- a/relational_operators/TableGeneratorOperator.hpp
+++ b/relational_operators/TableGeneratorOperator.hpp
@@ -78,6 +78,10 @@ class TableGeneratorOperator : public RelationalOperator {
 
   ~TableGeneratorOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kTableGenerator;
+  }
+
   std::string getName() const override {
     return "TableGeneratorOperator";
   }

--- a/relational_operators/TextScanOperator.hpp
+++ b/relational_operators/TextScanOperator.hpp
@@ -135,6 +135,10 @@ class TextScanOperator : public RelationalOperator {
 
   ~TextScanOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kTextScan;
+  }
+
   std::string getName() const override {
     return "TextScanOperator";
   }

--- a/relational_operators/UpdateOperator.hpp
+++ b/relational_operators/UpdateOperator.hpp
@@ -97,6 +97,10 @@ class UpdateOperator : public RelationalOperator {
 
   ~UpdateOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kUpdate;
+  }
+
   std::string getName() const override {
     return "UpdateOperator";
   }

--- a/relational_operators/WindowAggregationOperator.hpp
+++ b/relational_operators/WindowAggregationOperator.hpp
@@ -79,6 +79,10 @@ class WindowAggregationOperator : public RelationalOperator {
 
   ~WindowAggregationOperator() override {}
 
+  OperatorType getOperatorType() const override {
+    return kWindowAggregation;
+  }
+
   std::string getName() const override {
     return "WindowAggregationOperator";
   }

--- a/storage/AggregationOperationState.cpp
+++ b/storage/AggregationOperationState.cpp
@@ -949,9 +949,15 @@ void AggregationOperationState::finalizeHashTableImplThreadPrivate(
 std::size_t AggregationOperationState::getMemoryConsumptionBytes() const {
   std::size_t memory = getMemoryConsumptionBytesHelper(distinctify_hashtables_);
   memory += getMemoryConsumptionBytesHelper(group_by_hashtables_);
-  memory += collision_free_hashtable_->getMemoryConsumptionBytes();
-  memory += group_by_hashtable_pool_->getMemoryConsumptionPoolBytes();
-  memory += partitioned_group_by_hashtable_pool_->getMemoryConsumptionPoolBytes();
+  if (collision_free_hashtable_ != nullptr) {
+    memory += collision_free_hashtable_->getMemoryConsumptionBytes();
+  }
+  if (group_by_hashtable_pool_ != nullptr) {
+    memory += group_by_hashtable_pool_->getMemoryConsumptionPoolBytes();
+  }
+  if (partitioned_group_by_hashtable_pool_ != nullptr) {
+    memory += partitioned_group_by_hashtable_pool_->getMemoryConsumptionPoolBytes();
+  }
   return memory;
 }
 

--- a/storage/PartitionedHashTablePool.hpp
+++ b/storage/PartitionedHashTablePool.hpp
@@ -118,7 +118,7 @@ class PartitionedHashTablePool {
    **/
   std::size_t getMemoryConsumptionPoolBytes() const {
     std::size_t memory = 0;
-    for (std::size_t ht_id = 0; ht_id <  hash_tables_.size(); ++ht_id) {
+    for (std::size_t ht_id = 0; ht_id < hash_tables_.size(); ++ht_id) {
       if (hash_tables_[ht_id] != nullptr) {
         memory += hash_tables_[ht_id]->getMemoryConsumptionBytes();
       }


### PR DESCRIPTION
The goal of this PR is that the scheduler should be able to identify individual operations in the query plan DAG.