### PR TITLE
Initial SingleNodeClient implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ if (ENABLE_VECTOR_PREDICATE_SHORT_CIRCUIT)
   )
 endif()
 
+option(ENABLE_SINGLE_NODE_SERVER "Enables server mode in single node setting" ON)
 option(ENABLE_DISTRIBUTED "Use the distributed version of Quickstep" OFF)
 
 macro (set_gflags_lib_name)
@@ -792,3 +793,13 @@ if (ENABLE_DISTRIBUTED)
                         ${GFLAGS_LIB_NAME}
                         ${GRPCPLUSPLUS_LIBRARIES})
 endif(ENABLE_DISTRIBUTED)
+
+if(ENABLE_SINGLE_NODE_SERVER)
+  add_executable (quickstep_client cli/QuickstepClient.cpp)
+  target_link_libraries(quickstep_client
+            ${GFLAGS_LIB_NAME}
+            ${GRPCPLUSPLUS_LIBRARIES}
+            ${PROTOBUF3_LIBRARIES}
+            glog
+            quickstep_cli_SingleNodeServer_proto)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,11 +795,10 @@ if (ENABLE_DISTRIBUTED)
 endif(ENABLE_DISTRIBUTED)
 
 if(ENABLE_SINGLE_NODE_SERVER)
-  add_executable (quickstep_client cli/QuickstepClient.cpp)
+  add_executable (quickstep_client cli/SingleNodeClientExecutable.cpp)
   target_link_libraries(quickstep_client
             ${GFLAGS_LIB_NAME}
             ${GRPCPLUSPLUS_LIBRARIES}
-            ${PROTOBUF3_LIBRARIES}
             glog
-            quickstep_cli_SingleNodeServer_proto)
+            quickstep_cli_SingleNodeClient)
 endif()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -44,6 +44,22 @@ configure_file (
   "${CMAKE_CURRENT_BINARY_DIR}/CliConfig.h"
 )
 
+# Compile the protos for Single Node Server mode.
+if(ENABLE_SINGLE_NODE_SERVER)
+  # We will need some of the TMBs libraries
+  set(CMAKE_MODULE_PATH
+      ${CMAKE_MODULE_PATH}
+      "${PROJECT_SOURCE_DIR}/third_party/src/tmb/cmake")
+
+  find_package(Grpc++ REQUIRED)
+  include_directories(${GRPCPLUSPLUS_INCLUDE_DIRS})
+
+  GRPC_GENERATE_CPP(cli_SingleNodeServer_proto_srcs
+                    cli_SingleNodeServer_proto_hdrs
+                    .
+                    SingleNodeServer.proto)
+endif()
+
 # Declare micro-libs and link dependencies:
 add_library(quickstep_cli_CommandExecutor CommandExecutor.cpp CommandExecutor.hpp)
 add_library(quickstep_cli_CommandExecutorUtil CommandExecutorUtil.cpp CommandExecutorUtil.hpp)
@@ -65,6 +81,12 @@ else()
               LineReaderDumb.cpp
               LineReader.hpp
               LineReaderDumb.hpp)
+endif()
+
+if (ENABLE_SINGLE_NODE_SERVER)
+  add_library(quickstep_cli_SingleNodeServer_proto
+              ${cli_SingleNodeServer_proto_srcs}
+              ${cli_SingleNodeServer_proto_hdrs})
 endif()
 
 add_library(quickstep_cli_PrintToScreen PrintToScreen.cpp PrintToScreen.hpp)
@@ -150,7 +172,15 @@ if(USE_LINENOISE)
 else()
   target_link_libraries(quickstep_cli_LineReader
                         quickstep_utility_Macros)
+
 endif()
+
+if(ENABLE_SINGLE_NODE_SERVER)
+  target_link_libraries(quickstep_cli_SingleNodeServer_proto
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        ${PROTOBUF3_LIBRARY})
+endif()
+
 target_link_libraries(quickstep_cli_PrintToScreen
                       ${GFLAGS_LIB_NAME}
                       quickstep_catalog_CatalogAttribute

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -84,6 +84,12 @@ else()
 endif()
 
 if (ENABLE_SINGLE_NODE_SERVER)
+  add_library(quickstep_cli_SingleNodeClient
+              SingleNodeClient.cpp
+              SingleNodeClient.hpp)
+  add_library(quickstep_cli_SingleNodeServerWrapper
+              SingleNodeServerWrapper.cpp
+              SingleNodeServerWrapper.hpp)
   add_library(quickstep_cli_SingleNodeServer_proto
               ${cli_SingleNodeServer_proto_srcs}
               ${cli_SingleNodeServer_proto_hdrs})
@@ -92,6 +98,14 @@ endif()
 add_library(quickstep_cli_PrintToScreen PrintToScreen.cpp PrintToScreen.hpp)
 
 # Link dependencies:
+if (ENABLE_SINGLE_NODE_SERVER)
+  target_link_libraries(quickstep_cli_SingleNodeClient
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        ${PROTOBUF3_LIBRARIES}
+                        glog
+                        quickstep_cli_SingleNodeServer_proto)
+endif()
 target_link_libraries(quickstep_cli_CommandExecutor
                       glog
                       quickstep_catalog_CatalogAttribute
@@ -176,6 +190,12 @@ else()
 endif()
 
 if(ENABLE_SINGLE_NODE_SERVER)
+  target_link_libraries(quickstep_cli_SingleNodeServerWrapper
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        ${PROTOBUF3_LIBRARIES}
+                        glog
+                        quickstep_cli_SingleNodeServer_proto)
   target_link_libraries(quickstep_cli_SingleNodeServer_proto
                         ${GRPCPLUSPLUS_LIBRARIES}
                         ${PROTOBUF3_LIBRARY})

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 if (ENABLE_DISTRIBUTED)
   add_subdirectory(distributed)
 endif(ENABLE_DISTRIBUTED)

--- a/cli/QuickstepClient.cpp
+++ b/cli/QuickstepClient.cpp
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <grpc++/grpc++.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cli/SingleNodeServer.grpc.pb.h"
+#include "cli/SingleNodeServer.pb.h"
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+static bool ValidatePort(const char *flagname, std::int32_t value) {
+  if (value > 0 && value < 65536) {
+    return true;
+  }
+  std::printf("Invalid value for --%s: %d\n", flagname, static_cast<int>(value));
+  return false;
+}
+
+DEFINE_int32(port, 3000, "Listens for TCP connection on this port.");
+DEFINE_validator(port, &ValidatePort);
+
+namespace quickstep {
+
+class QuickstepClient {
+ public:
+  explicit QuickstepClient(std::shared_ptr<Channel> const &channel)
+      : stub_(SingleNodeServerRequest::NewStub(channel)) {}
+
+  /**
+   * Assembles the client's payload, sends it and presents the response back from the server.
+   * @param user_query A SQL statement or command to be executed on the server.
+   * @return The text of the server's response.
+   */
+  std::string SendQuery(const std::string &user_query) {
+    QueryRequest request;
+    request.set_query(user_query);
+    QueryResponse response;
+    ClientContext context;
+
+    Status status = stub_->SendQuery(&context, request, &response);
+
+    if (status.ok()) {
+      return HandleQueryResponse(response);
+    } else {
+      LOG(WARNING) << "RPC call failed with code " << status.error_code()
+                   << " and message: " << status.error_message();
+      return "RPC failed";
+    }
+  }
+
+ private:
+  /**
+   * Handle a valid response from the server.
+   * @param response A valid query response.
+   * @return The response string.
+   */
+  std::string HandleQueryResponse(QueryResponse const &response) const {
+    if (response.error()) {
+      return response.error_result();
+    }
+    return response.query_result();
+  }
+
+  std::unique_ptr<SingleNodeServerRequest::Stub> stub_;
+};
+
+}  // namespace quickstep
+
+int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Attempts to send a single query retrieved from stdin to the Quickstep Server.
+  quickstep::QuickstepClient qs_client(
+    grpc::CreateChannel("localhost:" + std::to_string(FLAGS_port),
+                        grpc::InsecureChannelCredentials()));
+  std::string user_query;
+  std::cin >> user_query;
+  std::cout << "query: " << user_query << std::endl;
+  std::cout << qs_client.SendQuery(user_query) << std::endl;
+  return 0;
+}

--- a/cli/SingleNodeClient.cpp
+++ b/cli/SingleNodeClient.cpp
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "cli/SingleNodeClient.hpp"
+
+#include "gflags/gflags.h"
+
+static bool ValidatePort(const char *flagname, std::int32_t value) {
+  if (value > 0 && value < 65536) {
+    return true;
+  }
+  std::printf("Invalid value for --%s: %d\n", flagname, static_cast<int>(value));
+  return false;
+}
+
+DEFINE_int32(port, 3000, "Listens for TCP connection on this port.");
+DEFINE_validator(port, &ValidatePort);

--- a/cli/SingleNodeClient.hpp
+++ b/cli/SingleNodeClient.hpp
@@ -17,6 +17,9 @@
  * under the License.
  **/
 
+#ifndef QUICKSTEP_CLI_SINGLE_NODE_CLIENT_HPP_
+#define QUICKSTEP_CLI_SINGLE_NODE_CLIENT_HPP_
+
 #include <grpc++/grpc++.h>
 
 #include <iostream>
@@ -34,23 +37,15 @@ using grpc::Channel;
 using grpc::ClientContext;
 using grpc::Status;
 
-static bool ValidatePort(const char *flagname, std::int32_t value) {
-  if (value > 0 && value < 65536) {
-    return true;
-  }
-  std::printf("Invalid value for --%s: %d\n", flagname, static_cast<int>(value));
-  return false;
-}
-
-DEFINE_int32(port, 3000, "Listens for TCP connection on this port.");
-DEFINE_validator(port, &ValidatePort);
-
 namespace quickstep {
 
-class QuickstepClient {
+/**
+ * A simple wrapper class used to do CLI interactions with QuickstepCLI via the gRPC interface.
+ */
+class SingleNodeClient {
  public:
-  explicit QuickstepClient(std::shared_ptr<Channel> const &channel)
-      : stub_(SingleNodeServerRequest::NewStub(channel)) {}
+  explicit SingleNodeClient(std::shared_ptr<Channel> const &channel)
+    : stub_(SingleNodeServer::NewStub(channel)) {}
 
   /**
    * Assembles the client's payload, sends it and presents the response back from the server.
@@ -87,22 +82,9 @@ class QuickstepClient {
     return response.query_result();
   }
 
-  std::unique_ptr<SingleNodeServerRequest::Stub> stub_;
+  std::unique_ptr<SingleNodeServer::Stub> stub_;
 };
 
 }  // namespace quickstep
 
-int main(int argc, char **argv) {
-  google::InitGoogleLogging(argv[0]);
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-
-  // Attempts to send a single query retrieved from stdin to the Quickstep Server.
-  quickstep::QuickstepClient qs_client(
-    grpc::CreateChannel("localhost:" + std::to_string(FLAGS_port),
-                        grpc::InsecureChannelCredentials()));
-  std::string user_query;
-  std::cin >> user_query;
-  std::cout << "query: " << user_query << std::endl;
-  std::cout << qs_client.SendQuery(user_query) << std::endl;
-  return 0;
-}
+#endif //QUICKSTEP_CLI_SINGLE_NODE_CLIENT_HPP_

--- a/cli/SingleNodeClientExecutable.cpp
+++ b/cli/SingleNodeClientExecutable.cpp
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <grpc++/grpc++.h>
+
+#include <iostream>
+#include <istream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cli/SingleNodeClient.hpp"
+
+#include "gflags/gflags.h"
+
+DECLARE_int32(port);
+
+int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Attempts to send a single query retrieved from stdin to the Quickstep Server.
+  quickstep::SingleNodeClient qs_client(
+    grpc::CreateChannel("localhost:" + std::to_string(FLAGS_port),
+                        grpc::InsecureChannelCredentials()));
+
+  std::cin >> std::noskipws;
+  std::istream_iterator<char> it(std::cin), end;
+  std::string user_query(it, end);
+
+  std::cout << "Result\n" << qs_client.SendQuery(user_query) << std::endl;
+
+  return 0;
+}

--- a/cli/SingleNodeServer.proto
+++ b/cli/SingleNodeServer.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 
 package quickstep;
 
-service SingleNodeServerRequest {
+service SingleNodeServer {
   rpc SendQuery (QueryRequest) returns (QueryResponse) {}
 }
 

--- a/cli/SingleNodeServer.proto
+++ b/cli/SingleNodeServer.proto
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+
+package quickstep;
+
+service SingleNodeServerRequest {
+  rpc SendQuery (QueryRequest) returns (QueryResponse) {}
+}
+
+message QueryRequest {
+  string query = 1;
+}
+
+message QueryResponse {
+  bool error = 1;
+  string query_result = 2;
+  string error_result = 3;
+}

--- a/cli/SingleNodeServerWrapper.cpp
+++ b/cli/SingleNodeServerWrapper.cpp
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "cli/SingleNodeServerWrapper.hpp"

--- a/cli/SingleNodeServerWrapper.hpp
+++ b/cli/SingleNodeServerWrapper.hpp
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_CLI_SINGLE_NODE_SERVER_WRAPPER_HPP_
+#define QUICKSTEP_CLI_SINGLE_NODE_SERVER_WRAPPER_HPP_
+
+#include <grpc++/grpc++.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cli/SingleNodeServer.grpc.pb.h"
+#include "cli/SingleNodeServer.pb.h"
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+#endif  // QUICKSTEP_CLI_SINGLE_NODE_SERVER_WRAPPER_HPP_

--- a/cli/tests/CMakeLists.txt
+++ b/cli/tests/CMakeLists.txt
@@ -15,6 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+if(ENABLE_SINGLE_NODE_SERVER)
+  set(CMAKE_MODULE_PATH
+      ${CMAKE_MODULE_PATH}
+      "${PROJECT_SOURCE_DIR}/third_party/src/tmb/cmake")
+
+  find_package(Grpc++ REQUIRED)
+endif()
+
 add_subdirectory(command_executor)
 
 add_executable(quickstep_cli_tests_CommandExecutorTest
@@ -31,6 +39,10 @@ if (ENABLE_DISTRIBUTED)
                  "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.cpp"
                  "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.hpp")
 endif(ENABLE_DISTRIBUTED)
+if (ENABLE_SINGLE_NODE_SERVER)
+  add_executable(quickstep_cli_tests_SingleNodeServerTest
+                 SingleNodeServerTest.cpp)
+endif()
 
 target_link_libraries(quickstep_cli_tests_CommandExecutorTest
                       glog
@@ -90,3 +102,12 @@ if (ENABLE_DISTRIBUTED)
                         ${GFLAGS_LIB_NAME}
                         ${LIBS})
 endif(ENABLE_DISTRIBUTED)
+if (ENABLE_SINGLE_NODE_SERVER)
+  target_link_libraries(quickstep_cli_tests_SingleNodeServerTest
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        quickstep_cli_SingleNodeClient
+                        quickstep_cli_SingleNodeServerWrapper
+                        glog
+                        gtest)
+endif()

--- a/cli/tests/SingleNodeServerTest.cpp
+++ b/cli/tests/SingleNodeServerTest.cpp
@@ -1,4 +1,37 @@
-//
-// Created by Marc Spehlmann on 4/10/17.
-//
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
 
+#include <cstddef>
+#include <memory>
+
+#include "cli/SingleNodeClient.hpp"
+#include "cli/SingleNodeServerWrapper.hpp"
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+using std::unique_ptr;
+
+namespace quickstep {
+
+TEST(Placeholder, SingleNodeServerTest) {
+  EXPECT_TRUE(true) << "yay";
+}
+
+}  // namespace quickstep

--- a/cli/tests/SingleNodeServerTest.cpp
+++ b/cli/tests/SingleNodeServerTest.cpp
@@ -1,0 +1,4 @@
+//
+// Created by Marc Spehlmann on 4/10/17.
+//
+


### PR DESCRIPTION
This is the first part of a couple of PRs which will implement basic server functionality in QS. The basic usage of the client is:
```
$ GLOG_logtostderr=1 ./quickstep_client --port 3001 < my_query.sql

W0408 09:10:28.233783 3400758208 QuickstepClient.cpp:74] RPC call failed with code 14 and message: Connect Failed
RPC failed
```
The client uses gRPC libraries from the tmb and thus makes some changes to cli/CMakelists to include necessary libraries.

This will not add additional functionality on top of the the existing CLI, it merely allows quickstep to run as a separate process.

The next PR will have appropriate changes to the cli to handle network interactions.
