### PR TITLE
QUICKSTEP-87 Adds network cli interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ if (ENABLE_VECTOR_PREDICATE_SHORT_CIRCUIT)
   )
 endif()
 
+option(ENABLE_NETWORK_CLI "Allows use of the network cli" OFF)
 option(ENABLE_DISTRIBUTED "Use the distributed version of Quickstep" OFF)
 
 macro (set_gflags_lib_name)
@@ -730,6 +731,7 @@ target_link_libraries(quickstep_cli_shell
                       quickstep_cli_Flags
                       quickstep_cli_InputParserUtil
                       quickstep_cli_LineReader
+                      quickstep_cli_LocalIO
                       quickstep_cli_PrintToScreen
                       quickstep_parser_ParseStatement
                       quickstep_parser_SqlParserWrapper
@@ -755,7 +757,10 @@ if (ENABLE_HDFS)
   target_link_libraries(quickstep_cli_shell
                         quickstep_storage_FileManagerHdfs)
 endif()
-
+if (ENABLE_NETWORK_CLI)
+  target_link_libraries(quickstep_cli_shell
+                        quickstep_cli_NetworkIO)
+endif()
 # Link against other required system and third-party libraries.
 target_link_libraries(quickstep_cli_shell ${LIBS})
 
@@ -792,3 +797,14 @@ if (ENABLE_DISTRIBUTED)
                         ${GFLAGS_LIB_NAME}
                         ${GRPCPLUSPLUS_LIBRARIES})
 endif(ENABLE_DISTRIBUTED)
+
+if (ENABLE_NETWORK_CLI)
+  add_executable (quickstep_client cli/NetworkCliClientMain.cpp)
+  target_link_libraries(quickstep_client
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        glog
+                        quickstep_cli_LineReaderBuffered
+                        quickstep_cli_NetworkCliClient
+                        quickstep_cli_NetworkIO)
+endif()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -16,6 +16,7 @@
 # under the License.
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 if (ENABLE_DISTRIBUTED)
   add_subdirectory(distributed)
 endif(ENABLE_DISTRIBUTED)
@@ -39,10 +40,30 @@ if (ENABLE_GOOGLE_PROFILER)
   set(QUICKSTEP_ENABLE_GOOGLE_PROFILER TRUE)
 endif()
 
+if (ENABLE_NETWORK_CLI)
+  set(QUICKSTEP_ENABLE_NETWORK_CLI TRUE)
+endif()
+
 configure_file (
   "${CMAKE_CURRENT_SOURCE_DIR}/CliConfig.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/CliConfig.h"
 )
+
+# Compile the protos for Single Node Server mode.
+if (ENABLE_NETWORK_CLI)
+  # We will need some of the TMBs libraries
+  set(CMAKE_MODULE_PATH
+      ${CMAKE_MODULE_PATH}
+      "${PROJECT_SOURCE_DIR}/third_party/src/tmb/cmake")
+
+  find_package(Grpc++ REQUIRED)
+  include_directories(${GRPCPLUSPLUS_INCLUDE_DIRS})
+
+  GRPC_GENERATE_CPP(cli_NetworkCli_proto_srcs
+                    cli_NetworkCli_proto_hdrs
+                    .
+                    NetworkCli.proto)
+endif()
 
 # Declare micro-libs and link dependencies:
 add_library(quickstep_cli_CommandExecutor CommandExecutor.cpp CommandExecutor.hpp)
@@ -51,6 +72,7 @@ add_library(quickstep_cli_Constants ../empty_src.cpp Constants.hpp)
 add_library(quickstep_cli_DefaultsConfigurator DefaultsConfigurator.cpp DefaultsConfigurator.hpp)
 add_library(quickstep_cli_DropRelation DropRelation.cpp DropRelation.hpp)
 add_library(quickstep_cli_Flags Flags.cpp Flags.hpp)
+add_library(quickstep_cli_IOInterface ../empty_src.cpp IOInterface.hpp)
 add_library(quickstep_cli_InputParserUtil InputParserUtil.cpp InputParserUtil.hpp)
 
 if(USE_LINENOISE)
@@ -65,6 +87,25 @@ else()
               LineReaderDumb.cpp
               LineReader.hpp
               LineReaderDumb.hpp)
+endif()
+
+add_library(quickstep_cli_LineReaderBuffered
+            LineReaderBuffered.cpp
+            LineReaderBuffered.hpp)
+add_library(quickstep_cli_LocalIO
+            ../empty_src.cpp
+            LocalIO.hpp)
+
+if (ENABLE_NETWORK_CLI)
+  add_library(quickstep_cli_NetworkCli_proto
+              ${cli_NetworkCli_proto_srcs}
+              ${cli_NetworkCli_proto_hdrs})
+  add_library(quickstep_cli_NetworkCliClient
+              ../empty_src.cpp
+              NetworkCliClient.hpp)
+  add_library(quickstep_cli_NetworkIO
+              NetworkIO.cpp
+              NetworkIO.hpp)
 endif()
 
 add_library(quickstep_cli_PrintToScreen PrintToScreen.cpp PrintToScreen.hpp)
@@ -135,6 +176,8 @@ target_link_libraries(quickstep_cli_Flags
                       quickstep_cli_DefaultsConfigurator
                       quickstep_storage_StorageConstants
                       ${GFLAGS_LIB_NAME})
+target_link_libraries(quickstep_cli_IOInterface
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_cli_InputParserUtil
                       glog
                       quickstep_utility_Macros
@@ -150,6 +193,37 @@ if(USE_LINENOISE)
 else()
   target_link_libraries(quickstep_cli_LineReader
                         quickstep_utility_Macros)
+endif()
+target_link_libraries(quickstep_cli_LineReaderBuffered
+                      quickstep_cli_LineReader
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_cli_LocalIO
+                      quickstep_cli_LineReader
+                      quickstep_cli_IOInterface
+                      quickstep_utility_Macros)
+if (ENABLE_NETWORK_CLI)
+  target_link_libraries(quickstep_cli_NetworkCli_proto
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        ${PROTOBUF3_LIBRARY})
+  target_link_libraries(quickstep_cli_NetworkCliClient
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        ${PROTOBUF3_LIBRARIES}
+                        glog
+                        quickstep_cli_NetworkCli_proto
+                        quickstep_utility_Macros)
+  target_link_libraries(quickstep_cli_NetworkIO
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        ${PROTOBUF3_LIBRARIES}
+                        glog
+                        quickstep_cli_IOInterface
+                        quickstep_cli_NetworkCli_proto
+                        quickstep_threading_ConditionVariable
+                        quickstep_threading_SpinSharedMutex
+                        quickstep_utility_Macros
+                        quickstep_utility_MemStream
+                        quickstep_utility_ThreadSafeQueue)
 endif()
 target_link_libraries(quickstep_cli_PrintToScreen
                       ${GFLAGS_LIB_NAME}
@@ -175,6 +249,15 @@ target_link_libraries(quickstep_cli
                       quickstep_cli_DefaultsConfigurator
                       quickstep_cli_DropRelation
                       quickstep_cli_Flags
+                      quickstep_cli_IOInterface
                       quickstep_cli_InputParserUtil
                       quickstep_cli_LineReader
+                      quickstep_cli_LineReaderBuffered
+                      quickstep_cli_LocalIO
                       quickstep_cli_PrintToScreen)
+if (ENABLE_NETWORK_CLI)
+  target_link_libraries(quickstep_cli
+                        quickstep_cli_NetworkCli_proto
+                        quickstep_cli_NetworkCliClient
+                        quickstep_cli_NetworkIO)
+endif()

--- a/cli/IOInterface.hpp
+++ b/cli/IOInterface.hpp
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_CLI_IO_INTERFACE_HPP_
+#define QUICKSTEP_CLI_IO_INTERFACE_HPP_
+
+#include <cstdio>
+#include <string>
+
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+/**
+ * An individual IO interaction with Quickstep.
+ */
+class IOHandle {
+ public:
+  IOHandle() {}
+
+  /**
+   * @note Destructor should handle clean up of any IO state.
+   */
+  virtual ~IOHandle() {}
+
+  /**
+   * @return A file handle for standard output.
+   */
+  virtual FILE *out() = 0;
+
+  /**
+   * @return A file handle for error output.
+   */
+  virtual FILE *err() = 0;
+
+  virtual std::string getCommand() const = 0;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(IOHandle);
+};
+
+/**
+ * Virtual base defines a generic, file-based interface around IO. One IO interaction (eg a SQL query) will be assigned
+ * an IOHandle. On destruction of the IOHandle, the IO interaction has finished.
+ */
+class IOInterface {
+ public:
+  /**
+   * @note Destructing the IOInterface should close any outstanding IO state (eg an open port).
+   */
+  virtual ~IOInterface() {}
+
+  /**
+   * @brief Retrieves the next IOHandle. Blocks if no IO ready.
+   * @return An IOHandle.
+   */
+  virtual IOHandle* getNextIOHandle() = 0;
+
+ protected:
+  IOInterface() {}
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(IOInterface);
+};
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_CLI_IO_INTERFACE_HPP_

--- a/cli/LineReaderBuffered.cpp
+++ b/cli/LineReaderBuffered.cpp
@@ -17,7 +17,23 @@
  * under the License.
  **/
 
-#cmakedefine QUICKSTEP_USE_LINENOISE
-#cmakedefine QUICKSTEP_OS_WINDOWS
-#cmakedefine QUICKSTEP_ENABLE_GOOGLE_PROFILER
-#cmakedefine QUICKSTEP_ENABLE_NETWORK_CLI
+#include "cli/LineReaderBuffered.hpp"
+
+#include <string>
+
+namespace quickstep {
+
+LineReaderBuffered::LineReaderBuffered(const std::string &default_prompt,
+                                       const std::string &continue_prompt)
+    : LineReader(default_prompt, continue_prompt),
+      buffer_empty_(true) {}
+
+LineReaderBuffered::LineReaderBuffered() : LineReader("", ""), buffer_empty_(true) {}
+
+std::string LineReaderBuffered::getLineInternal(const bool continuing) {
+  // This method is called when the leftover_ string is depleted.
+  buffer_empty_ = true;
+  return "";
+}
+
+}  // namespace quickstep

--- a/cli/LineReaderBuffered.hpp
+++ b/cli/LineReaderBuffered.hpp
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_CLI_LINE_READER_BUFFERED_HPP_
+#define QUICKSTEP_CLI_LINE_READER_BUFFERED_HPP_
+
+#include <string>
+
+#include "cli/LineReader.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+class LineReaderBuffered : public LineReader {
+ public:
+  /**
+   * @brief A line reader which accepts a string buffer.
+   * Other line readers are meant to support some form of user interaction. This linereader does not and is intended for
+   * programmer use- it does not print anything to stdout. Therefore it ignores any prompt strings given to the
+   * inherited constructor.
+   * @param default_prompt Not used by this line reader, but required by interface.
+   * @param continue_prompt Not used by this line reader, but required by interface.
+   */
+  LineReaderBuffered(const std::string &default_prompt,
+                     const std::string &continue_prompt);
+
+  LineReaderBuffered();
+
+  ~LineReaderBuffered() override {}
+
+  /**
+   * @brief Replaces the current buffer contents with new contents.
+   * @param buffer Replacement text.
+   */
+  void setBuffer(std::string buffer) {
+    leftover_ = buffer;
+    buffer_empty_ = false;
+  }
+
+  /**
+   * @brief This is set to true after getNextCommand is called and runs out of input to process.
+   * @return True if the buffer has been consumed.
+   */
+  bool bufferEmpty() const {
+    return buffer_empty_;
+  }
+
+ protected:
+  std::string getLineInternal(const bool continuing) override;
+
+ private:
+  bool buffer_empty_;
+
+  DISALLOW_COPY_AND_ASSIGN(LineReaderBuffered);
+};
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_CLI_LINE_READER_BUFFERED_HPP_

--- a/cli/LocalIO.hpp
+++ b/cli/LocalIO.hpp
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_CLI_LOCAL_IO_HPP_
+#define QUICKSTEP_CLI_LOCAL_IO_HPP_
+
+#include <cstdio>
+#include <string>
+
+#include "cli/CliConfig.h"
+#include "cli/IOInterface.hpp"
+#include "cli/LineReader.hpp"
+#ifdef QUICKSTEP_USE_LINENOISE
+#include "cli/LineReaderLineNoise.hpp"
+typedef quickstep::LineReaderLineNoise LineReaderImpl;
+#else
+#include "cli/LineReaderDumb.hpp"
+typedef quickstep::LineReaderDumb LineReaderImpl;
+#endif
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+class LocalIOHandle final : public IOHandle {
+ public:
+  LocalIOHandle() {}
+
+  explicit LocalIOHandle(const std::string &command)
+      : command_(command) {}
+
+  ~LocalIOHandle() override {}
+
+  FILE *out() override {
+    return stdout;
+  }
+
+  FILE *err() override {
+    return stderr;
+  }
+
+  std::string getCommand() const override {
+    return command_;
+  }
+
+ private:
+  const std::string command_;
+
+  DISALLOW_COPY_AND_ASSIGN(LocalIOHandle);
+};
+
+/**
+ * IO class for getting commands from stdin via an interactive line reader.
+ */
+class LocalIO final : public IOInterface {
+ public:
+  LocalIO() : line_reader_("quickstep> ",
+                           "      ...> ") {}
+
+  ~LocalIO() override {}
+
+  IOHandle* getNextIOHandle() override {
+    return new LocalIOHandle(line_reader_.getNextCommand());
+  }
+
+ private:
+  LineReaderImpl line_reader_;
+
+  DISALLOW_COPY_AND_ASSIGN(LocalIO);
+};
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_CLI_LOCAL_IO_HPP_

--- a/cli/NetworkCli.proto
+++ b/cli/NetworkCli.proto
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+
+package quickstep;
+
+service NetworkCli {
+  rpc SendQuery (QueryRequest) returns (QueryResponse) {}
+}
+
+message QueryRequest {
+  string query = 1;
+}
+
+message QueryResponse {
+  string query_result = 1;
+  string error_result = 2;
+}

--- a/cli/NetworkCliClient.hpp
+++ b/cli/NetworkCliClient.hpp
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_CLI_SINGLE_NODE_CLIENT_HPP_
+#define QUICKSTEP_CLI_SINGLE_NODE_CLIENT_HPP_
+
+#include <grpc++/grpc++.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cli/NetworkCli.grpc.pb.h"
+#include "cli/NetworkCli.pb.h"
+#include "utility/Macros.hpp"
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+namespace quickstep {
+
+/**
+ * A simple wrapper class used to do CLI interactions with QuickstepCLI via the gRPC interface.
+ */
+class NetworkCliClient {
+ public:
+  explicit NetworkCliClient(const std::shared_ptr<Channel> &channel)
+      : stub_(NetworkCli::NewStub(channel)) {}
+
+  /**
+   * Assembles the client's payload, sends it and presents the response back from the server.
+   * @param user_query A SQL statement or command to be executed on the server.
+   * @return The text of the server's response.
+   */
+  std::string Query(const std::string &user_query) {
+    QueryRequest request;
+    request.set_query(user_query);
+    QueryResponse response;
+
+    Status status = SendQuery(request, &response);
+
+    if (status.ok()) {
+      return HandleQueryResponse(response);
+    } else {
+      LOG(WARNING) << "RPC call failed with code " << status.error_code()
+                   << " and message: " << status.error_message();
+      return "RPC failed";
+    }
+  }
+
+  Status SendQuery(const QueryRequest& request, QueryResponse* response) {
+    ClientContext context;
+    return stub_->SendQuery(&context, request, response);
+  }
+
+ private:
+  /**
+   * Handle a valid response from the server.
+   * @param response A valid query response.
+   * @return The response string.
+   */
+  std::string HandleQueryResponse(QueryResponse const &response) const {
+    return response.query_result() + response.error_result();
+  }
+
+  std::unique_ptr<NetworkCli::Stub> stub_;
+
+  DISALLOW_COPY_AND_ASSIGN(NetworkCliClient);
+};
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_CLI_SINGLE_NODE_CLIENT_HPP_

--- a/cli/NetworkCliClientMain.cpp
+++ b/cli/NetworkCliClientMain.cpp
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <grpc++/grpc++.h>
+
+#include <iostream>
+#include <istream>
+#include <memory>
+#include <string>
+
+#include "cli/LineReaderBuffered.hpp"
+#include "cli/NetworkCliClient.hpp"
+#include "cli/NetworkIO.hpp"
+
+#include "gflags/gflags.h"
+
+using quickstep::LineReaderBuffered;
+using quickstep::NetworkCliClient;
+
+int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  grpc_init();
+
+  // Attempts to send a single query retrieved from stdin to the Quickstep Server.
+  NetworkCliClient qs_client(
+    grpc::CreateChannel(quickstep::NetworkIO::GetAddress(),
+                        grpc::InsecureChannelCredentials()));
+
+  // Read stdin until EOF, then we use a Line reader to divide query into parts.
+  std::cin >> std::noskipws;
+  std::istream_iterator<char> it(std::cin), end;
+  std::string user_queries(it, end);
+
+  LineReaderBuffered linereader;
+  linereader.setBuffer(user_queries);
+  while (!linereader.bufferEmpty()) {
+    std::string query = linereader.getNextCommand();
+    if (!query.empty()) {
+      std::cout << query << std::endl;
+      std::cout << qs_client.Query(query) << std::endl;
+    }
+  }
+  return 0;
+}

--- a/cli/NetworkIO.cpp
+++ b/cli/NetworkIO.cpp
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "cli/NetworkIO.hpp"
+
+#include <grpc++/grpc++.h>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+namespace quickstep {
+
+static bool ValidatePort(const char *flagname, std::int32_t value) {
+  int const min = 0, max = 65536;
+  if (value > min && value < max) {
+    return true;
+  }
+  std::cout << "Invalid value for --" << flagname << ": " << value
+            << "\nUse ports between " << min << " and "
+            << max << std::endl;
+  return false;
+}
+
+DEFINE_int32(cli_network_port, 3000,
+             "Listens for TCP connections on this port when network mode is enabled. "
+               "This is only used if the cli is set to use the network mode (--mode=network).");
+DEFINE_validator(cli_network_port, &ValidatePort);
+
+DEFINE_string(cli_network_ip, "0.0.0.0",
+              "The ip address which the cli should open a connection on. This is only used "
+                "if the cli is set to use the network mode (--mode=network). Defaults to "
+                "the address of localhost.");
+
+NetworkIO::NetworkIO() {
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(GetAddress(), grpc::InsecureServerCredentials());
+  builder.RegisterService(&service_);
+  server_ = builder.BuildAndStart();
+  LOG(INFO) << "Listening on " << GetAddress();
+}
+
+}  // namespace quickstep

--- a/cli/NetworkIO.hpp
+++ b/cli/NetworkIO.hpp
@@ -1,0 +1,282 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_CLI_NETWORK_IO_HPP_
+#define QUICKSTEP_CLI_NETWORK_IO_HPP_
+
+#include <grpc++/grpc++.h>
+
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "cli/IOInterface.hpp"
+#include "cli/NetworkCli.grpc.pb.h"
+#include "cli/NetworkCli.pb.h"
+#include "threading/ConditionVariable.hpp"
+#include "threading/SpinSharedMutex.hpp"
+#include "utility/Macros.hpp"
+#include "utility/MemStream.hpp"
+#include "utility/ThreadSafeQueue.hpp"
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Server;
+using grpc::Status;
+
+namespace quickstep {
+DECLARE_int32(cli_network_port);
+DECLARE_string(cli_network_ip);
+namespace networkio_internal {
+
+/**
+ * Contains state and helper methods for managing interactions between a producer/consumer thread. A producer thread
+ * will wait on a condition variable. When the consumer thread returns, it will notify the producer.
+ */
+class RequestState {
+ public:
+  explicit RequestState(const QueryRequest& request)
+      : response_ready_(false),
+        canceled_(false),
+        request_(request),
+        condition_(mutex_.createConditionVariable()) {}
+
+  /**
+   * @brief Notifies that the consumer has finished consuming and that a response is ready.
+   * To be called after the consumer has executed.
+   * @param stdout_str Stdout from Quickstep.
+   * @param stderr_str Stderr from Quickstep.
+   */
+  void responseReady(const std::string& stdout_str, const std::string& stderr_str) {
+    std::unique_lock<Mutex> lock(mutex_);
+    response_message_.set_query_result(stdout_str);
+    response_message_.set_error_result(stderr_str);
+    response_ready_ = true;
+    condition_->signalOne();
+  }
+
+  /**
+   * @brief The producer thread blocks until Quickstep signals that it has finished.
+   * @note Quickstep may either produce a query response or cancel. Both these actions must notify the condition.
+   */
+  void waitForResponse() {
+    while (!response_ready_)
+      condition_->await();
+  }
+
+  /**
+   * @brief Notifies the producer that its request will not be served by Quickstep.
+   */
+  void cancel() {
+    std::unique_lock<Mutex> lock(mutex_);
+    canceled_ = true;
+    response_ready_ = true;
+    condition_->signalOne();
+  }
+
+  /**
+   * @return The producer's query for Quickstep to process.
+   */
+  std::string getRequest() const {
+    return request_.query();
+  }
+
+  /**
+   * @return The response message from Quickstep.
+   */
+  QueryResponse getResponse() const {
+    DCHECK(response_ready_);
+    return response_message_;
+  }
+
+  /**
+   * @return True if query was canceled.
+   */
+  bool getCanceled() const {
+    DCHECK(response_ready_);
+    return canceled_;
+  }
+
+ private:
+  bool response_ready_;
+  bool canceled_;
+  const QueryRequest& request_;
+  QueryResponse response_message_;
+  Mutex mutex_;
+  ConditionVariable *condition_;  // note: owned by the mutex.
+
+  DISALLOW_COPY_AND_ASSIGN(RequestState);
+};
+
+}  // namespace networkio_internal
+
+using networkio_internal::RequestState;
+
+/**
+ * @brief Contains the callback methods which the gRPC service defines.
+ * When a request is made of gRPC, a gRPC worker thread is spun up and enters one of the callback methods
+ * (eg SendQuery). This thread keeps the network connection open while Quickstep processes the query. Concurrency
+ * control between the gRPC worker thread, and the Quickstep thread is controlled by a RequestState object which is
+ * created for each interaction.
+ */
+class NetworkCliServiceImpl final : public NetworkCli::Service {
+ public:
+  NetworkCliServiceImpl()
+      : running_(true) {}
+
+  /**
+   * @brief Handles gRPC request.
+   * Sets the buffer in the RequestState, places the request on a queue, then waits for a response. The response shall
+   * be triggered by the Quickstep system.
+   */
+  Status SendQuery(grpc::ServerContext *context,
+                   const QueryRequest *request,
+                   QueryResponse *response) override {
+    std::unique_ptr<RequestState> request_state(new RequestState(*request));
+    // Check to see if the gRPC service has been shutdown.
+    {
+      SpinSharedMutexSharedLock<true> lock(service_mtx_);
+
+      if (!running_) {
+        return Status::CANCELLED;
+      }
+      // While we have a service lock, we add to the Queue. Note that we keep the service lock to protect ourselves from
+      // a race condition in the kill() method.
+
+      // Pushing to the queue will notify consumers.
+      request_queue_.push(request_state.get());
+    }
+
+    DCHECK(request_state);
+
+    // We have pushed to the request queue, so all there is to do now is wait for Quickstep to process the request.
+    request_state->waitForResponse();
+    if (request_state->getCanceled()) {
+      return Status::CANCELLED;
+    }
+    *response = request_state->getResponse();
+    return Status::OK;
+  }
+
+  /**
+   * @brief The consumer thread waits for a request to materialize.
+   * @return A non-owned RequestState.
+   */
+  RequestState* waitForRequest() {
+    return request_queue_.popOne();
+  }
+
+  /**
+   * @brief Stops accepting further requests and cancels all pending requests.
+   */
+  void kill() {
+    {
+      // This action guarantees that no further requests are added to the queue.
+      SpinSharedMutexExclusiveLock<true> lock(service_mtx_);
+      running_ = false;
+    }
+    // Go through each pending request, and cancel them.
+    while (!request_queue_.empty()) {
+      request_queue_.popOne()->cancel();
+    }
+  }
+
+ private:
+  SpinSharedMutex<true> service_mtx_;
+  bool running_;
+  ThreadSafeQueue<RequestState*> request_queue_;
+
+  DISALLOW_COPY_AND_ASSIGN(NetworkCliServiceImpl);
+};
+
+class NetworkIOHandle final : public IOHandle {
+ public:
+  explicit NetworkIOHandle(RequestState* state)
+      : request_state_(state) {}
+
+  ~NetworkIOHandle() override {
+      // All the commands from the last network interaction have completed, return our response.
+      // This signals to the producer thread that the interaction is complete.
+      request_state_->responseReady(out_stream_.str(), err_stream_.str());
+  }
+
+  FILE* out() override {
+    return out_stream_.file();
+  }
+
+  FILE* err() override {
+    return err_stream_.file();
+  }
+
+  std::string getCommand() const override {
+    return request_state_->getRequest();
+  }
+
+ private:
+  MemStream out_stream_, err_stream_;
+  RequestState *request_state_;
+
+  DISALLOW_COPY_AND_ASSIGN(NetworkIOHandle);
+};
+
+/**
+ * A network interface that uses gRPC to accept commands.
+ */
+class NetworkIO final : public IOInterface {
+ public:
+  NetworkIO();
+
+  ~NetworkIO() override {
+    service_.kill();
+    server_->Shutdown();
+    server_->Wait();
+  }
+
+  IOHandle* getNextIOHandle() override {
+    return new NetworkIOHandle(service_.waitForRequest());
+  }
+
+  /**
+   * @brief Kills the underlying gRPC service.
+   */
+  void killService() {
+    service_.kill();
+  }
+
+  /**
+   * @return IP address and port of the network address specified by the user flags.
+   */
+  static std::string GetAddress() {
+    return FLAGS_cli_network_ip + ":" + std::to_string(FLAGS_cli_network_port);
+  }
+
+ private:
+  std::unique_ptr<Server> server_;
+  NetworkCliServiceImpl service_;
+
+  DISALLOW_COPY_AND_ASSIGN(NetworkIO);
+};
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_CLI_NETWORK_IO_HPP_

--- a/cli/tests/CMakeLists.txt
+++ b/cli/tests/CMakeLists.txt
@@ -31,6 +31,18 @@ if (ENABLE_DISTRIBUTED)
                  "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.cpp"
                  "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.hpp")
 endif(ENABLE_DISTRIBUTED)
+add_executable(LineReaderBuffered_unittest
+               LineReaderBuffered_unittest.cpp)
+if (ENABLE_NETWORK_CLI)
+  set(CMAKE_MODULE_PATH
+      ${CMAKE_MODULE_PATH}
+      "${PROJECT_SOURCE_DIR}/third_party/src/tmb/cmake")
+
+  find_package(Grpc++ REQUIRED)
+
+  add_executable(NetworkIO_unittest
+                 NetworkIO_unittest.cpp)
+endif()
 
 target_link_libraries(quickstep_cli_tests_CommandExecutorTest
                       glog
@@ -90,3 +102,26 @@ if (ENABLE_DISTRIBUTED)
                         ${GFLAGS_LIB_NAME}
                         ${LIBS})
 endif(ENABLE_DISTRIBUTED)
+
+target_link_libraries(LineReaderBuffered_unittest
+                      ${GFLAGS_LIB_NAME}
+                      glog
+                      gtest
+                      quickstep_cli_LineReaderBuffered)
+add_test(LineReaderBuffered_unittest LineReaderBuffered_unittest)
+
+if (ENABLE_NETWORK_CLI)
+  target_link_libraries(NetworkIO_unittest
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        glog
+                        gtest
+                        quickstep_cli_Flags
+                        quickstep_cli_IOInterface
+                        quickstep_cli_LineReaderBuffered
+                        quickstep_cli_NetworkCliClient
+                        quickstep_cli_NetworkIO
+                        quickstep_threading_Thread
+                        quickstep_utility_Macros)
+  add_test(NetworkIO_unittest NetworkIO_unittest)
+endif()

--- a/cli/tests/LineReaderBuffered_unittest.cpp
+++ b/cli/tests/LineReaderBuffered_unittest.cpp
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "cli/LineReaderBuffered.hpp"
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace quickstep {
+
+/**
+ * Create a string of several SQL statements and expect that they are individually parsed out.
+ */
+TEST(NetworkIOTest, TestLineReaderBuffered) {
+  LineReaderBuffered linereader;
+  EXPECT_TRUE(linereader.bufferEmpty());
+
+  std::vector<std::string> statements_orig = {"select * from foo;", "select 1;", "select 2;", "quit;"};
+  std::string statements_str;
+  statements_str = accumulate(statements_orig.begin(), statements_orig.end(), statements_str);
+  linereader.setBuffer(statements_str);
+  ASSERT_FALSE(linereader.bufferEmpty());
+
+  std::vector<std::string> statements_parsed;
+  std::size_t parsed_commands;
+  for (parsed_commands = 0;
+       parsed_commands < statements_orig.size() + 1 && !linereader.bufferEmpty();
+       parsed_commands++) {
+    std::string command = linereader.getNextCommand();
+    if (!command.empty()) {
+      statements_parsed.push_back(command);
+    }
+  }
+
+  ASSERT_EQ(statements_parsed.size(), statements_orig.size());
+  for (std::size_t i = 0; i < statements_parsed.size(); ++i) {
+    EXPECT_EQ(statements_orig[i], statements_parsed[i]);
+  }
+  EXPECT_TRUE(linereader.bufferEmpty());
+}
+
+}  // namespace quickstep
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  ::testing::InitGoogleTest(&argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return RUN_ALL_TESTS();
+}

--- a/cli/tests/NetworkIO_unittest.cpp
+++ b/cli/tests/NetworkIO_unittest.cpp
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include <cstddef>
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cli/LineReaderBuffered.hpp"
+#include "cli/NetworkCliClient.hpp"
+#include "cli/NetworkIO.hpp"
+#include "threading/Thread.hpp"
+#include "utility/Macros.hpp"
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace quickstep {
+
+using networkio_internal::RequestState;
+
+static std::string const kQueryRequest = "O Captain! My Captain!";
+static std::string const kQueryResponse = "Our fearful trip is done,";
+
+/**
+ * Contains a server instance for testing.
+ */
+class TestNetworkIO {
+ public:
+  TestNetworkIO() : server_address_(NetworkIO::GetAddress()) {
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(server_address_, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+    CHECK(server_) << "Failed to start server";
+    LOG(INFO) << "TestSingleNodeServer listening on " << server_address_;
+  }
+
+  ~TestNetworkIO() {
+    service_.kill();
+    server_->Shutdown();
+    server_->Wait();
+  }
+
+  /**
+   * @brief Waits on the service for a sent message.
+   */
+  std::string getSentMessage() {
+    CHECK(current_request_ == nullptr);
+    current_request_ = service_.waitForRequest();
+    EXPECT_EQ(current_request_->getCanceled(), false);
+    return current_request_->getRequest();
+  }
+
+  /**
+   * @brief Sets the response message of the Service worker. Alerts it that the request is ready.
+   */
+  void setResponse(std::string response) {
+    CHECK_NOTNULL(current_request_);
+    current_request_->responseReady(response, std::string(""));
+    current_request_ = nullptr;
+  }
+
+  NetworkCliServiceImpl& getService() {
+    return service_;
+  }
+
+ private:
+  NetworkCliServiceImpl service_;
+  std::string server_address_;
+  std::unique_ptr<grpc::Server> server_;
+  RequestState* current_request_;
+
+  DISALLOW_COPY_AND_ASSIGN(TestNetworkIO);
+};
+
+/**
+ * We will pass this thread a lambda based on the desired server interactions.
+ */
+class HelperThread : public Thread {
+ public:
+  explicit HelperThread(std::function<void(void)> function) : function_(function) {}
+
+ protected:
+  void run() override {
+    function_();
+  }
+
+ private:
+  std::function<void(void)> function_;
+
+  DISALLOW_COPY_AND_ASSIGN(HelperThread);
+};
+
+/**
+ * Tests a simple call and response to the Service.
+ */
+TEST(NetworkIOTest, TestNetworkIOCommandInteraction) {
+  NetworkIO networkIO;
+
+  // This thread will handle the response from the client in a similar way as the quickstep cli will.
+  HelperThread server_handler([&networkIO]() {
+    std::unique_ptr<IOHandle> command(networkIO.getNextIOHandle());
+    EXPECT_EQ(command->getCommand(), kQueryRequest);
+
+    // Set some output for the main test thread, destruction of the handle will return the request.
+    fprintf(command->out(), "%s", kQueryResponse.c_str());
+  });
+  server_handler.start();
+
+  NetworkCliClient client(
+    grpc::CreateChannel(NetworkIO::GetAddress(),
+                        grpc::InsecureChannelCredentials()));
+  QueryRequest request;
+  request.set_query(kQueryRequest);
+  QueryResponse response;
+  Status status = client.SendQuery(request, &response);
+  ASSERT_TRUE(status.ok());
+  EXPECT_EQ(kQueryResponse, response.query_result());
+  EXPECT_TRUE(response.error_result().empty());
+
+  server_handler.join();
+}
+
+/**
+ * Tests that killing the service will cancel requests.
+ */
+TEST(NetworkIOTest, TestShutdown) {
+  // Start a server:
+  NetworkIO networkIO;
+
+  std::function<void(void)> send_request_fn([]() {
+    // Create a request, and, on return it should be canceled.
+    NetworkCliClient client(grpc::CreateChannel(NetworkIO::GetAddress(),
+                            grpc::InsecureChannelCredentials()));
+    QueryRequest request;
+    request.set_query(kQueryRequest);
+    QueryResponse response;
+    Status status = client.SendQuery(request, &response);
+    EXPECT_EQ(grpc::OK, status.error_code());
+
+    // Server will kill the next request.
+    status = client.SendQuery(request, &response);
+    EXPECT_EQ(grpc::CANCELLED, status.error_code());
+  });
+
+  HelperThread client_thread(send_request_fn);
+  client_thread.start();
+
+  {
+    std::unique_ptr<IOHandle> ioHandle(networkIO.getNextIOHandle());
+    EXPECT_EQ(ioHandle->getCommand(), kQueryRequest);
+    // Killing the service should cause the response the client thread receives to be canceled.
+    networkIO.killService();
+  }
+
+  client_thread.join();
+}
+
+}  // namespace quickstep
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  ::testing::InitGoogleTest(&argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  grpc_init();
+  return RUN_ALL_TESTS();
+}

--- a/validate_cmakelists.py
+++ b/validate_cmakelists.py
@@ -48,6 +48,7 @@ EXCLUDED_TOP_LEVEL_DIRS = ["build", "third_party"]
 IGNORED_DEPENDENCIES = frozenset(
     ["quickstep_cli_LineReaderDumb",
      "quickstep_cli_LineReaderLineNoise",
+     "quickstep_cli_NetworkCli.grpc_proto",
      "quickstep_storage_DataExchange.grpc_proto",
      "quickstep_threading_WinThreadsAPI",
      "quickstep_utility_textbasedtest_TextBasedTest",


### PR DESCRIPTION
# Adds Network CLI functionality to Single Node

**Functional Changes include:**
]Adding a network mode to the cli. Run quickstep in `network` mode (defaults to `local`)

`quickstep_cli_shell --mode=network`

Now quickstep boots a server, you can interact using the client executable...

`quickstep_client < my_query.sql`

**Code Changes include:**
* Adds a generic IO interface
  * Hides Linereader from CLI behind class `LocalIO`
  * New `NetworkIO` also hidden here
* Adds tests for NetworkIO
* Adds simple Client executable 
* Cmake flag to disable (`ENABLE_NETWORK_CLI=false`)