### PR TITLE
Assigned partition_id to RebuildWorkOrder.

### DIFF
--- a/query_execution/QueryManagerSingleNode.cpp
+++ b/query_execution/QueryManagerSingleNode.cpp
@@ -174,12 +174,13 @@ void QueryManagerSingleNode::getRebuildWorkOrders(const dag_node_index index,
   }
 
   std::vector<MutableBlockReference> partially_filled_block_refs;
+  std::vector<partition_id> part_ids;
 
   DCHECK(query_context_ != nullptr);
   InsertDestination *insert_destination = query_context_->getInsertDestination(insert_destination_index);
   DCHECK(insert_destination != nullptr);
 
-  insert_destination->getPartiallyFilledBlocks(&partially_filled_block_refs);
+  insert_destination->getPartiallyFilledBlocks(&partially_filled_block_refs, &part_ids);
 
   for (std::vector<MutableBlockReference>::size_type i = 0;
        i < partially_filled_block_refs.size();
@@ -189,6 +190,7 @@ void QueryManagerSingleNode::getRebuildWorkOrders(const dag_node_index index,
                              std::move(partially_filled_block_refs[i]),
                              index,
                              op.getOutputRelationID(),
+                             part_ids[i],
                              foreman_client_id_,
                              bus_),
         index);

--- a/query_execution/Shiftboss.cpp
+++ b/query_execution/Shiftboss.cpp
@@ -405,7 +405,8 @@ void Shiftboss::processInitiateRebuildMessage(const std::size_t query_id,
   DCHECK(insert_destination != nullptr);
 
   vector<MutableBlockReference> partially_filled_block_refs;
-  insert_destination->getPartiallyFilledBlocks(&partially_filled_block_refs);
+  vector<partition_id> part_ids;
+  insert_destination->getPartiallyFilledBlocks(&partially_filled_block_refs, &part_ids);
 
   serialization::InitiateRebuildResponseMessage proto;
   proto.set_query_id(query_id);
@@ -439,6 +440,7 @@ void Shiftboss::processInitiateRebuildMessage(const std::size_t query_id,
                              move(partially_filled_block_refs[i]),
                              op_index,
                              rel_id,
+                             part_ids[i],
                              shiftboss_client_id_local_,
                              bus_local_);
 

--- a/relational_operators/RebuildWorkOrder.hpp
+++ b/relational_operators/RebuildWorkOrder.hpp
@@ -57,6 +57,7 @@ class RebuildWorkOrder : public WorkOrder {
    *        query plan DAG that produced the output block.
    * @param input_relation_id The ID of the CatalogRelation to which the given
    *        storage block belongs to.
+   * @param part_id The partition_id of the block, if any.
    * @param scheduler_client_id The TMB client ID of the scheduler thread.
    * @param bus A pointer to the TMB.
    **/
@@ -65,12 +66,14 @@ class RebuildWorkOrder : public WorkOrder {
       MutableBlockReference &&block_ref,  // NOLINT(whitespace/operators)
       const std::size_t input_operator_index,
       const relation_id input_relation_id,
+      const partition_id part_id,
       const client_id scheduler_client_id,
       MessageBus *bus)
       : WorkOrder(query_id),
         block_ref_(std::move(block_ref)),
         input_operator_index_(input_operator_index),
         input_relation_id_(input_relation_id),
+        part_id_(part_id),
         scheduler_client_id_(scheduler_client_id),
         bus_(bus) {}
 
@@ -88,6 +91,7 @@ class RebuildWorkOrder : public WorkOrder {
     proto.set_block_id(block_ref_->getID());
     proto.set_relation_id(input_relation_id_);
     proto.set_query_id(query_id_);
+    proto.set_partition_id(part_id_);
 
     // NOTE(zuyu): Using the heap memory to serialize proto as a c-like string.
     const std::size_t proto_length = proto.ByteSize();
@@ -114,6 +118,7 @@ class RebuildWorkOrder : public WorkOrder {
   MutableBlockReference block_ref_;
   const std::size_t input_operator_index_;
   const relation_id input_relation_id_;
+  const partition_id part_id_;
   const client_id scheduler_client_id_;
 
   MessageBus *bus_;

--- a/storage/InsertDestination.cpp
+++ b/storage/InsertDestination.cpp
@@ -29,6 +29,7 @@
 #include "catalog/Catalog.pb.h"
 #include "catalog/CatalogAttribute.hpp"
 #include "catalog/CatalogRelationSchema.hpp"
+#include "catalog/CatalogTypedefs.hpp"
 #include "catalog/PartitionSchemeHeader.hpp"
 #include "query_execution/QueryExecutionMessages.pb.h"
 #include "query_execution/QueryExecutionTypedefs.hpp"
@@ -421,11 +422,15 @@ MutableBlockReference BlockPoolInsertDestination::createNewBlock() {
   return storage_manager_->getBlockMutable(new_id, relation_);
 }
 
-void BlockPoolInsertDestination::getPartiallyFilledBlocks(std::vector<MutableBlockReference> *partial_blocks) {
+void BlockPoolInsertDestination::getPartiallyFilledBlocks(std::vector<MutableBlockReference> *partial_blocks,
+                                                          vector<partition_id> *part_ids) {
   SpinMutexLock lock(mutex_);
   for (std::vector<MutableBlockReference>::size_type i = 0; i < available_block_refs_.size(); ++i) {
     partial_blocks->push_back((std::move(available_block_refs_[i])));
+    // No partition.
+    part_ids->push_back(0u);
   }
+
   available_block_refs_.clear();
 }
 


### PR DESCRIPTION
This PR fixed the bug when the input relation has partitions, but lost the info during the rebuild phase.