### PR TITLE
QUICKSTEP-76: Enabled LIP in the distributed version.

### DIFF
--- a/cli/distributed/QuickstepDistributedCli.cpp
+++ b/cli/distributed/QuickstepDistributedCli.cpp
@@ -69,11 +69,6 @@ using quickstep::FLAGS_role;
 int main(int argc, char *argv[]) {
   google::InitGoogleLogging(argv[0]);
 
-  // TODO(quickstep-team): Fix JIRA QUICKSTEP-76 for adding LIP filter support
-  // in the distributed version.
-  quickstep::optimizer::FLAGS_use_lip_filters = false;
-  quickstep::optimizer::FLAGS_use_filter_joins = false;
-
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   grpc_init();
 

--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -281,6 +281,7 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_storage_StorageBlockInfo
                         quickstep_utility_DAG
                         quickstep_utility_Macros
+                        quickstep_utility_lipfilter_LIPFilter_proto
                         tmb)
 endif(ENABLE_DISTRIBUTED)
 target_link_libraries(quickstep_queryexecution_QueryManagerSingleNode

--- a/query_execution/ForemanDistributed.hpp
+++ b/query_execution/ForemanDistributed.hpp
@@ -98,6 +98,10 @@ class ForemanDistributed final : public ForemanBase {
                                   const std::size_t next_shiftboss_index_to_schedule,
                                   std::size_t *shiftboss_index_for_hash_join);
 
+  bool isLipRelatedWorkOrder(const serialization::WorkOrderMessage &proto,
+                             const std::size_t next_shiftboss_index_to_schedule,
+                             std::size_t *shiftboss_index_for_lip);
+
   /**
    * @brief Dispatch schedulable WorkOrders, wrapped in WorkOrderMessages to the
    *        worker threads.

--- a/query_execution/PolicyEnforcerDistributed.cpp
+++ b/query_execution/PolicyEnforcerDistributed.cpp
@@ -192,6 +192,7 @@ void PolicyEnforcerDistributed::processInitiateRebuildResponseMessage(const tmb:
 void PolicyEnforcerDistributed::getShiftbossIndexForAggregation(
     const std::size_t query_id,
     const QueryContext::aggregation_state_id aggr_state_index,
+    const vector<QueryContext::lip_filter_id> &lip_filter_indexes,
     const BlockLocator &block_locator,
     const block_id block,
     const std::size_t next_shiftboss_index_to_schedule,
@@ -199,6 +200,7 @@ void PolicyEnforcerDistributed::getShiftbossIndexForAggregation(
   DCHECK(admitted_queries_.find(query_id) != admitted_queries_.end());
   QueryManagerDistributed *query_manager = static_cast<QueryManagerDistributed*>(admitted_queries_[query_id].get());
   query_manager->getShiftbossIndexForAggregation(aggr_state_index,
+                                                 lip_filter_indexes,
                                                  block_locator,
                                                  block,
                                                  next_shiftboss_index_to_schedule,
@@ -209,6 +211,7 @@ void PolicyEnforcerDistributed::getShiftbossIndexForHashJoin(
     const std::size_t query_id,
     const QueryContext::join_hash_table_id join_hash_table_index,
     const partition_id part_id,
+    const vector<QueryContext::lip_filter_id> &lip_filter_indexes,
     const BlockLocator &block_locator,
     const block_id block,
     const std::size_t next_shiftboss_index_to_schedule,
@@ -217,10 +220,27 @@ void PolicyEnforcerDistributed::getShiftbossIndexForHashJoin(
   QueryManagerDistributed *query_manager = static_cast<QueryManagerDistributed*>(admitted_queries_[query_id].get());
   query_manager->getShiftbossIndexForHashJoin(join_hash_table_index,
                                               part_id,
+                                              lip_filter_indexes,
                                               block_locator,
                                               block,
                                               next_shiftboss_index_to_schedule,
                                               shiftboss_index);
+}
+
+void PolicyEnforcerDistributed::getShiftbossIndexForLip(
+    const std::size_t query_id,
+    const vector<QueryContext::lip_filter_id> &lip_filter_indexes,
+    const BlockLocator &block_locator,
+    const block_id block,
+    const std::size_t next_shiftboss_index_to_schedule,
+    std::size_t *shiftboss_index) {
+  DCHECK(admitted_queries_.find(query_id) != admitted_queries_.end());
+  QueryManagerDistributed *query_manager = static_cast<QueryManagerDistributed*>(admitted_queries_[query_id].get());
+  query_manager->getShiftbossIndexForLip(lip_filter_indexes,
+                                         block_locator,
+                                         block,
+                                         next_shiftboss_index_to_schedule,
+                                         shiftboss_index);
 }
 
 void PolicyEnforcerDistributed::initiateQueryInShiftboss(QueryHandle *query_handle) {

--- a/query_execution/PolicyEnforcerDistributed.hpp
+++ b/query_execution/PolicyEnforcerDistributed.hpp
@@ -126,13 +126,14 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
   /**
    * @brief Get or set the index of Shiftboss for an Aggregation related
    * WorkOrder. If it is the first Aggregation on <aggr_state_index>,
-   * <shiftboss_index> will be set based on block locality if found,
-   * otherwise <next_shiftboss_index_to_schedule>.
+   * <shiftboss_index> will be set based on <lip_filter_indexes> locality or
+   * block locality if found, otherwise <next_shiftboss_index_to_schedule>.
    * Otherwise, <shiftboss_index> will be set to the index of the Shiftboss that
    * has executed the first Aggregation.
    *
    * @param query_id The query id.
    * @param aggr_state_index The Hash Table for the Aggregation.
+   * @param lip_filter_indexes The LIP filter indexes used by the WorkOrder.
    * @param block_locator The BlockLocator to use.
    * @param block The block id to feed BlockLocator for the locality info.
    * @param next_shiftboss_index The index of Shiftboss to schedule a next WorkOrder.
@@ -141,6 +142,7 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
   void getShiftbossIndexForAggregation(
       const std::size_t query_id,
       const QueryContext::aggregation_state_id aggr_state_index,
+      const std::vector<QueryContext::lip_filter_id> &lip_filter_indexes,
       const BlockLocator &block_locator,
       const block_id block,
       const std::size_t next_shiftboss_index_to_schedule,
@@ -149,14 +151,15 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
   /**
    * @brief Get or set the index of Shiftboss for a HashJoin related WorkOrder.
    * If it is the first BuildHash on <join_hash_table_index, part_id>,
-   * <shiftboss_index> will be set to block locality if found,
-   * otherwise <next_shiftboss_index_to_schedule>.
+   * <shiftboss_index> will be set based on <lip_filter_indexes> locality or
+   * block locality if found, otherwise <next_shiftboss_index_to_schedule>.
    * Otherwise, <shiftboss_index> will be set to the index of the Shiftboss that
    * has executed the first BuildHash.
    *
    * @param query_id The query id.
    * @param join_hash_table_index The Hash Table for the Join.
    * @param part_id The partition ID.
+   * @param lip_filter_indexes The LIP filter indexes used by the WorkOrder.
    * @param block_locator The BlockLocator to use.
    * @param block The block id to feed BlockLocator for the locality info.
    * @param next_shiftboss_index The index of Shiftboss to schedule a next WorkOrder.
@@ -166,6 +169,30 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
       const std::size_t query_id,
       const QueryContext::join_hash_table_id join_hash_table_index,
       const partition_id part_id,
+      const std::vector<QueryContext::lip_filter_id> &lip_filter_indexes,
+      const BlockLocator &block_locator,
+      const block_id block,
+      const std::size_t next_shiftboss_index_to_schedule,
+      std::size_t *shiftboss_index);
+
+  /**
+   * @brief Get or set the index of Shiftboss for a LIP related WorkOrder.
+   * If it is the first WorkOrder on <lip_filter_indexes>,
+   * <shiftboss_index> will be set based on block locality if found,
+   * otherwise <next_shiftboss_index_to_schedule>.
+   * Otherwise, <shiftboss_index> will be set to the index of the Shiftboss that
+   * has executed the first WorkOrder.
+   *
+   * @param query_id The query id.
+   * @param lip_filter_indexes The LIP filter indexes used by the WorkOrder.
+   * @param block_locator The BlockLocator to use.
+   * @param block The block id to feed BlockLocator for the locality info.
+   * @param next_shiftboss_index The index of Shiftboss to schedule a next WorkOrder.
+   * @param shiftboss_index The index of Shiftboss to schedule the WorkOrder.
+   **/
+  void getShiftbossIndexForLip(
+      const std::size_t query_id,
+      const std::vector<QueryContext::lip_filter_id> &lip_filter_indexes,
       const BlockLocator &block_locator,
       const block_id block,
       const std::size_t next_shiftboss_index_to_schedule,

--- a/query_optimizer/tests/DistributedExecutionGeneratorTest.cpp
+++ b/query_optimizer/tests/DistributedExecutionGeneratorTest.cpp
@@ -46,11 +46,6 @@ QUICKSTEP_GENERATE_TEXT_TEST(DISTRIBUTED_EXECUTION_GENERATOR_TEST);
 int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
 
-  // TODO(quickstep-team): Fix JIRA QUICKSTEP-76 for adding LIP filter support
-  // in the distributed version.
-  quickstep::optimizer::FLAGS_use_lip_filters = false;
-  quickstep::optimizer::FLAGS_use_filter_joins = false;
-
   // Honor FLAGS_buffer_pool_slots in StorageManager.
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 

--- a/relational_operators/AggregationOperator.cpp
+++ b/relational_operators/AggregationOperator.cpp
@@ -98,6 +98,10 @@ serialization::WorkOrder* AggregationOperator::createWorkOrderProto(const block_
   proto->SetExtension(serialization::AggregationWorkOrder::aggr_state_index, aggr_state_index_);
   proto->SetExtension(serialization::AggregationWorkOrder::lip_deployment_index, lip_deployment_index_);
 
+  for (const QueryContext::lip_filter_id lip_filter_index : lip_filter_indexes_) {
+    proto->AddExtension(serialization::AggregationWorkOrder::lip_filter_indexes, lip_filter_index);
+  }
+
   return proto;
 }
 

--- a/relational_operators/BuildHashOperator.cpp
+++ b/relational_operators/BuildHashOperator.cpp
@@ -147,6 +147,10 @@ serialization::WorkOrder* BuildHashOperator::createWorkOrderProto(const block_id
   proto->SetExtension(serialization::BuildHashWorkOrder::block_id, block);
   proto->SetExtension(serialization::BuildHashWorkOrder::lip_deployment_index, lip_deployment_index_);
 
+  for (const QueryContext::lip_filter_id lip_filter_index : lip_filter_indexes_) {
+    proto->AddExtension(serialization::BuildHashWorkOrder::lip_filter_indexes, lip_filter_index);
+  }
+
   return proto;
 }
 

--- a/relational_operators/BuildLIPFilterOperator.cpp
+++ b/relational_operators/BuildLIPFilterOperator.cpp
@@ -120,6 +120,10 @@ serialization::WorkOrder* BuildLIPFilterOperator::createWorkOrderProto(const blo
                       build_side_predicate_index_);
   proto->SetExtension(serialization::BuildLIPFilterWorkOrder::lip_deployment_index, lip_deployment_index_);
 
+  for (const QueryContext::lip_filter_id lip_filter_index : lip_filter_indexes_) {
+    proto->AddExtension(serialization::BuildLIPFilterWorkOrder::lip_filter_indexes, lip_filter_index);
+  }
+
   return proto;
 }
 

--- a/relational_operators/HashJoinOperator.cpp
+++ b/relational_operators/HashJoinOperator.cpp
@@ -388,6 +388,10 @@ serialization::WorkOrder* HashJoinOperator::createNonOuterJoinWorkOrderProto(
   proto->SetExtension(serialization::HashJoinWorkOrder::residual_predicate_index, residual_predicate_index_);
   proto->SetExtension(serialization::HashJoinWorkOrder::lip_deployment_index, lip_deployment_index_);
 
+  for (const QueryContext::lip_filter_id lip_filter_index : lip_filter_indexes_) {
+    proto->AddExtension(serialization::HashJoinWorkOrder::lip_filter_indexes, lip_filter_index);
+  }
+
   return proto;
 }
 
@@ -445,6 +449,10 @@ serialization::WorkOrder* HashJoinOperator::createOuterJoinWorkOrderProto(const 
   proto->SetExtension(serialization::HashJoinWorkOrder::block_id, block);
   proto->SetExtension(serialization::HashJoinWorkOrder::partition_id, part_id);
   proto->SetExtension(serialization::HashJoinWorkOrder::lip_deployment_index, lip_deployment_index_);
+
+  for (const QueryContext::lip_filter_id lip_filter_index : lip_filter_indexes_) {
+    proto->AddExtension(serialization::HashJoinWorkOrder::lip_filter_indexes, lip_filter_index);
+  }
 
   for (const bool is_attribute_on_build : is_selection_on_build_) {
     proto->AddExtension(serialization::HashJoinWorkOrder::is_selection_on_build, is_attribute_on_build);

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -274,8 +275,10 @@ class RelationalOperator {
   /**
    * @brief Deploy a group of LIPFilters to this operator.
    */
-  void deployLIPFilters(const QueryContext::lip_deployment_id lip_deployment_index) {
+  void deployLIPFilters(const QueryContext::lip_deployment_id lip_deployment_index,
+                        const std::unordered_set<QueryContext::lip_filter_id> &lip_filter_indexes) {
     lip_deployment_index_ = lip_deployment_index;
+    lip_filter_indexes_ = lip_filter_indexes;
   }
 
  protected:
@@ -300,6 +303,7 @@ class RelationalOperator {
   std::size_t op_index_;
 
   QueryContext::lip_deployment_id lip_deployment_index_;
+  std::unordered_set<QueryContext::lip_filter_id> lip_filter_indexes_;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(RelationalOperator);

--- a/relational_operators/SelectOperator.cpp
+++ b/relational_operators/SelectOperator.cpp
@@ -150,6 +150,10 @@ serialization::WorkOrder* SelectOperator::createWorkOrderProto(const block_id bl
   proto->SetExtension(serialization::SelectWorkOrder::selection_index, selection_index_);
   proto->SetExtension(serialization::SelectWorkOrder::lip_deployment_index, lip_deployment_index_);
 
+  for (const QueryContext::lip_filter_id lip_filter_index : lip_filter_indexes_) {
+    proto->AddExtension(serialization::SelectWorkOrder::lip_filter_indexes, lip_filter_index);
+  }
+
   return proto;
 }
 

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -64,6 +64,7 @@ message AggregationWorkOrder {
     optional uint32 aggr_state_index = 16;
     optional fixed64 block_id = 17;
     optional int32 lip_deployment_index = 18;
+    repeated uint32 lip_filter_indexes = 19;
   }
 }
 
@@ -76,7 +77,7 @@ message BuildAggregationExistenceMapWorkOrder {
   }
 }
 
-// Next tag: 39.
+// Next tag: 40.
 message BuildHashWorkOrder {
   extend WorkOrder {
     // All required.
@@ -87,6 +88,7 @@ message BuildHashWorkOrder {
     optional uint64 partition_id = 38;
     optional fixed64 block_id = 36;
     optional int32 lip_deployment_index = 37;
+    repeated uint32 lip_filter_indexes = 39;
   }
 }
 
@@ -97,6 +99,7 @@ message BuildLIPFilterWorkOrder {
     optional fixed64 build_block_id = 49;
     optional int32 build_side_predicate_index = 50;
     optional int32 lip_deployment_index = 51;
+    repeated uint32 lip_filter_indexes = 52;
   }
 }
 
@@ -141,7 +144,7 @@ message FinalizeAggregationWorkOrder {
   }
 }
 
-// Next tag: 173.
+// Next tag: 174.
 message HashJoinWorkOrder {
   enum HashJoinWorkOrderType {
     HASH_ANTI_JOIN = 0;
@@ -169,6 +172,7 @@ message HashJoinWorkOrder {
     repeated bool is_selection_on_build = 170;
 
     optional int32 lip_deployment_index = 171;
+    repeated uint32 lip_filter_indexes = 173;
   }
 }
 
@@ -227,6 +231,7 @@ message SelectWorkOrder {
     optional int32 selection_index = 246;
 
     optional int32 lip_deployment_index = 247;
+    repeated uint32 lip_filter_indexes = 248;
   }
 }
 


### PR DESCRIPTION
Assigned to @jianqiao.

This PR enables LIP feature in the distributed version. By computing the LIP filter group (aka equivalence class) based on the LIP filter usages in a LIP deployment, any work orders that use a LIP filter from the same group will be scheduled to the same node.

In all SSB queries, since there is only one LIP filter group, when enabling LIP feature, all work orders that use any LIP will be scheduled to one node.

Note that this PR is not compatible with partitions, until partitioned aggregations are supported.