### PR TITLE
Simplified ExtractCommonSubexpression rule as a BottomUp rule.

### DIFF
--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -109,7 +109,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_ExtractCommonSubexpression
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_physical_PhysicalType
                       quickstep_queryoptimizer_physical_Selection
-                      quickstep_queryoptimizer_rules_Rule
+                      quickstep_queryoptimizer_rules_BottomUpRule
                       quickstep_utility_HashError
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_FuseAggregateJoin

--- a/query_optimizer/rules/ExtractCommonSubexpression.hpp
+++ b/query_optimizer/rules/ExtractCommonSubexpression.hpp
@@ -34,7 +34,7 @@
 #include "query_optimizer/expressions/ExpressionType.hpp"
 #include "query_optimizer/expressions/Scalar.hpp"
 #include "query_optimizer/physical/Physical.hpp"
-#include "query_optimizer/rules/Rule.hpp"
+#include "query_optimizer/rules/BottomUpRule.hpp"
 #include "utility/Macros.hpp"
 
 namespace quickstep {
@@ -54,7 +54,7 @@ class OptimizerContext;
  *       of the physical passes (e.g. ReuseAggregateExpressions) to be finalized
  *       before this one to maximize optimization opportunities.
  */
-class ExtractCommonSubexpression : public Rule<physical::Physical> {
+class ExtractCommonSubexpression : public BottomUpRule<physical::Physical> {
  public:
   /**
    * @brief Constructor.
@@ -69,11 +69,10 @@ class ExtractCommonSubexpression : public Rule<physical::Physical> {
     return "ExtractCommonSubexpression";
   }
 
-  physical::PhysicalPtr apply(const physical::PhysicalPtr &input) override;
+ protected:
+  physical::PhysicalPtr applyToNode(const physical::PhysicalPtr &input) override;
 
  private:
-  physical::PhysicalPtr applyInternal(const physical::PhysicalPtr &input);
-
   struct ScalarHash {
     inline std::size_t operator()(const expressions::ScalarPtr &scalar) const {
       return scalar->hash();


### PR DESCRIPTION
This small PR simplified PR #237 by deriving from a `BottomUpRule`.

Assigned to @jianqiao.