### PR TITLE
Added the support for partitioned (but not parallel) aggregations.

### DIFF
--- a/query_execution/BlockLocator.hpp
+++ b/query_execution/BlockLocator.hpp
@@ -123,6 +123,8 @@ class BlockLocator : public Thread {
    * @return Whether the block locality info has found.
    **/
   bool getBlockLocalityInfo(const block_id block, std::size_t *shiftboss_index_for_block) const {
+    if (block == kInvalidBlockId) { return false; }
+
     const std::unordered_set<block_id_domain> block_domains = getBlockDomains(block);
     if (!block_domains.empty()) {
       // NOTE(zuyu): This lock is held for the rest duration of this call, as the

--- a/query_execution/PolicyEnforcerDistributed.cpp
+++ b/query_execution/PolicyEnforcerDistributed.cpp
@@ -192,6 +192,7 @@ void PolicyEnforcerDistributed::processInitiateRebuildResponseMessage(const tmb:
 void PolicyEnforcerDistributed::getShiftbossIndexForAggregation(
     const std::size_t query_id,
     const QueryContext::aggregation_state_id aggr_state_index,
+    const partition_id part_id,
     const vector<QueryContext::lip_filter_id> &lip_filter_indexes,
     const BlockLocator &block_locator,
     const block_id block,
@@ -200,6 +201,7 @@ void PolicyEnforcerDistributed::getShiftbossIndexForAggregation(
   DCHECK(admitted_queries_.find(query_id) != admitted_queries_.end());
   QueryManagerDistributed *query_manager = static_cast<QueryManagerDistributed*>(admitted_queries_[query_id].get());
   query_manager->getShiftbossIndexForAggregation(aggr_state_index,
+                                                 part_id,
                                                  lip_filter_indexes,
                                                  block_locator,
                                                  block,

--- a/query_execution/PolicyEnforcerDistributed.hpp
+++ b/query_execution/PolicyEnforcerDistributed.hpp
@@ -133,6 +133,7 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
    *
    * @param query_id The query id.
    * @param aggr_state_index The Hash Table for the Aggregation.
+   * @param part_id The partition ID.
    * @param lip_filter_indexes The LIP filter indexes used by the WorkOrder.
    * @param block_locator The BlockLocator to use.
    * @param block The block id to feed BlockLocator for the locality info.
@@ -142,6 +143,7 @@ class PolicyEnforcerDistributed final : public PolicyEnforcerBase {
   void getShiftbossIndexForAggregation(
       const std::size_t query_id,
       const QueryContext::aggregation_state_id aggr_state_index,
+      const partition_id part_id,
       const std::vector<QueryContext::lip_filter_id> &lip_filter_indexes,
       const BlockLocator &block_locator,
       const block_id block,

--- a/query_execution/QueryContext.proto
+++ b/query_execution/QueryContext.proto
@@ -30,6 +30,11 @@ import "utility/SortConfiguration.proto";
 import "utility/lip_filter/LIPFilter.proto";
 
 message QueryContext {
+  message AggregationOperationStateContext {
+    required AggregationOperationState aggregation_state = 1;
+    optional uint64 num_partitions = 2 [default = 1];
+  }
+
   message HashTableContext {
     required HashTable join_hash_table = 1;
     optional uint64 num_partitions = 2 [default = 1];
@@ -50,7 +55,7 @@ message QueryContext {
     repeated UpdateAssignment update_assignments = 2;
   }
 
-  repeated AggregationOperationState aggregation_states = 1;
+  repeated AggregationOperationStateContext aggregation_states = 1;
   repeated GeneratorFunctionHandle generator_functions = 2;
   repeated HashTableContext join_hash_tables = 3;
   repeated InsertDestination insert_destinations = 4;

--- a/query_execution/QueryManagerDistributed.cpp
+++ b/query_execution/QueryManagerDistributed.cpp
@@ -76,7 +76,10 @@ QueryManagerDistributed::QueryManagerDistributed(QueryHandle *query_handle,
   }
 
   const serialization::QueryContext &query_context_proto = query_handle->getQueryContextProto();
-  shiftboss_indexes_for_aggrs_.resize(query_context_proto.aggregation_states_size(), kInvalidShiftbossIndex);
+  for (int i = 0; i < query_context_proto.aggregation_states_size(); ++i) {
+    shiftboss_indexes_for_aggrs_.push_back(
+        vector<size_t>(query_context_proto.aggregation_states(i).num_partitions(), kInvalidShiftbossIndex));
+  }
 
   for (int i = 0; i < query_context_proto.join_hash_tables_size(); ++i) {
     shiftboss_indexes_for_hash_joins_.push_back(

--- a/relational_operators/BuildAggregationExistenceMapOperator.hpp
+++ b/relational_operators/BuildAggregationExistenceMapOperator.hpp
@@ -21,12 +21,12 @@
 #define QUICKSTEP_RELATIONAL_OPERATORS_BUILD_AGGREGATION_EXISTENCE_MAP_OPERATOR_HPP_
 
 #include <cstddef>
-
 #include <string>
 #include <vector>
 
 #include "catalog/CatalogRelation.hpp"
 #include "catalog/CatalogTypedefs.hpp"
+#include "catalog/PartitionScheme.hpp"
 #include "query_execution/QueryContext.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
@@ -70,21 +70,36 @@ class BuildAggregationExistenceMapOperator : public RelationalOperator {
    *        is fully available to the operator before it can start generating
    *        workorders.
    * @param aggr_state_index The index of the AggregationState in QueryContext.
+   * @param num_partitions The number of partitions in 'input_relation'. If no
+   *        partitions, it is one.
    **/
   BuildAggregationExistenceMapOperator(const std::size_t query_id,
                                        const CatalogRelation &input_relation,
                                        const attribute_id build_attribute,
                                        const bool input_relation_is_stored,
-                                       const QueryContext::aggregation_state_id aggr_state_index)
+                                       const QueryContext::aggregation_state_id aggr_state_index,
+                                       const std::size_t num_partitions)
       : RelationalOperator(query_id),
         input_relation_(input_relation),
         build_attribute_(build_attribute),
         input_relation_is_stored_(input_relation_is_stored),
         aggr_state_index_(aggr_state_index),
-        input_relation_block_ids_(input_relation_is_stored ? input_relation.getBlocksSnapshot()
-                                                           : std::vector<block_id>()),
-        num_workorders_generated_(0),
-        started_(false) {}
+        num_partitions_(num_partitions),
+        input_relation_block_ids_(num_partitions),
+        num_workorders_generated_(num_partitions),
+        started_(false) {
+    if (input_relation_is_stored) {
+      if (input_relation.hasPartitionScheme()) {
+        const PartitionScheme &part_scheme = *input_relation.getPartitionScheme();
+        for (std::size_t part_id = 0; part_id < num_partitions_; ++part_id) {
+          input_relation_block_ids_[part_id] = part_scheme.getBlocksInPartition(part_id);
+        }
+      } else {
+        // No partition.
+        input_relation_block_ids_[0] = input_relation.getBlocksSnapshot();
+      }
+    }
+  }
 
   ~BuildAggregationExistenceMapOperator() override {}
 
@@ -113,19 +128,21 @@ class BuildAggregationExistenceMapOperator : public RelationalOperator {
 
   void feedInputBlock(const block_id input_block_id, const relation_id input_relation_id,
                       const partition_id part_id) override {
-    input_relation_block_ids_.push_back(input_block_id);
+    input_relation_block_ids_[part_id].push_back(input_block_id);
   }
 
  private:
-  serialization::WorkOrder* createWorkOrderProto(const block_id block);
+  serialization::WorkOrder* createWorkOrderProto(const block_id block, const partition_id part_id);
 
   const CatalogRelation &input_relation_;
   const attribute_id build_attribute_;
   const bool input_relation_is_stored_;
   const QueryContext::aggregation_state_id aggr_state_index_;
+  const std::size_t num_partitions_;
 
-  std::vector<block_id> input_relation_block_ids_;
-  std::vector<block_id>::size_type num_workorders_generated_;
+  // The index is the partition id.
+  std::vector<BlocksInPartition> input_relation_block_ids_;
+  std::vector<std::size_t> num_workorders_generated_;
   bool started_;
 
   DISALLOW_COPY_AND_ASSIGN(BuildAggregationExistenceMapOperator);

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(quickstep_relationaloperators_AggregationOperator
                       glog
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionScheme
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrderProtosContainer
                       quickstep_queryexecution_WorkOrdersContainer
@@ -105,6 +106,7 @@ target_link_libraries(quickstep_relationaloperators_BuildAggregationExistenceMap
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionScheme
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrderProtosContainer
                       quickstep_queryexecution_WorkOrdersContainer
@@ -205,6 +207,7 @@ target_link_libraries(quickstep_relationaloperators_DeleteOperator
                       tmb)
 target_link_libraries(quickstep_relationaloperators_DestroyAggregationStateOperator
                       glog
+                      quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrderProtosContainer
                       quickstep_queryexecution_WorkOrdersContainer
@@ -581,6 +584,7 @@ target_link_libraries(quickstep_relationaloperators_WorkOrderFactory
                       quickstep_relationaloperators_DropTableOperator
                       quickstep_relationaloperators_FinalizeAggregationOperator
                       quickstep_relationaloperators_HashJoinOperator
+                      quickstep_relationaloperators_InitializeAggregationOperator
                       quickstep_relationaloperators_InsertOperator
                       quickstep_relationaloperators_NestedLoopsJoinOperator
                       quickstep_relationaloperators_SampleOperator

--- a/relational_operators/DestroyAggregationStateOperator.hpp
+++ b/relational_operators/DestroyAggregationStateOperator.hpp
@@ -22,6 +22,7 @@
 
 #include <string>
 
+#include "catalog/CatalogTypedefs.hpp"
 #include "query_execution/QueryContext.hpp"
 #include "relational_operators/RelationalOperator.hpp"
 #include "relational_operators/WorkOrder.hpp"
@@ -53,12 +54,16 @@ class DestroyAggregationStateOperator : public RelationalOperator {
    *
    * @param query_id The ID of the query to which this operator belongs.
    * @param aggr_state_index The index of the AggregationState in QueryContext.
+   * @param num_partitions The number of partitions of 'input_relation' in a
+   *        partitioned aggregation. If no partitions, it is one.
    **/
   DestroyAggregationStateOperator(
       const std::size_t query_id,
-      const QueryContext::aggregation_state_id aggr_state_index)
+      const QueryContext::aggregation_state_id aggr_state_index,
+      const std::size_t num_partitions)
       : RelationalOperator(query_id),
         aggr_state_index_(aggr_state_index),
+        num_partitions_(num_partitions),
         work_generated_(false) {}
 
   ~DestroyAggregationStateOperator() override {}
@@ -81,6 +86,7 @@ class DestroyAggregationStateOperator : public RelationalOperator {
 
  private:
   const QueryContext::aggregation_state_id aggr_state_index_;
+  const std::size_t num_partitions_;
   bool work_generated_;
 
   DISALLOW_COPY_AND_ASSIGN(DestroyAggregationStateOperator);
@@ -96,14 +102,17 @@ class DestroyAggregationStateWorkOrder : public WorkOrder {
    *
    * @param query_id The ID of the query to which this WorkOrder belongs.
    * @param aggr_state_index The index of the AggregationState in QueryContext.
+   * @param part_id The partition id.
    * @param query_context The QueryContext to use.
    **/
   DestroyAggregationStateWorkOrder(
       const std::size_t query_id,
       const QueryContext::aggregation_state_id aggr_state_index,
+      const partition_id part_id,
       QueryContext *query_context)
       : WorkOrder(query_id),
         aggr_state_index_(aggr_state_index),
+        part_id_(part_id),
         query_context_(DCHECK_NOTNULL(query_context)) {}
 
   ~DestroyAggregationStateWorkOrder() override {}
@@ -112,6 +121,7 @@ class DestroyAggregationStateWorkOrder : public WorkOrder {
 
  private:
   const QueryContext::aggregation_state_id aggr_state_index_;
+  const partition_id part_id_;
   QueryContext *query_context_;
 
   DISALLOW_COPY_AND_ASSIGN(DestroyAggregationStateWorkOrder);

--- a/relational_operators/FinalizeAggregationOperator.cpp
+++ b/relational_operators/FinalizeAggregationOperator.cpp
@@ -19,6 +19,9 @@
 
 #include "relational_operators/FinalizeAggregationOperator.hpp"
 
+#include <cstddef>
+
+#include "catalog/CatalogTypedefs.hpp"
 #include "query_execution/QueryContext.hpp"
 #include "query_execution/WorkOrderProtosContainer.hpp"
 #include "query_execution/WorkOrdersContainer.hpp"
@@ -41,19 +44,23 @@ bool FinalizeAggregationOperator::getAllWorkOrders(
 
   if (blocking_dependencies_met_ && !started_) {
     started_ = true;
-    AggregationOperationState *agg_state =
-        query_context->getAggregationState(aggr_state_index_);
-    DCHECK(agg_state != nullptr);
-    for (std::size_t part_id = 0;
-         part_id < agg_state->getNumFinalizationPartitions();
-         ++part_id) {
-      container->addNormalWorkOrder(
-          new FinalizeAggregationWorkOrder(
-              query_id_,
-              part_id,
-              agg_state,
-              query_context->getInsertDestination(output_destination_index_)),
-          op_index_);
+
+    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+      AggregationOperationState *agg_state =
+          query_context->getAggregationState(aggr_state_index_, part_id);
+      DCHECK(agg_state != nullptr);
+      for (std::size_t state_part_id = 0;
+           state_part_id < agg_state->getNumFinalizationPartitions();
+           ++state_part_id) {
+        container->addNormalWorkOrder(
+            new FinalizeAggregationWorkOrder(
+                query_id_,
+                part_id,
+                state_part_id,
+                agg_state,
+                query_context->getInsertDestination(output_destination_index_)),
+            op_index_);
+      }
     }
   }
   return started_;
@@ -66,21 +73,28 @@ bool FinalizeAggregationOperator::getAllWorkOrderProtos(WorkOrderProtosContainer
   if (blocking_dependencies_met_ && !started_) {
     started_ = true;
 
-    serialization::WorkOrder *proto = new serialization::WorkOrder;
-    proto->set_work_order_type(serialization::FINALIZE_AGGREGATION);
-    proto->set_query_id(query_id_);
-    proto->SetExtension(serialization::FinalizeAggregationWorkOrder::aggr_state_index,
-                        aggr_state_index_);
-    proto->SetExtension(serialization::FinalizeAggregationWorkOrder::insert_destination_index,
-                        output_destination_index_);
+    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+      serialization::WorkOrder *proto = new serialization::WorkOrder;
+      proto->set_work_order_type(serialization::FINALIZE_AGGREGATION);
+      proto->set_query_id(query_id_);
+      proto->SetExtension(serialization::FinalizeAggregationWorkOrder::aggr_state_index,
+                          aggr_state_index_);
+      proto->SetExtension(serialization::FinalizeAggregationWorkOrder::partition_id,
+                          part_id);
+      proto->SetExtension(serialization::FinalizeAggregationWorkOrder::state_partition_id,
+                          0u);
+      proto->SetExtension(serialization::FinalizeAggregationWorkOrder::insert_destination_index,
+                          output_destination_index_);
 
-    container->addWorkOrderProto(proto, op_index_);
+      container->addWorkOrderProto(proto, op_index_);
+    }
   }
   return started_;
 }
 
 void FinalizeAggregationWorkOrder::execute() {
-  state_->finalizeAggregate(partition_id_, output_destination_);
+  (void) part_id_;
+  state_->finalizeAggregate(state_partition_id_, output_destination_);
 }
 
 }  // namespace quickstep

--- a/relational_operators/InitializeAggregationOperator.hpp
+++ b/relational_operators/InitializeAggregationOperator.hpp
@@ -56,11 +56,15 @@ class InitializeAggregationOperator : public RelationalOperator {
    *
    * @param query_id The ID of this query.
    * @param aggr_state_index The index of the AggregationOperationState in QueryContext.
+   * @param num_partitions The number of partitions in 'input_relation'. If no
+   *        partitions, it is one.
    **/
   InitializeAggregationOperator(const std::size_t query_id,
-                                const QueryContext::aggregation_state_id aggr_state_index)
+                                const QueryContext::aggregation_state_id aggr_state_index,
+                                const std::size_t num_partitions)
       : RelationalOperator(query_id),
         aggr_state_index_(aggr_state_index),
+        num_partitions_(num_partitions),
         started_(false) {}
 
   ~InitializeAggregationOperator() override {}
@@ -83,6 +87,7 @@ class InitializeAggregationOperator : public RelationalOperator {
 
  private:
   const QueryContext::aggregation_state_id aggr_state_index_;
+  const std::size_t num_partitions_;
   bool started_;
 
   DISALLOW_COPY_AND_ASSIGN(InitializeAggregationOperator);
@@ -97,14 +102,14 @@ class InitializeAggregationWorkOrder : public WorkOrder {
    * @brief Constructor.
    *
    * @param query_id The ID of the query to which this operator belongs.
-   * @param partition_id The partition ID for which the work order is issued.
+   * @param state_partition_id The partition ID for which the work order is issued.
    * @param state The AggregationOperationState to be initialized.
    */
   InitializeAggregationWorkOrder(const std::size_t query_id,
-                                 const std::size_t partition_id,
+                                 const std::size_t state_partition_id,
                                  AggregationOperationState *state)
       : WorkOrder(query_id),
-        partition_id_(partition_id),
+        state_partition_id_(state_partition_id),
         state_(DCHECK_NOTNULL(state)) {}
 
   ~InitializeAggregationWorkOrder() override {}
@@ -112,7 +117,7 @@ class InitializeAggregationWorkOrder : public WorkOrder {
   void execute() override;
 
  private:
-  const std::size_t partition_id_;
+  const std::size_t state_partition_id_;
 
   AggregationOperationState *state_;
 

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -21,7 +21,7 @@ package quickstep.serialization;
 
 import "relational_operators/SortMergeRunOperator.proto";
 
-// Next tag: 25.
+// Next tag: 26.
 enum WorkOrderType {
   AGGREGATION = 1;
   BUILD_AGGREGATION_EXISTENCE_MAP = 23;
@@ -35,6 +35,7 @@ enum WorkOrderType {
   DROP_TABLE = 8;
   FINALIZE_AGGREGATION = 9;
   HASH_JOIN = 10;
+  INITIALIZE_AGGREGATION = 25;
   INSERT = 11;
   NESTED_LOOP_JOIN = 12;
   SAMPLE = 13;
@@ -58,10 +59,12 @@ message WorkOrder {
   extensions 16 to max;
 }
 
+// Next tag: 21.
 message AggregationWorkOrder {
   extend WorkOrder {
     // All required.
     optional uint32 aggr_state_index = 16;
+    optional uint64 partition_id = 20;
     optional fixed64 block_id = 17;
     optional int32 lip_deployment_index = 18;
     repeated uint32 lip_filter_indexes = 19;
@@ -74,6 +77,7 @@ message BuildAggregationExistenceMapWorkOrder {
     optional fixed64 build_block_id = 369;
     optional int32 build_attribute = 370;
     optional uint32 aggr_state_index = 371;
+    optional uint64 partition_id = 372;
   }
 }
 
@@ -118,6 +122,7 @@ message DeleteWorkOrder {
 message DestroyAggregationStateWorkOrder {
   extend WorkOrder {
     optional uint32 aggr_state_index = 352;
+    optional uint64 partition_id = 353;
   }
 }
 
@@ -138,10 +143,13 @@ message DropTableWorkOrder {
   }
 }
 
+// Next tag: 148.
 message FinalizeAggregationWorkOrder {
   extend WorkOrder {
     // All required.
     optional uint32 aggr_state_index = 144;
+    optional uint64 partition_id = 146;
+    optional uint64 state_partition_id = 147;
     optional int32 insert_destination_index = 145;
   }
 }
@@ -175,6 +183,15 @@ message HashJoinWorkOrder {
 
     optional int32 lip_deployment_index = 171;
     repeated uint32 lip_filter_indexes = 173;
+  }
+}
+
+message InitializeAggregationWorkOrder {
+  extend WorkOrder {
+    // All required.
+    optional uint32 aggr_state_index = 400;
+    optional uint64 partition_id = 401;
+    optional uint64 state_partition_id = 402;
   }
 }
 

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -82,6 +82,7 @@ namespace quickstep {
 namespace {
 constexpr std::size_t kQueryId = 0;
 constexpr int kOpIndex = 0;
+constexpr std::size_t kNumPartitions = 1u;
 }  // namespace
 
 class Type;
@@ -234,7 +235,8 @@ class AggregationOperatorTest : public ::testing::Test {
     query_context_proto.set_query_id(0);  // dummy query ID.
 
     const QueryContext::aggregation_state_id aggr_state_index = query_context_proto.aggregation_states_size();
-    serialization::AggregationOperationState *aggr_state_proto = query_context_proto.add_aggregation_states();
+    serialization::AggregationOperationState *aggr_state_proto =
+        query_context_proto.add_aggregation_states()->mutable_aggregation_state();
     aggr_state_proto->set_relation_id(table_->getID());
 
     // Add an aggregate.
@@ -276,7 +278,7 @@ class AggregationOperatorTest : public ::testing::Test {
     aggr_state_proto->set_estimated_num_entries(estimated_entries);
 
     // Create Operators.
-    op_.reset(new AggregationOperator(0, *table_, true, aggr_state_index));
+    op_.reset(new AggregationOperator(0, *table_, true, aggr_state_index, kNumPartitions));
 
     // Setup the InsertDestination proto in the query context proto.
     const QueryContext::insert_destination_id insert_destination_index =
@@ -290,11 +292,12 @@ class AggregationOperatorTest : public ::testing::Test {
     finalize_op_.reset(
         new FinalizeAggregationOperator(kQueryId,
                                         aggr_state_index,
+                                        kNumPartitions,
                                         *result_table_,
                                         insert_destination_index));
 
     destroy_aggr_state_op_.reset(
-        new DestroyAggregationStateOperator(kQueryId, aggr_state_index));
+        new DestroyAggregationStateOperator(kQueryId, aggr_state_index, kNumPartitions));
 
     // Set up the QueryContext.
     query_context_.reset(new QueryContext(query_context_proto,
@@ -331,7 +334,8 @@ class AggregationOperatorTest : public ::testing::Test {
     query_context_proto.set_query_id(0);  // dummy query ID.
 
     const QueryContext::aggregation_state_id aggr_state_index = query_context_proto.aggregation_states_size();
-    serialization::AggregationOperationState *aggr_state_proto = query_context_proto.add_aggregation_states();
+    serialization::AggregationOperationState *aggr_state_proto =
+        query_context_proto.add_aggregation_states()->mutable_aggregation_state();
     aggr_state_proto->set_relation_id(table_->getID());
 
     // Add an aggregate.
@@ -368,7 +372,7 @@ class AggregationOperatorTest : public ::testing::Test {
         serialization::HashTableImplType::SEPARATE_CHAINING);
 
     // Create Operators.
-    op_.reset(new AggregationOperator(0, *table_, true, aggr_state_index));
+    op_.reset(new AggregationOperator(0, *table_, true, aggr_state_index, kNumPartitions));
 
     // Setup the InsertDestination proto in the query context proto.
     const QueryContext::insert_destination_id insert_destination_index =
@@ -382,11 +386,12 @@ class AggregationOperatorTest : public ::testing::Test {
     finalize_op_.reset(
         new FinalizeAggregationOperator(kQueryId,
                                         aggr_state_index,
+                                        kNumPartitions,
                                         *result_table_,
                                         insert_destination_index));
 
     destroy_aggr_state_op_.reset(
-        new DestroyAggregationStateOperator(kQueryId, aggr_state_index));
+        new DestroyAggregationStateOperator(kQueryId, aggr_state_index, kNumPartitions));
 
     // Set up the QueryContext.
     query_context_.reset(new QueryContext(query_context_proto,


### PR DESCRIPTION
This PR added the support for aggregations with partitioned input relations.

Note that in the distributed version, supports for parallel aggregations based on `COLLISION_FREE_VECTOR` will need some discussion on the implementations. For now, I have two ideas, one is to fix the number of internal partitions of aggregations in the optimizer, and the other is to add support for the batched work order, which means that although `ForemanDistributed` sends one work order proto, such work order proto would generate multiple work orders for the same operator. In this case, it is the number of internal partitions for the aggregations.