### PR TITLE
Added operator support for BuildLipFilter with partitioned inputs.

### DIFF
--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -663,6 +663,14 @@ void ExecutionGenerator::convertFilterJoin(const P::FilterJoinPtr &physical_plan
   const CatalogRelationInfo *build_relation_info =
       findRelationInfoOutputByPhysical(build_physical);
 
+  const CatalogRelation &build_relation = *build_relation_info->relation;
+  const PartitionScheme *build_partition_scheme = build_relation.getPartitionScheme();
+
+  const std::size_t build_num_partitions =
+      build_partition_scheme
+          ? build_partition_scheme->getPartitionSchemeHeader().getNumPartitions()
+          : 1u;
+
   // Create a BuildLIPFilterOperator for the FilterJoin. This operator builds
   // LIP filters that are applied properly in downstream operators to achieve
   // the filter-join semantics.
@@ -670,7 +678,8 @@ void ExecutionGenerator::convertFilterJoin(const P::FilterJoinPtr &physical_plan
       execution_plan_->addRelationalOperator(
           new BuildLIPFilterOperator(
               query_handle_->query_id(),
-              *build_relation_info->relation,
+              build_relation,
+              build_num_partitions,
               build_side_predicate_index,
               build_relation_info->isStoredRelation()));
 

--- a/relational_operators/BuildLIPFilterOperator.cpp
+++ b/relational_operators/BuildLIPFilterOperator.cpp
@@ -55,8 +55,12 @@ bool BuildLIPFilterOperator::getAllWorkOrders(
       query_context->getPredicate(build_side_predicate_index_);
 
   if (input_relation_is_stored_) {
-    if (!started_) {
-      for (const block_id input_block_id : input_relation_block_ids_) {
+    if (started_) {
+      return true;
+    }
+
+    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+      for (const block_id input_block_id : input_relation_block_ids_[part_id]) {
         container->addNormalWorkOrder(
             new BuildLIPFilterWorkOrder(
                 query_id_,
@@ -68,22 +72,24 @@ bool BuildLIPFilterOperator::getAllWorkOrders(
                 CreateLIPFilterBuilderHelper(lip_deployment_index_, query_context)),
             op_index_);
       }
-      started_ = true;
     }
+    started_ = true;
     return true;
   } else {
-    while (num_workorders_generated_ < input_relation_block_ids_.size()) {
-      container->addNormalWorkOrder(
-          new BuildLIPFilterWorkOrder(
-              query_id_,
-              input_relation_,
-              input_relation_block_ids_[num_workorders_generated_],
-              build_side_predicate,
-              storage_manager,
-              CreateLIPFilterAdaptiveProberHelper(lip_deployment_index_, query_context),
-              CreateLIPFilterBuilderHelper(lip_deployment_index_, query_context)),
-          op_index_);
-      ++num_workorders_generated_;
+    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+      while (num_workorders_generated_[part_id] < input_relation_block_ids_[part_id].size()) {
+        container->addNormalWorkOrder(
+            new BuildLIPFilterWorkOrder(
+                query_id_,
+                input_relation_,
+                input_relation_block_ids_[part_id][num_workorders_generated_[part_id]],
+                build_side_predicate,
+                storage_manager,
+                CreateLIPFilterAdaptiveProberHelper(lip_deployment_index_, query_context),
+                CreateLIPFilterBuilderHelper(lip_deployment_index_, query_context)),
+            op_index_);
+        ++num_workorders_generated_[part_id];
+      }
     }
     return done_feeding_input_relation_;
   }
@@ -91,30 +97,38 @@ bool BuildLIPFilterOperator::getAllWorkOrders(
 
 bool BuildLIPFilterOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *container) {
   if (input_relation_is_stored_) {
-    if (!started_) {
-      for (const block_id block : input_relation_block_ids_) {
-        container->addWorkOrderProto(createWorkOrderProto(block), op_index_);
-      }
-      started_ = true;
+    if (started_) {
+      return true;
     }
+
+    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+      for (const block_id block : input_relation_block_ids_[part_id]) {
+        container->addWorkOrderProto(createWorkOrderProto(part_id, block), op_index_);
+      }
+    }
+    started_ = true;
     return true;
   } else {
-    while (num_workorders_generated_ < input_relation_block_ids_.size()) {
-      container->addWorkOrderProto(
-          createWorkOrderProto(input_relation_block_ids_[num_workorders_generated_]),
-          op_index_);
-      ++num_workorders_generated_;
+    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+      while (num_workorders_generated_[part_id] < input_relation_block_ids_[part_id].size()) {
+        container->addWorkOrderProto(
+            createWorkOrderProto(part_id, input_relation_block_ids_[part_id][num_workorders_generated_[part_id]]),
+            op_index_);
+        ++num_workorders_generated_[part_id];
+      }
     }
     return done_feeding_input_relation_;
   }
 }
 
-serialization::WorkOrder* BuildLIPFilterOperator::createWorkOrderProto(const block_id block) {
+serialization::WorkOrder* BuildLIPFilterOperator::createWorkOrderProto(const partition_id part_id,
+                                                                       const block_id block) {
   serialization::WorkOrder *proto = new serialization::WorkOrder;
   proto->set_work_order_type(serialization::BUILD_LIP_FILTER);
   proto->set_query_id(query_id_);
 
   proto->SetExtension(serialization::BuildLIPFilterWorkOrder::relation_id, input_relation_.getID());
+  proto->SetExtension(serialization::BuildLIPFilterWorkOrder::partition_id, part_id);
   proto->SetExtension(serialization::BuildLIPFilterWorkOrder::build_block_id, block);
   proto->SetExtension(serialization::BuildLIPFilterWorkOrder::build_side_predicate_index,
                       build_side_predicate_index_);

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -150,6 +150,8 @@ target_link_libraries(quickstep_relationaloperators_BuildLIPFilterOperator
                       glog
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_PartitionScheme
+                      quickstep_catalog_PartitionSchemeHeader
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_WorkOrderProtosContainer
                       quickstep_queryexecution_WorkOrdersContainer

--- a/relational_operators/WorkOrder.proto
+++ b/relational_operators/WorkOrder.proto
@@ -92,10 +92,12 @@ message BuildHashWorkOrder {
   }
 }
 
+// Next tag: 54.
 message BuildLIPFilterWorkOrder {
   extend WorkOrder {
     // All required.
     optional int32 relation_id = 48;
+    optional uint64 partition_id = 53;
     optional fixed64 build_block_id = 49;
     optional int32 build_side_predicate_index = 50;
     optional int32 lip_deployment_index = 51;


### PR DESCRIPTION
This small PR allows `BuildLipFilter` to accept partitioned inputs. There will be follow-up PRs for the optimizer and execution support.