### PR TITLE
QUICKSTEP-95: Fixed the exception due to zero tuple estimation for th…

### DIFF
--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -907,6 +907,7 @@ target_link_libraries(quickstep_storage_SimpleScalarSeparateChainingHashTable
                       quickstep_utility_Macros
                       quickstep_utility_PrimeNumber)
 target_link_libraries(quickstep_storage_SplitRowStoreTupleStorageSubBlock
+                      glog
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_expressions_predicate_PredicateCost
                       quickstep_storage_SplitRowStoreValueAccessor

--- a/storage/SplitRowStoreTupleStorageSubBlock.cpp
+++ b/storage/SplitRowStoreTupleStorageSubBlock.cpp
@@ -37,6 +37,8 @@
 #include "utility/Macros.hpp"
 #include "utility/ScopedBuffer.hpp"
 
+#include "glog/logging.h"
+
 namespace quickstep {
 
 QUICKSTEP_REGISTER_TUPLE_STORE(SplitRowStoreTupleStorageSubBlock, SPLIT_ROW_STORE);
@@ -128,6 +130,13 @@ SplitRowStoreTupleStorageSubBlock::SplitRowStoreTupleStorageSubBlock(
   tuple_slot_bytes_ = per_tuple_null_bitmap_bytes_
                       + relation.getFixedByteLength()
                       + relation.numVariableLengthAttributes() * (sizeof(std::uint32_t) * 2);
+  if (tuple_slot_bytes_ == 0) {
+    LOG(WARNING)
+        << "Estimated zero bytes per tuple for relation \"" << relation.getName()
+        << "\" (relation_id: " << relation.getID()
+        << "). Adjusting to 1 byte.";
+    tuple_slot_bytes_ = 1;
+  }
 
   // Size the occupancy bitmap by calculating the maximum tuples that can fit
   // assuming the bare-minimum per tuple storage is used (no variable-length


### PR DESCRIPTION
…e empty project expression.

The problem is that [tuple_slot_bytes_](https://github.com/apache/incubator-quickstep/blob/master/storage/SplitRowStoreTupleStorageSubBlock.cpp#L128) is ZERO if the project expression is empty, and [later](https://github.com/apache/incubator-quickstep/blob/master/storage/SplitRowStoreTupleStorageSubBlock.cpp#L142) results in a divide-by-zero exception.

It is easy to reproduce:

```
$ create table r (a int, b char(20));
$ insert into r values(1, 'madison');
$ create table s (a int, c float);
$ select s.a from r, s where r.a > 0;
```

```
I0619 18:26:45.097215 1944100864 PhysicalGenerator.cpp:196] Optimized physical plan:
TopLevelPlan
+-plan=NestedLoopsJoin
| +-left=Selection
| | +-input=TableReference[relation=r]
| | | +-AttributeReference[id=0,name=a,relation=r,type=Int]
| | | +-AttributeReference[id=1,name=b,relation=r,type=Char(20)]
| | +-filter_predicate=Greater
| | | +-AttributeReference[id=0,name=a,relation=r,type=Int]
| | | +-Literal[value=0,type=Int]
| | +-project_expressions=
| |   +-[]
| +-right=TableReference[relation=s]
| | +-AttributeReference[id=2,name=a,relation=s,type=Int]
| | +-AttributeReference[id=3,name=c,relation=s,type=Float]
| +-join_predicate=Literal[value=true]
| +-project_expressions=
|   +-AttributeReference[id=2,name=a,relation=s,type=Int]
+-output_attributes=
  +-AttributeReference[id=2,name=a,relation=s,type=Int]
```

Floating point exception: 8