### PR TITLE
Determine #Partitions for Aggr State Hash Table in the optimizer.

### DIFF
--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
                       quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_PartitionScheme
                       quickstep_catalog_PartitionSchemeHeader
+                      quickstep_cli_Flags
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_aggregation_AggregateFunction
                       quickstep_expressions_aggregation_AggregateFunction_proto

--- a/relational_operators/FinalizeAggregationOperator.cpp
+++ b/relational_operators/FinalizeAggregationOperator.cpp
@@ -50,7 +50,7 @@ bool FinalizeAggregationOperator::getAllWorkOrders(
           query_context->getAggregationState(aggr_state_index_, part_id);
       DCHECK(agg_state != nullptr);
       for (std::size_t state_part_id = 0;
-           state_part_id < agg_state->getNumFinalizationPartitions();
+           state_part_id < aggr_state_num_partitions_;
            ++state_part_id) {
         container->addNormalWorkOrder(
             new FinalizeAggregationWorkOrder(

--- a/relational_operators/FinalizeAggregationOperator.hpp
+++ b/relational_operators/FinalizeAggregationOperator.hpp
@@ -69,11 +69,13 @@ class FinalizeAggregationOperator : public RelationalOperator {
       const std::size_t query_id,
       const QueryContext::aggregation_state_id aggr_state_index,
       const std::size_t num_partitions,
+      const std::size_t aggr_state_num_partitions,
       const CatalogRelation &output_relation,
       const QueryContext::insert_destination_id output_destination_index)
       : RelationalOperator(query_id),
         aggr_state_index_(aggr_state_index),
         num_partitions_(num_partitions),
+        aggr_state_num_partitions_(aggr_state_num_partitions),
         output_relation_(output_relation),
         output_destination_index_(output_destination_index),
         started_(false) {}
@@ -106,7 +108,7 @@ class FinalizeAggregationOperator : public RelationalOperator {
 
  private:
   const QueryContext::aggregation_state_id aggr_state_index_;
-  const std::size_t num_partitions_;
+  const std::size_t num_partitions_, aggr_state_num_partitions_;
   const CatalogRelation &output_relation_;
   const QueryContext::insert_destination_id output_destination_index_;
   bool started_;

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -293,6 +293,7 @@ class AggregationOperatorTest : public ::testing::Test {
         new FinalizeAggregationOperator(kQueryId,
                                         aggr_state_index,
                                         kNumPartitions,
+                                        kNumPartitions,
                                         *result_table_,
                                         insert_destination_index));
 
@@ -386,6 +387,7 @@ class AggregationOperatorTest : public ::testing::Test {
     finalize_op_.reset(
         new FinalizeAggregationOperator(kQueryId,
                                         aggr_state_index,
+                                        kNumPartitions,
                                         kNumPartitions,
                                         *result_table_,
                                         insert_destination_index));

--- a/storage/AggregationOperationState.proto
+++ b/storage/AggregationOperationState.proto
@@ -42,4 +42,7 @@ message AggregationOperationState {
 
   // Each DISTINCT aggregation has its distinctify hash table impl type.
   repeated HashTableImplType distinctify_hash_table_impl_types = 7;
+
+  optional bool is_partitioned = 8;
+  optional uint64 num_partitions = 9 [default = 1];
 }

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -267,7 +267,6 @@ add_library(quickstep_storage_WindowAggregationOperationState_proto ${storage_Wi
 
 # Link dependencies:
 target_link_libraries(quickstep_storage_AggregationOperationState
-                      ${GFLAGS_LIB_NAME}
                       glog
                       quickstep_catalog_CatalogDatabaseLite
                       quickstep_catalog_CatalogRelationSchema

--- a/storage/CollisionFreeVectorTable.cpp
+++ b/storage/CollisionFreeVectorTable.cpp
@@ -43,15 +43,17 @@ namespace quickstep {
 CollisionFreeVectorTable::CollisionFreeVectorTable(
     const Type *key_type,
     const std::size_t num_entries,
+    const std::size_t num_finalize_partitions,
     const std::vector<AggregationHandle *> &handles,
     StorageManager *storage_manager)
     : key_type_(key_type),
       num_entries_(num_entries),
       num_handles_(handles.size()),
       handles_(handles),
-      num_finalize_partitions_(CalculateNumFinalizationPartitions(num_entries_)),
+      num_finalize_partitions_(num_finalize_partitions),
       storage_manager_(storage_manager) {
   DCHECK_GT(num_entries, 0u);
+  DCHECK_GT(num_finalize_partitions_, 0u);
 
   std::size_t required_memory = 0;
   const std::size_t existence_map_offset = 0;

--- a/storage/CollisionFreeVectorTable.hpp
+++ b/storage/CollisionFreeVectorTable.hpp
@@ -58,6 +58,8 @@ class CollisionFreeVectorTable : public AggregationStateHashTableBase {
    *
    * @param key_type The group-by key type.
    * @param num_entries The estimated number of entries this table will hold.
+   * @param num_finalize_partitions The number of partitions to be used for
+   *        finalizing the aggregation.
    * @param handles The aggregation handles.
    * @param storage_manager The StorageManager to use (a StorageBlob will be
    *        allocated to hold this table's contents).
@@ -65,6 +67,7 @@ class CollisionFreeVectorTable : public AggregationStateHashTableBase {
   CollisionFreeVectorTable(
       const Type *key_type,
       const std::size_t num_entries,
+      const std::size_t num_finalize_partitions,
       const std::vector<AggregationHandle *> &handles,
       StorageManager *storage_manager);
 
@@ -191,17 +194,6 @@ class CollisionFreeVectorTable : public AggregationStateHashTableBase {
     // TODO(jianqiao): set the upbound as (# of workers * 2) instead of the
     // hardcoded 80.
     return std::max(1uL, std::min(memory_size / kInitBlockSize, 80uL));
-  }
-
-  inline static std::size_t CalculateNumFinalizationPartitions(
-      const std::size_t num_entries) {
-    // Set finalization segment size as 4096 entries.
-    constexpr std::size_t kFinalizeSegmentSize = 4uL * 1024L;
-
-    // At least 1 partition, at most 80 partitions.
-    // TODO(jianqiao): set the upbound as (# of workers * 2) instead of the
-    // hardcoded 80.
-    return std::max(1uL, std::min(num_entries / kFinalizeSegmentSize, 80uL));
   }
 
   inline std::size_t calculatePartitionLength() const {

--- a/storage/HashTableFactory.hpp
+++ b/storage/HashTableFactory.hpp
@@ -356,6 +356,8 @@ class AggregationStateHashTableFactory {
    * @param storage_manager The StorageManager to use (a StorageBlob will be
    *        allocated to hold the hash table's contents). Forwarded as-is to the
    *        hash table constructor.
+   * @param num_partitions The number of partitions of this aggregation state
+   *        hash table.
    * @return A new aggregation state hash table.
    **/
   static AggregationStateHashTableBase* CreateResizable(
@@ -363,12 +365,13 @@ class AggregationStateHashTableFactory {
       const std::vector<const Type*> &key_types,
       const std::size_t num_entries,
       const std::vector<AggregationHandle *> &handles,
-      StorageManager *storage_manager) {
+      StorageManager *storage_manager,
+      const std::size_t num_partitions = 1u) {
     switch (hash_table_type) {
       case HashTableImplType::kCollisionFreeVector:
         DCHECK_EQ(1u, key_types.size());
         return new CollisionFreeVectorTable(
-            key_types.front(), num_entries, handles, storage_manager);
+            key_types.front(), num_entries, num_partitions, handles, storage_manager);
       case HashTableImplType::kSeparateChaining:
         return new PackedPayloadHashTable(
             key_types, num_entries, handles, storage_manager);


### PR DESCRIPTION
This PR allows the optimizer to determine the number of partitions for an aggregation state hash table, instead of getting it during the run-time from the aggregation state.

Assigned to @jianqiao.