### PR TITLE
Allowed pipelined work order scheduling.

### DIFF
--- a/query_execution/QueryManagerBase.cpp
+++ b/query_execution/QueryManagerBase.cpp
@@ -20,6 +20,7 @@
 #include "query_execution/QueryManagerBase.hpp"
 
 #include <memory>
+#include <queue>
 #include <utility>
 #include <vector>
 
@@ -205,6 +206,8 @@ void QueryManagerBase::processDataPipelineMessage(const dag_node_index op_index,
                                                   const block_id block,
                                                   const relation_id rel_id,
                                                   const partition_id part_id) {
+  data_pipeline_op_indexes_.push(op_index);
+
   for (const dag_node_index consumer_index :
        output_consumers_[op_index]) {
     // Feed the streamed block to the consumer. Note that 'output_consumers_'

--- a/query_execution/QueryManagerBase.hpp
+++ b/query_execution/QueryManagerBase.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <queue>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -296,6 +297,8 @@ class QueryManagerBase {
   std::unique_ptr<QueryExecutionState> query_exec_state_;
 
   std::unique_ptr<ExecutionDAGVisualizer> dag_visualizer_;
+
+  std::queue<dag_node_index> data_pipeline_op_indexes_;
 
  private:
   /**


### PR DESCRIPTION
This PR enabled pipelined work order scheduling, and thus improves the query execution time, particularly for a complex query with a deep execution plan. In other words, once a data pipelining message is received, the work order could be scheduled immediately.

Assigned to @jianqiao.