### PR TITLE
Removed an unnecessary API in RelationalOperator.

### DIFF
--- a/query_execution/QueryManagerDistributed.cpp
+++ b/query_execution/QueryManagerDistributed.cpp
@@ -70,7 +70,6 @@ QueryManagerDistributed::QueryManagerDistributed(QueryHandle *query_handle,
   // Collect all the workorders from all the relational operators in the DAG.
   for (dag_node_index index = 0; index < num_operators_in_dag_; ++index) {
     if (checkAllBlockingDependenciesMet(index)) {
-      query_dag_->getNodePayloadMutable(index)->informAllBlockingDependenciesMet();
       processOperator(index, false);
     }
   }

--- a/query_execution/QueryManagerSingleNode.cpp
+++ b/query_execution/QueryManagerSingleNode.cpp
@@ -64,7 +64,6 @@ QueryManagerSingleNode::QueryManagerSingleNode(
   // Collect all the workorders from all the relational operators in the DAG.
   for (dag_node_index index = 0; index < num_operators_in_dag_; ++index) {
     if (checkAllBlockingDependenciesMet(index)) {
-      query_dag_->getNodePayloadMutable(index)->informAllBlockingDependenciesMet();
       processOperator(index, false);
     }
   }

--- a/relational_operators/DeleteOperator.cpp
+++ b/relational_operators/DeleteOperator.cpp
@@ -54,22 +54,24 @@ bool DeleteOperator::getAllWorkOrders(
 
   if (relation_is_stored_) {
     // If relation_ is stored, iterate over the list of blocks in relation_.
-    if (!started_) {
-      for (const block_id input_block_id : relation_block_ids_) {
-        container->addNormalWorkOrder(
-            new DeleteWorkOrder(query_id_,
-                                relation_,
-                                input_block_id,
-                                predicate,
-                                storage_manager,
-                                op_index_,
-                                scheduler_client_id,
-                                bus),
-            op_index_);
-      }
-      started_ = true;
+    if (started_) {
+      return true;
     }
-    return started_;
+
+    for (const block_id input_block_id : relation_block_ids_) {
+      container->addNormalWorkOrder(
+          new DeleteWorkOrder(query_id_,
+                              relation_,
+                              input_block_id,
+                              predicate,
+                              storage_manager,
+                              op_index_,
+                              scheduler_client_id,
+                              bus),
+          op_index_);
+    }
+    started_ = true;
+    return true;
   } else {
     while (num_workorders_generated_ < relation_block_ids_.size()) {
       container->addNormalWorkOrder(
@@ -91,12 +93,14 @@ bool DeleteOperator::getAllWorkOrders(
 bool DeleteOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *container) {
   if (relation_is_stored_) {
     // If relation_ is stored, iterate over the list of blocks in relation_.
-    if (!started_) {
-      for (const block_id input_block_id : relation_block_ids_) {
-        container->addWorkOrderProto(createWorkOrderProto(input_block_id), op_index_);
-      }
-      started_ = true;
+    if (started_) {
+      return true;
     }
+
+    for (const block_id input_block_id : relation_block_ids_) {
+      container->addWorkOrderProto(createWorkOrderProto(input_block_id), op_index_);
+    }
+    started_ = true;
     return true;
   } else {
     while (num_workorders_generated_ < relation_block_ids_.size()) {

--- a/relational_operators/DestroyHashOperator.cpp
+++ b/relational_operators/DestroyHashOperator.cpp
@@ -34,32 +34,36 @@ bool DestroyHashOperator::getAllWorkOrders(
     StorageManager *storage_manager,
     const tmb::client_id scheduler_client_id,
     tmb::MessageBus *bus) {
-  if (blocking_dependencies_met_ && !work_generated_) {
-    for (std::size_t part_id = 0; part_id < build_num_partitions_; ++part_id) {
-      container->addNormalWorkOrder(
-          new DestroyHashWorkOrder(query_id_, hash_table_index_, part_id, query_context),
-          op_index_);
-    }
-    work_generated_ = true;
+  if (work_generated_) {
+    return true;
   }
-  return work_generated_;
+
+  for (std::size_t part_id = 0; part_id < build_num_partitions_; ++part_id) {
+    container->addNormalWorkOrder(
+        new DestroyHashWorkOrder(query_id_, hash_table_index_, part_id, query_context),
+        op_index_);
+  }
+  work_generated_ = true;
+  return true;
 }
 
 bool DestroyHashOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *container) {
-  if (blocking_dependencies_met_ && !work_generated_) {
-    for (std::size_t part_id = 0; part_id < build_num_partitions_; ++part_id) {
-      serialization::WorkOrder *proto = new serialization::WorkOrder;
-      proto->set_work_order_type(serialization::DESTROY_HASH);
-      proto->set_query_id(query_id_);
-      proto->SetExtension(serialization::DestroyHashWorkOrder::join_hash_table_index, hash_table_index_);
-      proto->SetExtension(serialization::DestroyHashWorkOrder::partition_id, part_id);
-
-      container->addWorkOrderProto(proto, op_index_);
-    }
-
-    work_generated_ = true;
+  if (work_generated_) {
+    return true;
   }
-  return work_generated_;
+
+  for (std::size_t part_id = 0; part_id < build_num_partitions_; ++part_id) {
+    serialization::WorkOrder *proto = new serialization::WorkOrder;
+    proto->set_work_order_type(serialization::DESTROY_HASH);
+    proto->set_query_id(query_id_);
+    proto->SetExtension(serialization::DestroyHashWorkOrder::join_hash_table_index, hash_table_index_);
+    proto->SetExtension(serialization::DestroyHashWorkOrder::partition_id, part_id);
+
+    container->addWorkOrderProto(proto, op_index_);
+  }
+
+  work_generated_ = true;
+  return true;
 }
 
 

--- a/relational_operators/InitializeAggregationOperator.cpp
+++ b/relational_operators/InitializeAggregationOperator.cpp
@@ -39,24 +39,27 @@ bool InitializeAggregationOperator::getAllWorkOrders(
     StorageManager *storage_manager,
     const tmb::client_id scheduler_client_id,
     tmb::MessageBus *bus) {
-  if (!started_) {
-    for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
-      AggregationOperationState *agg_state =
-          query_context->getAggregationState(aggr_state_index_, part_id);
-      DCHECK(agg_state != nullptr);
-
-      for (std::size_t state_part_id = 0;
-           state_part_id < aggr_state_num_init_partitions_;
-           ++state_part_id) {
-        container->addNormalWorkOrder(
-            new InitializeAggregationWorkOrder(query_id_,
-                                               state_part_id,
-                                               agg_state),
-            op_index_);
-      }
-    }
-    started_ = true;
+  if (started_) {
+    return true;
   }
+
+  for (partition_id part_id = 0; part_id < num_partitions_; ++part_id) {
+    AggregationOperationState *agg_state =
+        query_context->getAggregationState(aggr_state_index_, part_id);
+    DCHECK(agg_state != nullptr);
+
+    for (std::size_t state_part_id = 0;
+         state_part_id < aggr_state_num_init_partitions_;
+         ++state_part_id) {
+      container->addNormalWorkOrder(
+          new InitializeAggregationWorkOrder(query_id_,
+                                             state_part_id,
+                                             agg_state),
+          op_index_);
+    }
+  }
+
+  started_ = true;
   return true;
 }
 

--- a/relational_operators/InsertOperator.cpp
+++ b/relational_operators/InsertOperator.cpp
@@ -39,34 +39,37 @@ bool InsertOperator::getAllWorkOrders(
     StorageManager *storage_manager,
     const tmb::client_id scheduler_client_id,
     tmb::MessageBus *bus) {
-  if (blocking_dependencies_met_ && !work_generated_) {
-    DCHECK(query_context != nullptr);
-
-    work_generated_ = true;
-    container->addNormalWorkOrder(
-        new InsertWorkOrder(
-            query_id_,
-            query_context->getInsertDestination(output_destination_index_),
-            query_context->releaseTuple(tuple_index_)),
-        op_index_);
+  if (work_generated_) {
+    return true;
   }
-  return work_generated_;
+
+  DCHECK(query_context != nullptr);
+  container->addNormalWorkOrder(
+      new InsertWorkOrder(
+          query_id_,
+          query_context->getInsertDestination(output_destination_index_),
+          query_context->releaseTuple(tuple_index_)),
+      op_index_);
+
+  work_generated_ = true;
+  return true;
 }
 
 bool InsertOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *container) {
-  if (blocking_dependencies_met_ && !work_generated_) {
-    work_generated_ = true;
-
-    serialization::WorkOrder *proto = new serialization::WorkOrder;
-    proto->set_work_order_type(serialization::INSERT);
-    proto->set_query_id(query_id_);
-    proto->SetExtension(serialization::InsertWorkOrder::insert_destination_index, output_destination_index_);
-    proto->SetExtension(serialization::InsertWorkOrder::tuple_index, tuple_index_);
-
-    container->addWorkOrderProto(proto, op_index_);
+  if (work_generated_) {
+    return true;
   }
 
-  return work_generated_;
+  serialization::WorkOrder *proto = new serialization::WorkOrder;
+  proto->set_work_order_type(serialization::INSERT);
+  proto->set_query_id(query_id_);
+  proto->SetExtension(serialization::InsertWorkOrder::insert_destination_index, output_destination_index_);
+  proto->SetExtension(serialization::InsertWorkOrder::tuple_index, tuple_index_);
+
+  container->addWorkOrderProto(proto, op_index_);
+
+  work_generated_ = true;
+  return true;
 }
 
 

--- a/relational_operators/RelationalOperator.hpp
+++ b/relational_operators/RelationalOperator.hpp
@@ -163,19 +163,6 @@ class RelationalOperator {
   }
 
   /**
-   * @brief Inform this RelationalOperator that ALL the dependencies which break
-   *        the pipeline have been met.
-   *
-   * @note This function is only relevant in certain operators like HashJoin
-   *       which have a pipeline breaking dependency on BuildHash operator.
-   *       Such operators can start generating WorkOrders when all the pipeline
-   *       breaking dependencies are met.
-   **/
-  inline void informAllBlockingDependenciesMet() {
-    blocking_dependencies_met_ = true;
-  }
-
-  /**
    * @brief Receive input blocks for this RelationalOperator.
    *
    * @param input_block_id The ID of the input block.
@@ -289,16 +276,13 @@ class RelationalOperator {
    * @param blocking_dependencies_met If those dependencies which break the
    *        pipeline have been met.
    **/
-  explicit RelationalOperator(const std::size_t query_id,
-                              const bool blocking_dependencies_met = false)
+  explicit RelationalOperator(const std::size_t query_id)
       : query_id_(query_id),
-        blocking_dependencies_met_(blocking_dependencies_met),
         done_feeding_input_relation_(false),
         lip_deployment_index_(QueryContext::kInvalidLIPDeploymentId) {}
 
   const std::size_t query_id_;
 
-  bool blocking_dependencies_met_;
   bool done_feeding_input_relation_;
   std::size_t op_index_;
 

--- a/relational_operators/TableGeneratorOperator.cpp
+++ b/relational_operators/TableGeneratorOperator.cpp
@@ -39,35 +39,39 @@ bool TableGeneratorOperator::getAllWorkOrders(
     StorageManager *storage_manager,
     const tmb::client_id scheduler_client_id,
     tmb::MessageBus *bus) {
-  if (!started_) {
-    DCHECK(query_context != nullptr);
-
-    // Currently the generator function is not abstracted to be parallelizable,
-    // so just produce one work order.
-    container->addNormalWorkOrder(
-        new TableGeneratorWorkOrder(
-            query_id_,
-            query_context->getGeneratorFunctionHandle(
-                generator_function_index_),
-            query_context->getInsertDestination(output_destination_index_)),
-        op_index_);
-    started_ = true;
+  if (started_) {
+    return true;
   }
-  return started_;
+
+  DCHECK(query_context != nullptr);
+
+  // Currently the generator function is not abstracted to be parallelizable,
+  // so just produce one work order.
+  container->addNormalWorkOrder(
+      new TableGeneratorWorkOrder(
+          query_id_,
+          query_context->getGeneratorFunctionHandle(
+              generator_function_index_),
+          query_context->getInsertDestination(output_destination_index_)),
+      op_index_);
+  started_ = true;
+  return true;
 }
 
 bool TableGeneratorOperator::getAllWorkOrderProtos(WorkOrderProtosContainer *container) {
-  if (!started_) {
-    serialization::WorkOrder *proto = new serialization::WorkOrder;
-    proto->set_work_order_type(serialization::TABLE_GENERATOR);
-    proto->set_query_id(query_id_);
-
-    proto->SetExtension(serialization::TableGeneratorWorkOrder::generator_function_index, generator_function_index_);
-    proto->SetExtension(serialization::TableGeneratorWorkOrder::insert_destination_index, output_destination_index_);
-
-    container->addWorkOrderProto(proto, op_index_);
-    started_ = true;
+  if (started_) {
+    return true;
   }
+
+  serialization::WorkOrder *proto = new serialization::WorkOrder;
+  proto->set_work_order_type(serialization::TABLE_GENERATOR);
+  proto->set_query_id(query_id_);
+
+  proto->SetExtension(serialization::TableGeneratorWorkOrder::generator_function_index, generator_function_index_);
+  proto->SetExtension(serialization::TableGeneratorWorkOrder::insert_destination_index, output_destination_index_);
+
+  container->addWorkOrderProto(proto, op_index_);
+  started_ = true;
   return true;
 }
 

--- a/relational_operators/tests/AggregationOperator_unittest.cpp
+++ b/relational_operators/tests/AggregationOperator_unittest.cpp
@@ -425,8 +425,6 @@ class AggregationOperatorTest : public ::testing::Test {
       delete work_order;
     }
 
-    finalize_op_->informAllBlockingDependenciesMet();
-
     WorkOrdersContainer finalize_op_container(1, 0);
     const std::size_t finalize_op_index = 0;
     finalize_op_->getAllWorkOrders(&finalize_op_container,
@@ -440,8 +438,6 @@ class AggregationOperatorTest : public ::testing::Test {
       work_order->execute();
       delete work_order;
     }
-
-    destroy_aggr_state_op_->informAllBlockingDependenciesMet();
 
     WorkOrdersContainer destroy_aggr_state_op_container(1, 0);
     const std::size_t destroy_aggr_state_op_index = 0;

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -469,8 +469,6 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -512,7 +510,6 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
 
   // Create cleaner operator.
   unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(kQueryId, kSinglePartition, join_hash_table_index));
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -623,8 +620,6 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -687,7 +682,6 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
 
   // Create cleaner operator.
   unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(kQueryId, kSinglePartition, join_hash_table_index));
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -784,8 +778,6 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -827,7 +819,6 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
 
   // Create cleaner operator.
   unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(kQueryId, kSinglePartition, join_hash_table_index));
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -931,8 +922,6 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -999,7 +988,6 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
 
   // Create the cleaner operator.
   unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(kQueryId, kSinglePartition, join_hash_table_index));
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -1112,8 +1100,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -1180,7 +1166,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
 
   // Create cleaner operator.
   unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(kQueryId, kSinglePartition, join_hash_table_index));
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -1304,8 +1289,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -1372,7 +1355,6 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
 
   // Create cleaner operator.
   unique_ptr<DestroyHashOperator> cleaner(new DestroyHashOperator(kQueryId, kSinglePartition, join_hash_table_index));
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -1476,8 +1458,6 @@ TEST_P(HashJoinOperatorTest, SinlgeAttributePartitionedLongKeyHashJoinTest) {
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -1519,7 +1499,6 @@ TEST_P(HashJoinOperatorTest, SinlgeAttributePartitionedLongKeyHashJoinTest) {
 
   // Create cleaner operator.
   auto cleaner = make_unique<DestroyHashOperator>(kQueryId, kMultiplePartitions, join_hash_table_index);
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -1624,8 +1603,6 @@ TEST_P(HashJoinOperatorTest, SinlgeAttributePartitionedCompositeKeyHashJoinTest)
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -1692,7 +1669,6 @@ TEST_P(HashJoinOperatorTest, SinlgeAttributePartitionedCompositeKeyHashJoinTest)
 
   // Create cleaner operator.
   auto cleaner = make_unique<DestroyHashOperator>(kQueryId, kMultiplePartitions, join_hash_table_index);
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);
@@ -1807,8 +1783,6 @@ TEST_P(HashJoinOperatorTest, SinlgeAttributePartitionedCompositeKeyHashJoinWithR
 
   // Execute the operators.
   fetchAndExecuteWorkOrders(builder.get());
-
-  prober->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(prober.get());
 
   // Check result values
@@ -1875,7 +1849,6 @@ TEST_P(HashJoinOperatorTest, SinlgeAttributePartitionedCompositeKeyHashJoinWithR
 
   // Create cleaner operator.
   auto cleaner = make_unique<DestroyHashOperator>(kQueryId, kMultiplePartitions, join_hash_table_index);
-  cleaner->informAllBlockingDependenciesMet();
   fetchAndExecuteWorkOrders(cleaner.get());
 
   db_->dropRelationById(output_relation_id);

--- a/relational_operators/tests/TextScanOperator_unittest.cpp
+++ b/relational_operators/tests/TextScanOperator_unittest.cpp
@@ -110,7 +110,6 @@ class TextScanOperatorTest : public ::testing::Test {
     op->setOperatorIndex(kOpIndex);
     WorkOrdersContainer container(1, 0);
     const std::size_t op_index = 0;
-    op->informAllBlockingDependenciesMet();
     op->getAllWorkOrders(&container,
                          query_context_.get(),
                          storage_manager_.get(),


### PR DESCRIPTION
This PR removed `informAllBlockingDependenciesMet`, as it is redundant with regards to `checkAllBlockingDependenciesMet` in the query execution engine. Note that the current implementation of `Foreman` ensure that `getAllWorkOrders` will not be called unless the dependencies are met.

Assigned to @jianqiao.