### PR TITLE
Redirect stdout and stderr in network mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,6 +751,7 @@ target_link_libraries(quickstep_cli_shell
                       quickstep_utility_ExecutionDAGVisualizer
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
+                      quickstep_utility_ScopedReassignment
                       quickstep_utility_SqlError
                       quickstep_utility_StringUtil)
 if (ENABLE_HDFS)

--- a/cli/Flags.cpp
+++ b/cli/Flags.cpp
@@ -36,6 +36,9 @@ DEFINE_bool(print_query, false,
             "Print each input query statement. This is useful when running a "
             "large number of queries in a batch.");
 
+DEFINE_bool(display_timing, true,
+            "Whether to display execution time of each statement.");
+
 DEFINE_bool(initialize_db, false, "If true, initialize a database.");
 
 static bool ValidateNumWorkers(const char *flagname, int value) {

--- a/cli/Flags.hpp
+++ b/cli/Flags.hpp
@@ -45,6 +45,8 @@ DECLARE_string(storage_path);
 
 DECLARE_bool(preload_buffer_pool);
 
+DECLARE_bool(display_timing);
+
 /** @} */
 
 }  // namespace quickstep

--- a/cli/IOInterface.hpp
+++ b/cli/IOInterface.hpp
@@ -28,7 +28,7 @@
 namespace quickstep {
 
 /**
- * An individual IO interaction with Quickstep.
+ * @brief An individual IO interaction with Quickstep.
  */
 class IOHandle {
  public:
@@ -56,18 +56,21 @@ class IOHandle {
 };
 
 /**
- * Virtual base defines a generic, file-based interface around IO. One IO interaction (eg a SQL query) will be assigned
- * an IOHandle. On destruction of the IOHandle, the IO interaction has finished.
+ * @brief Virtual base defines a generic, file-based interface around IO.
+ *        One IO interaction (eg a SQL query) will be assigned an IOHandle.
+ *        On destruction of the IOHandle, the IO interaction has finished.
  */
 class IOInterface {
  public:
   /**
-   * @note Destructing the IOInterface should close any outstanding IO state (eg an open port).
+   * @note Destructing the IOInterface should close any outstanding IO state
+   *       (e.g. an open port).
    */
   virtual ~IOInterface() {}
 
   /**
    * @brief Retrieves the next IOHandle. Blocks if no IO ready.
+   *
    * @return An IOHandle.
    */
   virtual IOHandle* getNextIOHandle() = 0;

--- a/cli/NetworkCliClientMain.cpp
+++ b/cli/NetworkCliClientMain.cpp
@@ -53,7 +53,6 @@ int main(int argc, char **argv) {
   while (!linereader.bufferEmpty()) {
     std::string query = linereader.getNextCommand();
     if (!query.empty()) {
-      std::cout << query << std::endl;
       std::cout << qs_client.Query(query) << std::endl;
     }
   }

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
@@ -63,7 +63,9 @@ void ExecutionGeneratorTestRunner::runTestCase(
   sql_parser_.feedNextBuffer(new std::string(input));
 
   // Redirect stderr to output_stream.
-  stderr = output_stream.file();
+  if (!FLAGS_logtostderr) {
+    stderr = output_stream.file();
+  }
 
   while (true) {
     ParseResult result = sql_parser_.getNextStatement();

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -196,6 +196,7 @@ add_library(quickstep_utility_PtrMap ../empty_src.cpp PtrMap.hpp)
 add_library(quickstep_utility_PtrVector ../empty_src.cpp PtrVector.hpp)
 add_library(quickstep_utility_ScopedBuffer ../empty_src.cpp ScopedBuffer.hpp)
 add_library(quickstep_utility_ScopedDeleter ../empty_src.cpp ScopedDeleter.hpp)
+add_library(quickstep_utility_ScopedReassignment ../empty_src.cpp ScopedReassignment.hpp)
 add_library(quickstep_utility_ShardedLockManager ../empty_src.cpp ShardedLockManager.hpp)
 add_library(quickstep_utility_SortConfiguration SortConfiguration.cpp SortConfiguration.hpp)
 add_library(quickstep_utility_SortConfiguration_proto
@@ -313,6 +314,8 @@ target_link_libraries(quickstep_utility_ScopedBuffer
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_ScopedDeleter
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_utility_ScopedReassignment
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_SqlError
                       glog)
 target_link_libraries(quickstep_utility_SortConfiguration
@@ -379,6 +382,7 @@ target_link_libraries(quickstep_utility
                       quickstep_utility_PtrVector
                       quickstep_utility_ScopedBuffer
                       quickstep_utility_ScopedDeleter
+                      quickstep_utility_ScopedReassignment
                       quickstep_utility_ShardedLockManager
                       quickstep_utility_SortConfiguration
                       quickstep_utility_SortConfiguration_proto
@@ -461,6 +465,15 @@ target_link_libraries(ScopedDeleter_unittest
                       quickstep_utility_ScopedDeleter
                       ${LIBS})
 add_test(ScopedDeleter_unittest ScopedDeleter_unittest)
+
+add_executable(ScopedReassignment_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/ScopedReassignment_unittest.cpp")
+target_link_libraries(ScopedReassignment_unittest
+                      gtest
+                      gtest_main
+                      quickstep_utility_Macros
+                      quickstep_utility_ScopedReassignment
+                      ${LIBS})
+add_test(ScopedReassignment_unittest ScopedReassignment_unittest)
 
 add_executable(SqlError_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/SqlError_unittest.cpp")
 target_link_libraries(SqlError_unittest

--- a/utility/ScopedReassignment.hpp
+++ b/utility/ScopedReassignment.hpp
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_UTILITY_SCOPED_REASSIGNMENT_HPP_
+#define QUICKSTEP_UTILITY_SCOPED_REASSIGNMENT_HPP_
+
+#include <utility>
+#include <type_traits>
+
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+/** \addtogroup Utility
+ *  @{
+ */
+
+/**
+ * @brief RAII helper object that assigns a new value to a variable and restores
+ *        the old value when the helper object goes out of scope.
+ **/
+template <typename T>
+class ScopedReassignment {
+ public:
+  /**
+   * @brief Constructor.
+   *
+   * @param var The variable.
+   * @param new_value The new value to be assigned to \p var.
+   **/
+  template <typename U>
+  ScopedReassignment(T *var, U &&new_value)
+      : var_(*var),
+        old_value_(std::move(*var)) {
+    *var = std::forward<U>(new_value);
+  }
+
+  /**
+   * @brief Destructor. Restores the old value to \p var_.
+   **/
+  ~ScopedReassignment() {
+    var_ = std::move(old_value_);
+  }
+
+  /**
+   * @brief Get the old value.
+   *
+   * @return A const reference to the old value.
+   */
+  inline const T& old_value() const {
+    return old_value_;
+  }
+
+ private:
+  T &var_;
+  T old_value_;
+
+  DISALLOW_COPY_AND_ASSIGN(ScopedReassignment);
+};
+
+/** @} */
+
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_UTILITY_SCOPED_REASSIGNMENT_HPP_

--- a/utility/tests/ScopedReassignment_unittest.cpp
+++ b/utility/tests/ScopedReassignment_unittest.cpp
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "utility/ScopedReassignment.hpp"
+
+#include "utility/Macros.hpp"
+
+#include "gtest/gtest.h"
+
+namespace quickstep {
+
+namespace {
+const int kOldValue = 10;
+const int kNewValue = 20;
+}  // namespace
+
+/**
+ * @brief A test class that is movable but not copyable.
+ */
+class NonCopyable {
+ public:
+  explicit NonCopyable(const int value)
+      : value_(value) {}
+
+  explicit NonCopyable(NonCopyable &&other)
+      : value_(other.value_) {}
+
+  NonCopyable& operator=(NonCopyable &&other) {
+    value_ = other.value_;
+    return *this;
+  }
+
+  int value() const {
+    return value_;
+  }
+
+ private:
+  int value_;
+
+  DISALLOW_COPY_AND_ASSIGN(NonCopyable);
+};
+
+/**
+ * @brief A test class that is copyable but not movable.
+ */
+class NonMovable {
+ public:
+  explicit NonMovable(const int value)
+      : value_(value) {}
+
+  explicit NonMovable(const NonMovable &other)
+      : value_(other.value_) {}
+
+  NonMovable& operator=(const NonMovable &other) {
+    value_ = other.value_;
+    return *this;
+  }
+
+  int value() const {
+    return value_;
+  }
+
+ private:
+  int value_;
+};
+
+/**
+ * @brief A test class that is copyable and movable.
+ */
+class CopyableMovable {
+ public:
+  explicit CopyableMovable(const int value)
+      : value_(value) {}
+
+  explicit CopyableMovable(const CopyableMovable &other)
+      : copy_constructed_(true),
+        value_(other.value_) {}
+
+  explicit CopyableMovable(CopyableMovable &&other)
+      : value_(other.value_) {}
+
+  CopyableMovable& operator=(const CopyableMovable &other) {
+    value_ = other.value_;
+    copy_assigned_ = true;
+    return *this;
+  }
+
+  CopyableMovable& operator=(CopyableMovable &&other) {
+    value_ = other.value_;
+    copy_assigned_ = false;
+    return *this;
+  }
+
+  int value() const {
+    return value_;
+  }
+
+  bool copy_constructed() const {
+    return copy_constructed_;
+  }
+
+  bool copy_assigned() const {
+    return copy_assigned_;
+  }
+
+ private:
+  const bool copy_constructed_ = false;
+  int value_;
+  bool copy_assigned_ = false;
+};
+
+TEST(ScopedReassignment, NonCopyableTest) {
+  NonCopyable non_copyable(kOldValue);
+  {
+    NonCopyable other(kNewValue);
+    ScopedReassignment<NonCopyable> reassign(&non_copyable, std::move(other));
+    EXPECT_EQ(kNewValue, non_copyable.value());
+  }
+  EXPECT_EQ(kOldValue, non_copyable.value());
+
+  {
+    ScopedReassignment<NonCopyable> reassign(&non_copyable, NonCopyable(kNewValue));
+    EXPECT_EQ(kNewValue, non_copyable.value());
+  }
+  EXPECT_EQ(kOldValue, non_copyable.value());
+}
+
+TEST(ScopedReassignment, NonMovableTest) {
+  NonMovable non_movable(kOldValue);
+  {
+    NonMovable other(kNewValue);
+    ScopedReassignment<NonMovable> reassign(&non_movable, other);
+    EXPECT_EQ(kNewValue, non_movable.value());
+  }
+  EXPECT_EQ(kOldValue, non_movable.value());
+
+  {
+    ScopedReassignment<NonMovable> reassign(&non_movable, NonMovable(kNewValue));
+    EXPECT_EQ(kNewValue, non_movable.value());
+  }
+  EXPECT_EQ(kOldValue, non_movable.value());
+}
+
+TEST(ScopedReassignment, CopyableMovableTest) {
+  CopyableMovable copyable_movable(kOldValue);
+  {
+    CopyableMovable other(kNewValue);
+    ScopedReassignment<CopyableMovable> reassign(&copyable_movable, other);
+    EXPECT_EQ(kNewValue, copyable_movable.value());
+    EXPECT_FALSE(reassign.old_value().copy_constructed());
+    EXPECT_TRUE(copyable_movable.copy_assigned());
+  }
+  EXPECT_EQ(kOldValue, copyable_movable.value());
+  EXPECT_FALSE(copyable_movable.copy_assigned());
+
+  {
+    CopyableMovable other(kNewValue);
+    ScopedReassignment<CopyableMovable> reassign(&copyable_movable, std::move(other));
+    EXPECT_EQ(kNewValue, copyable_movable.value());
+    EXPECT_FALSE(reassign.old_value().copy_constructed());
+    EXPECT_FALSE(copyable_movable.copy_assigned());
+  }
+  EXPECT_EQ(kOldValue, copyable_movable.value());
+  EXPECT_FALSE(copyable_movable.copy_assigned());
+}
+
+}  // namespace quickstep


### PR DESCRIPTION
This PR redirects `stdout / stderr` to `io_handle->out() / io_handle->err()` (see [here](https://github.com/apache/incubator-quickstep/blob/fb9f856a78d947647406f661f3f3291e294bd266/cli/QuickstepCli.cpp#L309)) for transmitting the standard stream outputs to client in the network mode. It allows `quickstep_client` to use `COPY ... TO stdout ...` command to retrieve result table in CSV format.