### PR TITLE
QUICKSTEP-78: Displayed Partition Info using \d.

### DIFF
--- a/catalog/CMakeLists.txt
+++ b/catalog/CMakeLists.txt
@@ -167,6 +167,8 @@ target_link_libraries(quickstep_catalog_PartitionScheme
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_catalog_PartitionSchemeHeader
                       glog
+                      quickstep_catalog_CatalogAttribute
+                      quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_Catalog_proto
                       quickstep_storage_StorageConstants

--- a/catalog/PartitionScheme.cpp
+++ b/catalog/PartitionScheme.cpp
@@ -21,6 +21,8 @@
 
 #include <cstddef>
 #include <limits>
+#include <sstream>
+#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -109,6 +111,18 @@ partition_id PartitionScheme::getPartitionForBlock(const block_id block) const {
   }
   // Block was not found in any partitions.
   return std::numeric_limits<std::size_t>::max();
+}
+
+std::string PartitionScheme::toString(const CatalogRelationSchema &relation_schema) const {
+  std::ostringstream oss;
+  oss << "  |";
+  for (std::size_t i = 0; i < blocks_in_partition_.size(); ++i) {
+    SpinSharedMutexSharedLock<false> lock(blocks_in_partition_mutexes_[i]);
+    oss << ' ' << blocks_in_partition_[i].size() << " |";
+  }
+  oss << '\n';
+
+  return header_->toString(relation_schema) + oss.str();
 }
 
 }  // namespace quickstep

--- a/catalog/PartitionScheme.hpp
+++ b/catalog/PartitionScheme.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -38,6 +39,8 @@
 #include "glog/logging.h"
 
 namespace quickstep {
+
+class CatalogRelationSchema;
 
 /** \addtogroup Catalog
  *  @{
@@ -167,6 +170,15 @@ class PartitionScheme {
    *         std::size_t is returned.
    **/
   partition_id getPartitionForBlock(const block_id block) const;
+
+  /**
+   * @brief Display the partition scheme as a string.
+   *
+   * @param relation_schema The relation schema that owns this scheme.
+   *
+   * @return the string of the partition scheme.
+   **/
+  std::string toString(const CatalogRelationSchema &relation_schema) const;
 
  private:
   std::unique_ptr<const PartitionSchemeHeader> header_;

--- a/catalog/PartitionSchemeHeader.hpp
+++ b/catalog/PartitionSchemeHeader.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <memory>
 #include <random>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -41,6 +42,7 @@
 
 namespace quickstep {
 
+class CatalogRelationSchema;
 class Type;
 
 /** \addtogroup Catalog
@@ -164,6 +166,10 @@ class PartitionSchemeHeader {
   const PartitionAttributeIds partition_attribute_ids_;
 
  private:
+  std::string toString(const CatalogRelationSchema &relation_schema) const;
+
+  friend class PartitionScheme;
+
   DISALLOW_COPY_AND_ASSIGN(PartitionSchemeHeader);
 };
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -147,6 +147,7 @@ target_link_libraries(quickstep_cli_CommandExecutorUtil
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_IndexScheme
+                      quickstep_catalog_PartitionScheme
                       quickstep_cli_PrintToScreen
                       quickstep_parser_ParseString
                       quickstep_storage_StorageBlockLayout_proto

--- a/cli/CommandExecutorUtil.cpp
+++ b/cli/CommandExecutorUtil.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <iomanip>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,7 @@
 #include "catalog/CatalogDatabase.hpp"
 #include "catalog/CatalogRelation.hpp"
 #include "catalog/IndexScheme.hpp"
+#include "catalog/PartitionScheme.hpp"
 #include "cli/PrintToScreen.hpp"
 #include "parser/ParseString.hpp"
 #include "storage/StorageBlockLayout.pb.h"
@@ -146,9 +148,9 @@ string ExecuteDescribeTable(
   }
 
   ostringstream oss;
-  oss << setw(kInitMaxColumnWidth) << "Table" << " \"" << table_name_val << "\"\n";
-  oss << std::left << setw(max_attr_column_width + 1) << " Column" << " |";
-  oss << setw(max_type_column_width + 1) << " Type" << '\n';
+  oss << setw(kInitMaxColumnWidth) << "Table" << " \"" << table_name_val << "\"\n"
+      << std::left << setw(max_attr_column_width + 1) << " Column" << " |"
+      << setw(max_type_column_width + 1) << " Type" << '\n';
 
   // Add room for one extra character to allow spacing between the column ending and the vertical bar
   oss << PrintToScreen::GenerateHBar({ max_attr_column_width + 1, max_type_column_width + 1 });
@@ -157,7 +159,7 @@ string ExecuteDescribeTable(
     oss << ' ' << setw(max_attr_column_width) << attr.getDisplayName() << " | "
         << setw(max_type_column_width) << attr.getType().getName() << '\n';
   }
-  // TODO(rogers): Add handlers for partitioning information.
+
   if (relation->hasIndexScheme()) {
     oss << setw(kInitMaxColumnWidth + 2) << " Indexes" << '\n';
     for (const auto &index : relation->getIndexScheme()) {
@@ -171,6 +173,11 @@ string ExecuteDescribeTable(
       }
       oss << ")\n";
     }
+  }
+
+  if (relation->hasPartitionScheme()) {
+    oss << setw(kInitMaxColumnWidth + 2) << " Partition Info\n  "
+        << relation->getPartitionScheme()->toString(*relation);
   }
 
   return oss.str();

--- a/cli/tests/command_executor/D.test
+++ b/cli/tests/command_executor/D.test
@@ -38,6 +38,11 @@ CREATE TABLE foo4 (col1 INT,
                    col5 CHAR(5));
 CREATE INDEX foo4_index_1 ON foo4 (col1, col2) USING CSBTREE;
 CREATE INDEX foo4_index_2 ON foo4 (col3, col4) USING CSBTREE;
+CREATE TABLE foo_hash_part (col1 INT,
+                            col2 FLOAT)
+PARTITION BY HASH(col1) PARTITIONS 4;
+INSERT INTO foo_hash_part
+SELECT i, i * 3.0 FROM generate_series(1, 100) AS gs(i);
 CREATE TABLE averylongtablenamethatseemstoneverend (col1 INT);
 DROP TABLE TEST;
 INSERT INTO averylongtablenamethatseemstoneverend VALUES (1);
@@ -102,6 +107,17 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
   "foo4_index_2" CSB_TREE (col3, col4)
   "foo4_index_1" CSB_TREE (col1, col2)
 ==
+\d foo_hash_part
+--
+ Table "foo_hash_part"
+ Column | Type  
++-------+-------+
+ col1   | Int   
+ col2   | Float 
+ Partition Info
+  PARTITION BY HASH ( col1 ) PARTITIONS 4
+  | 1 | 1 | 1 | 1 |
+==
 \d
 --
        List of relations
@@ -112,6 +128,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  foo2                                  | table | 1      
  foo3                                  | table | 1      
  foo4                                  | table | 0      
+ foo_hash_part                         | table | 4      
  averylongtablenamethatseemstoneverend | table | 1      
 
 ==


### PR DESCRIPTION
Assigned to @jianqiao.

This PR displayed the partition info via `\d [table name]` as following:
```
 Partition Info
  PARTITION BY HASH ( col1 ) PARTITIONS 4
  | 1 | 1 | 1 | 1 |
```