### PR TITLE
Prune columns after partition rule.

### DIFF
--- a/query_optimizer/PhysicalGenerator.cpp
+++ b/query_optimizer/PhysicalGenerator.cpp
@@ -173,6 +173,7 @@ P::PhysicalPtr PhysicalGenerator::optimizePlan() {
   // set output PartitionSchemeHeader in a Physical Plan node, when needed.
   if (FLAGS_use_partition_rule) {
     rules.push_back(std::make_unique<Partition>(optimizer_context_));
+    rules.push_back(std::make_unique<PruneColumns>());
   }
 
   // NOTE(jianqiao): Adding rules after InjectJoinFilters (or AttachLIPFilters)


### PR DESCRIPTION
This small PR allows to prune columns after partition rule, and thus improve the query performance by avoiding unused attributes.