### PR TITLE
QUICKSTEP-104 Fix the problem that LineReader cannot recognize a command if there are whitespaces before it.

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -189,10 +189,12 @@ if(QUICKSTEP_HAVE_LIBNUMA)
 endif()
 if(USE_LINENOISE)
   target_link_libraries(quickstep_cli_LineReader
+                        glog
                         linenoise
                         quickstep_utility_Macros)
 else()
   target_link_libraries(quickstep_cli_LineReader
+                        glog
                         quickstep_utility_Macros)
 endif()
 target_link_libraries(quickstep_cli_LineReaderBuffered

--- a/cli/LineReader.cpp
+++ b/cli/LineReader.cpp
@@ -23,6 +23,8 @@
 #include <cctype>
 #include <string>
 
+#include "glog/logging.h"
+
 using std::ispunct;
 using std::size_t;
 using std::string;
@@ -171,7 +173,7 @@ std::string LineReader::getNextCommand() {
             case '.':
             case '\\':  //  Fall Through.
               // If the dot or forward slash begins the line, begin a command search.
-              if (scan_position == 0) {
+              if (special_char_location == multiline_buffer.find_first_not_of(" \t\r\n")) {
                 line_state = kCommand;
               } else {
                 // This is a regular character, so skip over it.
@@ -217,7 +219,12 @@ std::string LineReader::getNextCommand() {
             if (std::all_of(leftover_.begin(), leftover_.end(), ::isspace)) {
               leftover_.clear();
             }
-            return multiline_buffer.substr(0, special_char_location + 1);
+            // Skip all the whitespaces before the command.
+            const std::size_t start_position =
+                multiline_buffer.find_first_not_of(" \t\r\n");
+            DCHECK_LT(start_position, special_char_location + 1);
+            return multiline_buffer.substr(start_position,
+                                           special_char_location + 1 - start_position);
           }
           break;
       }

--- a/cli/tests/command_executor/D.test
+++ b/cli/tests/command_executor/D.test
@@ -58,6 +58,8 @@ INSERT INTO foo2 values(5, 1, 1.0, 1.0, 'XYZ');
 INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
 --
 ==
+
+
 \d foo
 --
  Table "foo"
@@ -69,6 +71,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  col4   | Float  
  col5   | Char(5)
 ==
+
 \d foo2
 --
  Table "foo2"
@@ -80,6 +83,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  col4                           | Float  
  averyverylongcolumnnamefortest | Char(5)
 ==
+
 \d foo3
 --
  Table "foo3"
@@ -93,6 +97,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  Indexes
   "foo3_index_1" CSB_TREE (col1)
 ==
+
 \d foo4
 --
  Table "foo4"
@@ -107,6 +112,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
   "foo4_index_2" CSB_TREE (col3, col4)
   "foo4_index_1" CSB_TREE (col1, col2)
 ==
+
 \d foo_hash_part
 --
  Table "foo_hash_part"
@@ -118,6 +124,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
   PARTITION BY HASH ( col1 ) PARTITIONS 4
   | 1 | 1 | 1 | 1 |
 ==
+
 \d
 --
        List of relations
@@ -132,6 +139,22 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  averylongtablenamethatseemstoneverend | table | 1      
 
 ==
+
+\d
+--
+       List of relations
+
+ Name                                  | Type  | Blocks 
++--------------------------------------+-------+---------+
+ foo                                   | table | 1      
+ foo2                                  | table | 1      
+ foo3                                  | table | 1      
+ foo4                                  | table | 0      
+ foo_hash_part                         | table | 4      
+ averylongtablenamethatseemstoneverend | table | 1      
+
+==
+
 \d invalidtable
 --
 ERROR:  Unrecognized relation invalidtable (1 : 4)

--- a/cli/tests/command_executor/Dt.test
+++ b/cli/tests/command_executor/Dt.test
@@ -50,6 +50,8 @@ INSERT INTO foo2 values(5, 1, 1.0, 1.0, 'XYZ');
 INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
 --
 ==
+
+
 \dt
 --
        List of relations
@@ -63,6 +65,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  averylongtablenamethatseemstoneverend | table | 1      
 
 ==
+
 \dt foo
 --
        List of relations
@@ -72,6 +75,7 @@ INSERT INTO foo3 values(5, 1, 1.0, 1.0, 'XYZZ');
  foo    | table | 1      
 
 ==
+
 \dt invalidtable
 --
 ERROR:  Unrecognized relation invalidtable (1 : 5)


### PR DESCRIPTION
This PR fixes a bug that the Quickstep REPL cannot recognize a command (e.g. `\d`, `\analyze`) if there are whitespaces or empty lines before the command.