### PR TITLE
Removed unused argument always_mark_full.

### DIFF
--- a/storage/InsertDestination.hpp
+++ b/storage/InsertDestination.hpp
@@ -156,16 +156,15 @@ class InsertDestination : public InsertDestinationInterface {
 
   void insertTupleInBatch(const Tuple &tuple) override;
 
-  void bulkInsertTuples(ValueAccessor *accessor, bool always_mark_full = false) override;
+  void bulkInsertTuples(ValueAccessor *accessor,
+                        const bool always_mark_full = false) override;
 
   void bulkInsertTuplesWithRemappedAttributes(
       const std::vector<attribute_id> &attribute_map,
-      ValueAccessor *accessor,
-      bool always_mark_full = false) override;
+      ValueAccessor *accessor) override;
 
   void bulkInsertTuplesFromValueAccessors(
-      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map,
-      bool always_mark_full = false) override;
+      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map) override;
 
   void insertTuplesFromVector(std::vector<Tuple>::const_iterator begin,
                               std::vector<Tuple>::const_iterator end) override;
@@ -363,8 +362,7 @@ class AlwaysCreateBlockInsertDestination : public InsertDestination {
   }
 
   void bulkInsertTuplesFromValueAccessors(
-      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map,
-      bool always_mark_full = false) override {
+      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map) override {
     LOG(FATAL) << "bulkInsertTuplesFromValueAccessors is not implemented for AlwaysCreateBlockInsertDestination";
   }
 
@@ -551,16 +549,15 @@ class PartitionAwareInsertDestination : public InsertDestination {
 
   void insertTupleInBatch(const Tuple &tuple) override;
 
-  void bulkInsertTuples(ValueAccessor *accessor, bool always_mark_full = false) override;
+  void bulkInsertTuples(ValueAccessor *accessor,
+                        const bool always_mark_full = false) override;
 
   void bulkInsertTuplesWithRemappedAttributes(
       const std::vector<attribute_id> &attribute_map,
-      ValueAccessor *accessor,
-      bool always_mark_full = false) override;
+      ValueAccessor *accessor) override;
 
   void bulkInsertTuplesFromValueAccessors(
-      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map,
-      bool always_mark_full = false) override {
+      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map) override {
     LOG(FATAL) << "bulkInsertTuplesFromValueAccessors is not implemented for PartitionAwareInsertDestination";
   }
 

--- a/storage/InsertDestinationInterface.hpp
+++ b/storage/InsertDestinationInterface.hpp
@@ -104,7 +104,7 @@ class InsertDestinationInterface {
    *        insertion from ValueAccessor even when partially full.
    **/
   virtual void bulkInsertTuples(ValueAccessor *accessor,
-                                bool always_mark_full = false) = 0;
+                                const bool always_mark_full = false) = 0;
 
   /**
    * @brief Bulk-insert tuples from a ValueAccessor with differently-ordered
@@ -115,13 +115,10 @@ class InsertDestinationInterface {
    *        corresponding attributes which should be read from accessor.
    * @param accessor A ValueAccessor whose tuples will by inserted into blocks
    *        from this InsertDestination.
-   * @param always_mark_full If \c true, always mark the blocks full after
-   *        insertion from ValueAccessor even when partially full.
    **/
   virtual void bulkInsertTuplesWithRemappedAttributes(
       const std::vector<attribute_id> &attribute_map,
-      ValueAccessor *accessor,
-      bool always_mark_full = false) = 0;
+      ValueAccessor *accessor) = 0;
 
   /**
    * @brief Bulk-insert tuples from one or more ValueAccessors
@@ -137,12 +134,9 @@ class InsertDestinationInterface {
    *        is the attribute_id "n" in corresponding input value accessor.
    *        Set the i-th element to kInvalidCatalogId if it doesn't come from
    *        the corresponding value accessor.
-   * @param always_mark_full If \c true, always mark the blocks full after
-   *        insertion from ValueAccessor even when partially full.
    **/
   virtual void bulkInsertTuplesFromValueAccessors(
-      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map,
-      bool always_mark_full = false) = 0;
+      const std::vector<std::pair<ValueAccessor *, std::vector<attribute_id>>> &accessor_attribute_map) = 0;
 
   /**
    * @brief Insert tuples from a range of Tuples in a vector.


### PR DESCRIPTION
This PR cleans up the unused argument `always_mark_full`, and avoids branching overhead.