### PR TITLE
DO NOT MERGE: Optimizing Hash repartition on a raw pointer, instead of using TypedValue.

### DIFF
--- a/catalog/CMakeLists.txt
+++ b/catalog/CMakeLists.txt
@@ -166,15 +166,20 @@ target_link_libraries(quickstep_catalog_PartitionScheme
                       quickstep_threading_SpinSharedMutex
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_catalog_PartitionSchemeHeader
+                      farmhash
                       glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_Catalog_proto
                       quickstep_storage_StorageConstants
+                      quickstep_storage_TupleIdSequence
+                      quickstep_storage_ValueAccessor
+                      quickstep_storage_ValueAccessorUtil
                       quickstep_threading_SpinMutex
                       quickstep_types_Type
                       quickstep_types_TypeFactory
+                      quickstep_types_TypeID
                       quickstep_types_Type_proto
                       quickstep_types_TypedValue
                       quickstep_types_TypedValue_proto
@@ -182,6 +187,7 @@ target_link_libraries(quickstep_catalog_PartitionSchemeHeader
                       quickstep_types_operations_comparisons_EqualComparison
                       quickstep_types_operations_comparisons_LessComparison
                       quickstep_utility_CompositeHash
+                      quickstep_utility_HashPair
                       quickstep_utility_Macros)
 
 # Module all-in-one library:

--- a/catalog/Catalog.proto
+++ b/catalog/Catalog.proto
@@ -51,8 +51,7 @@ message PartitionSchemeHeader {
 message HashPartitionSchemeHeader {
   extend PartitionSchemeHeader {
     // Required.
-    repeated Type.TypeID partition_attr_types = 16;
-    repeated uint64 char_type_lengths = 17;
+    repeated Type partition_attr_types = 16;
   }
 }
 

--- a/catalog/Catalog.proto
+++ b/catalog/Catalog.proto
@@ -48,6 +48,14 @@ message PartitionSchemeHeader {
   extensions 16 to max;
 }
 
+message HashPartitionSchemeHeader {
+  extend PartitionSchemeHeader {
+    // Required.
+    repeated Type.TypeID partition_attr_types = 16;
+    repeated uint64 char_type_lengths = 17;
+  }
+}
+
 message PartitionValues {
   repeated TypedValue partition_values = 1;
 }

--- a/catalog/PartitionSchemeHeader.hpp
+++ b/catalog/PartitionSchemeHeader.hpp
@@ -21,6 +21,7 @@
 #define QUICKSTEP_CATALOG_PARTITION_SCHEME_HEADER_HPP_
 
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <random>
 #include <string>
@@ -30,20 +31,26 @@
 #include "catalog/Catalog.pb.h"
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/StorageConstants.hpp"
+#include "storage/TupleIdSequence.hpp"
+#include "storage/ValueAccessor.hpp"
+#include "storage/ValueAccessorUtil.hpp"
 #include "threading/SpinMutex.hpp"
+#include "types/Type.hpp"
+#include "types/TypeID.hpp"
 #include "types/TypedValue.hpp"
 #include "types/operations/comparisons/Comparison.hpp"
 #include "types/operations/comparisons/EqualComparison.hpp"
 #include "types/operations/comparisons/LessComparison.hpp"
 #include "utility/CompositeHash.hpp"
+#include "utility/HashPair.hpp"
 #include "utility/Macros.hpp"
 
+#include "farmhash/farmhash.h"
 #include "glog/logging.h"
 
 namespace quickstep {
 
 class CatalogRelationSchema;
-class Type;
 
 /** \addtogroup Catalog
  *  @{
@@ -109,6 +116,10 @@ class PartitionSchemeHeader {
   // tuples that correspond to those partitions.
   virtual partition_id getPartitionId(
       const PartitionValues &value_of_attributes) const = 0;
+
+  virtual void setPartitionMembership(
+      std::vector<std::unique_ptr<TupleIdSequence>> *partition_membership,
+      ValueAccessor *accessor) const = 0;
 
   /**
    * @brief Serialize the Partition Scheme as Protocol Buffer.
@@ -186,9 +197,15 @@ class HashPartitionSchemeHeader final : public PartitionSchemeHeader {
    * @param attributes A vector of attributes on which the partitioning happens.
    **/
   HashPartitionSchemeHeader(const std::size_t num_partitions,
-                            PartitionAttributeIds &&attributes)  // NOLINT(whitespace/operators)
+                            PartitionAttributeIds &&attributes,  // NOLINT(whitespace/operators)
+                            std::vector<TypeID> &&attribute_types,
+                            std::vector<std::size_t> &&char_type_lengths = {})
       : PartitionSchemeHeader(PartitionType::kHash, num_partitions, std::move(attributes)),
+        attr_type_ids_(std::move(attribute_types)),
+        char_type_lengths_(std::move(char_type_lengths)),
         is_power_of_two_(!(num_partitions & (num_partitions - 1))) {
+    DCHECK_EQ(partition_attribute_ids_.size(),
+              attr_type_ids_.size());
   }
 
   /**
@@ -198,24 +215,99 @@ class HashPartitionSchemeHeader final : public PartitionSchemeHeader {
   }
 
   partition_id getPartitionId(
-      const PartitionValues &value_of_attributes) const override {
-    DCHECK_EQ(partition_attribute_ids_.size(), value_of_attributes.size());
-    return getPartitionId(HashCompositeKey(value_of_attributes));
-  }
+      const PartitionValues &value_of_attributes) const override;
+
+  void setPartitionMembership(
+      std::vector<std::unique_ptr<TupleIdSequence>> *partition_membership,
+      ValueAccessor *accessor) const override;
+
+  serialization::PartitionSchemeHeader getProto() const override;
 
  private:
-  partition_id getPartitionId(const std::size_t hash_code) const {
-    if (is_power_of_two_) {
-      return hash_code & (num_partitions_ - 1);
-    }
+  template <bool is_power_of_two>
+  partition_id getPartitionIdImpl(const std::size_t hash_code) const;
 
-    return (hash_code >= num_partitions_) ? hash_code % num_partitions_
-                                          : hash_code;
-  }
+  template <TypeID type_id, typename ValueAccessorT, typename ...Optional>
+  void setPartitionMembershipImpl(ValueAccessorT *accessor,
+                                  const attribute_id attr_id,
+                                  std::vector<std::unique_ptr<TupleIdSequence>> *partition_membership,
+                                  const Optional &...length) const;
+
+  template <TypeID type_id>
+  std::size_t getHashCode(const void *data) const;
+
+  template <TypeID type_id>
+  std::size_t getHashCode(const void *data, const std::size_t length) const;
+
+  // The size is equal to 'partition_attribute_ids_.size()'.
+  const std::vector<TypeID> attr_type_ids_;
+  const std::vector<std::size_t> char_type_lengths_;
 
   const bool is_power_of_two_;
+
   DISALLOW_COPY_AND_ASSIGN(HashPartitionSchemeHeader);
 };
+
+// Explicit specializations of getPartitionIdImpl().
+template <>
+inline partition_id HashPartitionSchemeHeader::getPartitionIdImpl<true>(const std::size_t hash_code) const {
+  return hash_code & (num_partitions_ - 1);
+}
+
+template <>
+inline partition_id HashPartitionSchemeHeader::getPartitionIdImpl<false>(const std::size_t hash_code) const {
+  return (hash_code >= num_partitions_) ? hash_code % num_partitions_
+                                        : hash_code;
+}
+
+// Explicit specializations of getHashCode().
+template <>
+inline std::size_t HashPartitionSchemeHeader::getHashCode<kInt>(const void *data) const {
+  return *static_cast<const std::uint32_t*>(data);
+}
+
+template <>
+inline std::size_t HashPartitionSchemeHeader::getHashCode<kLong>(const void *data) const {
+  return *static_cast<const std::uint64_t*>(data);
+}
+
+template <>
+inline std::size_t HashPartitionSchemeHeader::getHashCode<kVarChar>(const void *data) const {
+  const char *p_char = static_cast<const char*>(data);
+  // Don't hash any bytes that follow it.
+  return util::Hash(p_char, std::strlen(p_char));
+}
+
+template <>
+inline std::size_t HashPartitionSchemeHeader::getHashCode<kChar>(const void *data, const std::size_t length) const {
+  // Don't hash any bytes that follow it.
+  const std::size_t actual_length =
+      strnlen(static_cast<const char*>(data), length);
+  return util::Hash(static_cast<const char*>(data), actual_length);
+}
+
+// Implementation of setPartitionMembershipImpl() is written out-of-line
+// here because instantiations of getHashCode() and getPartitionIdImpl() must
+// come after the explicit specializations above.
+template <TypeID type_id, typename ValueAccessorT, typename ...Optional>
+inline void HashPartitionSchemeHeader::setPartitionMembershipImpl(
+    ValueAccessorT *accessor, const attribute_id attr_id,
+    std::vector<std::unique_ptr<TupleIdSequence>> *partition_membership,
+    const Optional &...length) const {
+  if (is_power_of_two_) {
+    while (accessor->next()) {
+      const std::size_t hash_code = getHashCode<type_id>(accessor->getUntypedValue(attr_id), length...);
+      const partition_id part_id = getPartitionIdImpl<true>(hash_code);
+      (*partition_membership)[part_id]->set(accessor->getCurrentPosition());
+    }
+  } else {
+    while (accessor->next()) {
+      const std::size_t hash_code = getHashCode<type_id>(accessor->getUntypedValue(attr_id), length...);
+      const partition_id part_id = getPartitionIdImpl<false>(hash_code);
+      (*partition_membership)[part_id]->set(accessor->getCurrentPosition());
+    }
+  }
+}
 
 /**
  * @brief Implementation of PartitionSchemeHeader that partitions the tuples in
@@ -243,6 +335,20 @@ class RandomPartitionSchemeHeader final : public PartitionSchemeHeader {
       const PartitionValues &value_of_attributes) const override {
     SpinMutexLock lock(mutex_);
     return dist_(mt_);
+  }
+
+  void setPartitionMembership(
+      std::vector<std::unique_ptr<TupleIdSequence>> *partition_membership,
+      ValueAccessor *accessor) const override {
+    InvokeOnAnyValueAccessor(
+        accessor,
+        [this,
+         &partition_membership](auto *accessor) -> void {
+      SpinMutexLock lock(mutex_);
+      while (accessor->next()) {
+        (*partition_membership)[dist_(mt_)]->set(accessor->getCurrentPosition());
+      }
+    });
   }
 
  private:
@@ -331,6 +437,12 @@ class RangePartitionSchemeHeader final : public PartitionSchemeHeader {
     }
 
     return start;
+  }
+
+  void setPartitionMembership(
+      std::vector<std::unique_ptr<TupleIdSequence>> *partition_membership,
+      ValueAccessor *accessor) const override {
+    LOG(FATAL) << "TODO";
   }
 
   serialization::PartitionSchemeHeader getProto() const override;

--- a/catalog/tests/NUMAPlacementScheme_unittest.cpp
+++ b/catalog/tests/NUMAPlacementScheme_unittest.cpp
@@ -82,7 +82,7 @@ TEST(NUMAPlacementSchemeTest, NUMAPlacementSchemeSerializationTest) {
   // Create a HashPartitionSchemeHeader object with 64 partitions and attribute
   //  0 as the partitioning attribute.
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kInt }));
 
   // Create a NUMAPlacementScheme object with the num_partitions.
   std::unique_ptr<NUMAPlacementScheme> placement_scheme(

--- a/catalog/tests/PartitionScheme_unittest.cpp
+++ b/catalog/tests/PartitionScheme_unittest.cpp
@@ -39,6 +39,7 @@
 
 #include "gtest/gtest.h"
 
+using std::make_unique;
 using std::move;
 using std::size_t;
 using std::vector;
@@ -48,7 +49,7 @@ namespace quickstep {
 TEST(PartitionSchemeHeaderTest, IntegerHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 4;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kInt }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const int kSampleInts[] = {
@@ -66,7 +67,7 @@ TEST(PartitionSchemeHeaderTest, IntegerHashPartitionSchemeHeaderTest) {
 TEST(PartitionSchemeHeaderTest, LongHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 8;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kLong }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const std::int64_t kSampleLongs[] = {INT64_C(10),
@@ -87,7 +88,7 @@ TEST(PartitionSchemeHeaderTest, LongHashPartitionSchemeHeaderTest) {
 TEST(PartitionSchemeHeaderTest, FloatHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 5;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kFloat }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const float kSampleFloats[] = {
@@ -105,7 +106,7 @@ TEST(PartitionSchemeHeaderTest, FloatHashPartitionSchemeHeaderTest) {
 TEST(PartitionSchemeHeaderTest, DoubleHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 6;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kDouble }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const double kSampleDoubles[] = {
@@ -124,7 +125,7 @@ TEST(PartitionSchemeHeaderTest, DoubleHashPartitionSchemeHeaderTest) {
 TEST(PartitionSchemeHeaderTest, CharacterHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 7;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kChar }, { 20 }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const char *kSampleStrings[] = {
@@ -147,7 +148,7 @@ TEST(PartitionSchemeHeaderTest, CharacterHashPartitionSchemeHeaderTest) {
 TEST(PartitionSchemeHeaderTest, VarCharHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 7;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kVarChar }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const char *kSampleStrings[] = {
@@ -172,7 +173,8 @@ TEST(PartitionSchemeHeaderTest, MultiAttributeHashPartitionSchemeHeaderTest) {
   constexpr attribute_id kPartitioningFirstAttribute = 0;
   constexpr attribute_id kPartitioningLastAttribute = 2;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { kPartitioningFirstAttribute, kPartitioningLastAttribute }));
+      new HashPartitionSchemeHeader(num_partitions, { kPartitioningFirstAttribute, kPartitioningLastAttribute },
+                                    { kInt, kDouble }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(kPartitioningFirstAttribute, partition_scheme_header->getPartitionAttributeIds().front());
   EXPECT_EQ(kPartitioningLastAttribute, partition_scheme_header->getPartitionAttributeIds().back());
@@ -399,7 +401,7 @@ TEST(PartitionSchemeHeaderTest, MultiAttributeRangePartitionSchemeHeaderTest) {
 
 TEST(PartitionSchemeTest, AddBlocksToPartitionTest) {
   std::unique_ptr<PartitionScheme> partition_scheme(
-      new PartitionScheme(new HashPartitionSchemeHeader(4, { 0 })));
+      new PartitionScheme(new HashPartitionSchemeHeader(4, { 0 }, { kInt })));
   for (int i = 0; i < 10; ++i) {
     partition_scheme->addBlockToPartition(i, i % 4);
   }
@@ -468,7 +470,7 @@ TEST(PartitionSchemeTest, AddBlocksToPartitionTest) {
 
 TEST(PartitionSchemeTest, RemoveBlocksFromPartitionTest) {
   std::unique_ptr<PartitionScheme> partition_scheme(
-      new PartitionScheme(new HashPartitionSchemeHeader(4, { 0 })));
+      new PartitionScheme(new HashPartitionSchemeHeader(4, { 0 }, { kInt })));
   for (int i = 0; i < 10; ++i) {
     partition_scheme->addBlockToPartition(i, i % 4);
   }
@@ -552,7 +554,7 @@ TEST(PartitionSchemeTest, RemoveBlocksFromPartitionTest) {
 TEST(PartitionSchemeTest, CheckHashPartitionSchemeSerialization) {
   const std::size_t num_partitions = 4;
   std::unique_ptr<PartitionScheme> part_scheme(
-      new PartitionScheme(new HashPartitionSchemeHeader(num_partitions, { 0 })));
+      new PartitionScheme(new HashPartitionSchemeHeader(num_partitions, { 0 }, { kInt })));
   // Add some blocks to each partition.
   for (int i = 0; i < 10; ++i) {
     part_scheme->addBlockToPartition(i, i % num_partitions);
@@ -592,8 +594,7 @@ TEST(PartitionSchemeTest, CheckHashPartitionSchemeSerialization) {
 
 TEST(PartitionSchemeTest, CheckRandomPartitionSchemeSerialization) {
   const std::size_t num_partitions = 4;
-  std::unique_ptr<PartitionScheme> part_scheme(
-      new PartitionScheme(new RandomPartitionSchemeHeader(num_partitions)));
+  auto part_scheme = make_unique<PartitionScheme>(new RandomPartitionSchemeHeader(num_partitions));
   // Add some blocks to each partition.
   for (int i = 0; i < 10; ++i) {
     part_scheme->addBlockToPartition(i, i % num_partitions);
@@ -635,13 +636,12 @@ TEST(PartitionSchemeTest, CheckRandomPartitionSchemeSerialization) {
 // due to QUICKSTEP-86.
 
 TEST(PartitionSchemeTest, CheckBlocksInPartitionTest) {
-  std::unique_ptr<PartitionScheme> partition_scheme;
   constexpr std::size_t kNumBlocks = 10;
   constexpr std::size_t kNumPartitions = 4;
   constexpr attribute_id kPartitioningAttribute = 0;
   // Create a partition scheme object.
-  partition_scheme.reset(
-      new PartitionScheme(new HashPartitionSchemeHeader(kNumPartitions, { kPartitioningAttribute })));
+  auto partition_scheme = make_unique<PartitionScheme>(
+      new HashPartitionSchemeHeader(kNumPartitions, { kPartitioningAttribute }, { kInt }));
   // Add blocks to different partitions.
   for (std::size_t block_id = 0; block_id < kNumBlocks; ++block_id) {
     partition_scheme->addBlockToPartition(block_id,

--- a/catalog/tests/PartitionScheme_unittest.cpp
+++ b/catalog/tests/PartitionScheme_unittest.cpp
@@ -125,7 +125,7 @@ TEST(PartitionSchemeHeaderTest, DoubleHashPartitionSchemeHeaderTest) {
 TEST(PartitionSchemeHeaderTest, CharacterHashPartitionSchemeHeaderTest) {
   const std::size_t num_partitions = 7;
   std::unique_ptr<PartitionSchemeHeader> partition_scheme_header(
-      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kChar }, { 20 }));
+      new HashPartitionSchemeHeader(num_partitions, { 0 }, { kChar }, { false }, { 20 }));
   EXPECT_EQ(num_partitions, partition_scheme_header->getNumPartitions());
   EXPECT_EQ(0, partition_scheme_header->getPartitionAttributeIds().front());
   const char *kSampleStrings[] = {

--- a/query_optimizer/resolver/CMakeLists.txt
+++ b/query_optimizer/resolver/CMakeLists.txt
@@ -124,8 +124,9 @@ target_link_libraries(quickstep_queryoptimizer_resolver_Resolver
                       quickstep_storage_StorageConstants
                       quickstep_types_IntType
                       quickstep_types_Type
-                      quickstep_types_TypedValue
                       quickstep_types_TypeFactory
+                      quickstep_types_TypeID
+                      quickstep_types_TypedValue
                       quickstep_types_operations_binaryoperations_BinaryOperation
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory

--- a/query_optimizer/resolver/Resolver.cpp
+++ b/query_optimizer/resolver/Resolver.cpp
@@ -119,8 +119,9 @@
 #include "storage/StorageConstants.hpp"
 #include "types/IntType.hpp"
 #include "types/Type.hpp"
-#include "types/TypedValue.hpp"
 #include "types/TypeFactory.hpp"
+#include "types/TypeID.hpp"
+#include "types/TypedValue.hpp"
 #include "types/operations/binary_operations/BinaryOperation.hpp"
 #include "types/operations/comparisons/Comparison.hpp"
 #include "types/operations/comparisons/ComparisonFactory.hpp"
@@ -659,7 +660,7 @@ L::LogicalPtr Resolver::resolveCreateTable(
       block_properties(resolveBlockProperties(create_table_statement));
 
   std::shared_ptr<const S::PartitionSchemeHeader> partition_scheme_header_proto(
-      resolvePartitionClause(create_table_statement));
+      resolvePartitionClause(create_table_statement, attributes));
 
   return L::CreateTable::Create(relation_name, attributes, block_properties, partition_scheme_header_proto);
 }
@@ -840,7 +841,8 @@ StorageBlockLayoutDescription* Resolver::resolveBlockProperties(
 }
 
 const S::PartitionSchemeHeader* Resolver::resolvePartitionClause(
-    const ParseStatementCreateTable &create_table_statement) {
+    const ParseStatementCreateTable &create_table_statement,
+    const std::vector<E::AttributeReferencePtr> &attributes) {
   const ParsePartitionClause *partition_clause = create_table_statement.opt_partition_clause();
   if (partition_clause == nullptr) {
     return nullptr;
@@ -882,6 +884,17 @@ const S::PartitionSchemeHeader* Resolver::resolvePartitionClause(
     unique_partition_attrs.insert(attr_id);
 
     proto->add_partition_attribute_ids(attr_id);
+  }
+
+  if (partition_type == kHashPartitionType) {
+    for (int i = 0; i < proto->partition_attribute_ids_size(); ++i) {
+      const Type &type = attributes[proto->partition_attribute_ids(i)]->getValueType();
+      const TypeID type_id = type.getTypeID();
+      proto->AddExtension(S::HashPartitionSchemeHeader::partition_attr_types, SerializeTypeID(type_id));
+      if (type_id == kChar) {
+        proto->AddExtension(S::HashPartitionSchemeHeader::char_type_lengths, type.getPrintWidth());
+      }
+    }
   }
 
   return proto.release();

--- a/query_optimizer/resolver/Resolver.cpp
+++ b/query_optimizer/resolver/Resolver.cpp
@@ -889,11 +889,7 @@ const S::PartitionSchemeHeader* Resolver::resolvePartitionClause(
   if (partition_type == kHashPartitionType) {
     for (int i = 0; i < proto->partition_attribute_ids_size(); ++i) {
       const Type &type = attributes[proto->partition_attribute_ids(i)]->getValueType();
-      const TypeID type_id = type.getTypeID();
-      proto->AddExtension(S::HashPartitionSchemeHeader::partition_attr_types, SerializeTypeID(type_id));
-      if (type_id == kChar) {
-        proto->AddExtension(S::HashPartitionSchemeHeader::char_type_lengths, type.getPrintWidth());
-      }
+      proto->AddExtension(S::HashPartitionSchemeHeader::partition_attr_types)->MergeFrom(type.getProto());
     }
   }
 

--- a/query_optimizer/resolver/Resolver.hpp
+++ b/query_optimizer/resolver/Resolver.hpp
@@ -26,11 +26,12 @@
 #include <vector>
 
 #include "query_optimizer/expressions/Alias.hpp"
+#include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
-#include "query_optimizer/expressions/SubqueryExpression.hpp"
 #include "query_optimizer/expressions/Scalar.hpp"
+#include "query_optimizer/expressions/SubqueryExpression.hpp"
 #include "query_optimizer/expressions/WindowAggregateFunction.hpp"
 #include "query_optimizer/logical/Logical.hpp"
 #include "utility/Macros.hpp"
@@ -243,7 +244,8 @@ class Resolver {
    * @return A pointer to a user-owned serialized PartitionSchemeHeader.
    */
   const serialization::PartitionSchemeHeader* resolvePartitionClause(
-      const ParseStatementCreateTable &create_table_statement);
+      const ParseStatementCreateTable &create_table_statement,
+      const std::vector<expressions::AttributeReferencePtr> &attributes);
 
   /**
    * @brief Resolves a DELETE query and returns a logical plan.

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -272,11 +272,13 @@ class HashJoinOperatorTest : public ::testing::TestWithParam<HashTableImplType> 
   void insertTuplesWithSingleAttributePartitions() {
     // Set PartitionScheme.
     dim_part_scheme_ = new PartitionScheme(
-        new HashPartitionSchemeHeader(kMultiplePartitions, { dim_table_->getAttributeByName("long")->getID() }));
+        new HashPartitionSchemeHeader(kMultiplePartitions, { dim_table_->getAttributeByName("long")->getID() },
+                                      { kLong }, { 0 }));
     dim_table_->setPartitionScheme(dim_part_scheme_);
 
     fact_part_scheme_ = new PartitionScheme(
-        new HashPartitionSchemeHeader(kMultiplePartitions, { fact_table_->getAttributeByName("long")->getID() }));
+        new HashPartitionSchemeHeader(kMultiplePartitions, { fact_table_->getAttributeByName("long")->getID() },
+                                      { kLong }, { 0 }));
     fact_table_->setPartitionScheme(fact_part_scheme_);
 
     // Create StorageLayout

--- a/storage/InsertDestination.cpp
+++ b/storage/InsertDestination.cpp
@@ -651,7 +651,6 @@ void PartitionAwareInsertDestination::bulkInsertTuplesWithRemappedAttributes(
 
     // Iterate over ValueAccessor for each tuple,
     // set a bit in the appropriate TupleIdSequence.
-    accessor->beginIteration();
     this->setPartitionMembership(&partition_membership, accessor);
 
     // For each partition, create an adapter around Value Accessor and

--- a/storage/InsertDestination.hpp
+++ b/storage/InsertDestination.hpp
@@ -646,14 +646,7 @@ class PartitionAwareInsertDestination : public InsertDestination {
         (*partition_membership)[input_partition_id_]->set(accessor->getCurrentPosition());
       }
     } else {
-      PartitionSchemeHeader::PartitionValues values(partition_attr_ids.size());
-      while (accessor->next()) {
-        for (std::size_t i = 0; i < partition_attr_ids.size(); ++i) {
-          values[i] = accessor->getTypedValue(partition_attr_ids[i]);
-        }
-        (*partition_membership)[partition_scheme_header_->getPartitionId(values)]->set(
-            accessor->getCurrentPosition());
-      }
+      partition_scheme_header_->setPartitionMembership(partition_membership, accessor);
     }
   }
 

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -182,6 +182,9 @@ target_link_libraries(quickstep_types_TypeFactory
                       quickstep_types_VarCharType
                       quickstep_types_YearMonthIntervalType
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_types_TypeID
+                      glog
+                      quickstep_types_Type_proto)
 target_link_libraries(quickstep_types_TypedValue
                       farmhash
                       glog

--- a/types/Type.cpp
+++ b/types/Type.cpp
@@ -30,38 +30,7 @@ namespace quickstep {
 
 serialization::Type Type::getProto() const {
   serialization::Type proto;
-  switch (type_id_) {
-    case kInt:
-      proto.set_type_id(serialization::Type::INT);
-      break;
-    case kLong:
-      proto.set_type_id(serialization::Type::LONG);
-      break;
-    case kFloat:
-      proto.set_type_id(serialization::Type::FLOAT);
-      break;
-    case kDouble:
-      proto.set_type_id(serialization::Type::DOUBLE);
-      break;
-    case kDate:
-      proto.set_type_id(serialization::Type::DATE);
-      break;
-    case kDatetime:
-      proto.set_type_id(serialization::Type::DATETIME);
-      break;
-    case kDatetimeInterval:
-      proto.set_type_id(serialization::Type::DATETIME_INTERVAL);
-      break;
-    case kYearMonthInterval:
-      proto.set_type_id(serialization::Type::YEAR_MONTH_INTERVAL);
-      break;
-    case kNullType:
-      proto.set_type_id(serialization::Type::NULL_TYPE);
-      break;
-    default:
-      FATAL_ERROR("Unrecognized TypeID in Type::getProto");
-  }
-
+  proto.set_type_id(SerializeTypeID(type_id_));
   proto.set_nullable(nullable_);
 
   return proto;

--- a/types/TypeID.cpp
+++ b/types/TypeID.cpp
@@ -19,6 +19,10 @@
 
 #include "types/TypeID.hpp"
 
+#include "types/Type.pb.h"
+
+#include "glog/logging.h"
+
 namespace quickstep {
 
 const char *kTypeNames[] = {
@@ -34,5 +38,63 @@ const char *kTypeNames[] = {
   "YearMonthInterval",
   "NullType"
 };
+
+TypeID DeserializeTypeID(const serialization::Type::TypeID type_id_proto) {
+  switch (type_id_proto) {
+    case serialization::Type::INT:
+      return kInt;
+    case serialization::Type::LONG:
+      return kLong;
+    case serialization::Type::FLOAT:
+      return kFloat;
+    case serialization::Type::DOUBLE:
+      return kDouble;
+    case serialization::Type::CHAR:
+      return kChar;
+    case serialization::Type::VAR_CHAR:
+      return kVarChar;
+    case serialization::Type::DATE:
+      return kDate;
+    case serialization::Type::DATETIME:
+      return kDatetime;
+    case serialization::Type::DATETIME_INTERVAL:
+      return kDatetimeInterval;
+    case serialization::Type::YEAR_MONTH_INTERVAL:
+      return kYearMonthInterval;
+    case serialization::Type::NULL_TYPE:
+      return kNullType;
+    default:
+      LOG(FATAL) << "Unrecognized TypeID in DeserializeTypeID";
+  }
+}
+
+serialization::Type::TypeID SerializeTypeID(const TypeID type_id) {
+  switch (type_id) {
+    case kInt:
+      return serialization::Type::INT;
+    case kLong:
+      return serialization::Type::LONG;
+    case kFloat:
+      return serialization::Type::FLOAT;
+    case kDouble:
+      return serialization::Type::DOUBLE;
+    case kChar:
+      return serialization::Type::CHAR;
+    case kVarChar:
+      return serialization::Type::VAR_CHAR;
+    case kDate:
+      return serialization::Type::DATE;
+    case kDatetime:
+      return serialization::Type::DATETIME;
+    case kDatetimeInterval:
+      return serialization::Type::DATETIME_INTERVAL;
+    case kYearMonthInterval:
+      return serialization::Type::YEAR_MONTH_INTERVAL;
+    case kNullType:
+      return serialization::Type::NULL_TYPE;
+    default:
+      LOG(FATAL) << "Unrecognized TypeID in SerializeTypeID";
+  }
+}
 
 }  // namespace quickstep

--- a/types/TypeID.hpp
+++ b/types/TypeID.hpp
@@ -21,6 +21,9 @@
 #define QUICKSTEP_TYPES_TYPE_ID_HPP_
 
 #include <cstddef>
+#include <cstdint>
+
+#include "types/Type.pb.h"
 
 namespace quickstep {
 
@@ -29,7 +32,7 @@ namespace quickstep {
  *
  * @note TypedValue assumes that this doesn't exceed 64 TypeIDs.
  **/
-enum TypeID {
+enum TypeID : std::uint8_t {
   kInt = 0,
   kLong,
   kFloat,
@@ -64,6 +67,10 @@ struct TypeSignature {
  * @note Defined out-of-line in TypeID.cpp
  **/
 extern const char *kTypeNames[kNumTypeIDs];
+
+extern TypeID DeserializeTypeID(const serialization::Type::TypeID type_id_proto);
+
+extern serialization::Type::TypeID SerializeTypeID(const TypeID type_id);
 
 }  // namespace quickstep
 


### PR DESCRIPTION
NOTE: deal with null values.

This PR optimizes hash repartition over a raw pointer, instead of `TypedValue`.

Experimental results show that repartition a `lineorder` from `SSB-100` on would reduce to `750 ms` from `1000 ms`.

Note that this PR added supports for the single partition attribute. For multi-attribute repartition, there are two basic approaches.
 1. like the single partition optimization, combine per-column hash, and then set the bit vector for the result partition.
 1. per-tuple evaluation, w/o any extra buffer used in the above approach.

The first approach on the single partition attribute actually takes `1200 ms`, while the latter takes `850 ms`.