### PR TITLE
Add a cmake option to handle the Travis CI timeout problem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,8 @@ before_script:
            -D CMAKE_CXX_COMPILER=$CXX
            -D CMAKE_LINKER=$CLINKER
            -D USE_TCMALLOC=0
-           -D VECTOR_COPY_ELISION_LEVEL=$VECTOR_COPY_ELISION_LEVEL ..)
+           -D VECTOR_COPY_ELISION_LEVEL=$VECTOR_COPY_ELISION_LEVEL
+           -D ENABLE_COMPARISON_INLINE_EXPANSION=OFF ..)
 
 script:
   - ./lint_everything.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,20 @@ if (ENABLE_VECTOR_PREDICATE_SHORT_CIRCUIT)
   )
 endif()
 
+set(COMPARISON_INLINE_EXPANSION_MSG_LIST
+    "This option controls whether to enable inlined template expansion "
+    "of comparison predicates. WARNING: This option should only be "
+    "turned off for development use. Turning off this option will greatly "
+    "reduce Quickstep compile time but incur drastic performance degradation.")
+string(REPLACE ";" "" COMPARISON_INLINE_EXPANSION_MSG ${COMPARISON_INLINE_EXPANSION_MSG_LIST})
+option(ENABLE_COMPARISON_INLINE_EXPANSION ${COMPARISON_INLINE_EXPANSION_MSG} ON)
+if (ENABLE_COMPARISON_INLINE_EXPANSION)
+  set_property(
+    DIRECTORY
+    APPEND PROPERTY COMPILE_DEFINITIONS QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
+  )
+endif()
+
 option(ENABLE_NETWORK_CLI "Allows use of the network cli" OFF)
 option(ENABLE_DISTRIBUTED "Use the distributed version of Quickstep" OFF)
 

--- a/types/operations/comparisons/AsciiStringComparators-inl.hpp
+++ b/types/operations/comparisons/AsciiStringComparators-inl.hpp
@@ -46,6 +46,7 @@
 
 namespace quickstep {
 
+#ifdef QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 template <template <typename T> class ComparisonFunctor,
           bool left_nullable, bool left_null_terminated, bool left_longer,
           bool right_nullable, bool right_null_terminated, bool right_longer>
@@ -586,6 +587,7 @@ TypedValue AsciiStringUncheckedComparator<ComparisonFunctor,
 
   return new_value;
 }
+#endif  // QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 
 }  // namespace quickstep
 

--- a/types/operations/comparisons/AsciiStringComparators.hpp
+++ b/types/operations/comparisons/AsciiStringComparators.hpp
@@ -122,6 +122,7 @@ class AsciiStringUncheckedComparator : public UncheckedComparator {
                                0);
   }
 
+#ifdef QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
   TupleIdSequence* compareColumnVectors(
       const ColumnVector &left,
       const ColumnVector &right,
@@ -202,6 +203,7 @@ class AsciiStringUncheckedComparator : public UncheckedComparator {
   TypedValue accumulateColumnVector(
       const TypedValue &current,
       const ColumnVector &column_vector) const override;
+#endif  // QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 
  private:
   /**
@@ -248,6 +250,7 @@ class AsciiStringUncheckedComparator : public UncheckedComparator {
     }
   }
 
+#ifdef QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
   template <bool column_vector_on_left>
   TupleIdSequence* compareColumnVectorAndStaticValueHelper(
       const ColumnVector &column_vector,
@@ -271,6 +274,7 @@ class AsciiStringUncheckedComparator : public UncheckedComparator {
       const TupleIdSequence *filter,
       const TupleIdSequence *existence_bitmap) const;
 #endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
+#endif  // QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 
   template <bool arguments_in_order>
   inline bool compareDataPtrsHelper(const void *left, const void *right) const {

--- a/types/operations/comparisons/Comparison.cpp
+++ b/types/operations/comparisons/Comparison.cpp
@@ -33,8 +33,6 @@ TupleIdSequence* UncheckedComparator::compareColumnVectors(
     const ColumnVector &right,
     const TupleIdSequence *filter,
     const TupleIdSequence *existence_bitmap) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareColumnVectors()");
   return compareColumnVectorsDefaultImpl<true, true>(
       left, right, filter, existence_bitmap);
 }
@@ -44,8 +42,6 @@ TupleIdSequence* UncheckedComparator::compareColumnVectorAndStaticValue(
     const TypedValue &right,
     const TupleIdSequence *filter,
     const TupleIdSequence *existence_bitmap) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareColumnVectorAndStaticValue()");
   return compareColumnVectorAndStaticValueDefaultImpl<true, true>(
       left, right, filter, existence_bitmap);
 }
@@ -55,8 +51,6 @@ TupleIdSequence* UncheckedComparator::compareStaticValueAndColumnVector(
     const ColumnVector &right,
     const TupleIdSequence *filter,
     const TupleIdSequence *existence_bitmap) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareStaticValueAndColumnVector()");
   return compareStaticValueAndColumnVectorDefaultImpl<true, true>(
       left, right, filter, existence_bitmap);
 }
@@ -67,8 +61,6 @@ TupleIdSequence* UncheckedComparator::compareSingleValueAccessor(
     const attribute_id left_id,
     const attribute_id right_id,
     const TupleIdSequence *filter) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareSingleValueAccessor()");
   return compareSingleValueAccessorDefaultImpl<true, true>(
       accessor, left_id, right_id, filter);
 }
@@ -78,8 +70,6 @@ TupleIdSequence* UncheckedComparator::compareValueAccessorAndStaticValue(
     const attribute_id left_id,
     const TypedValue &right,
     const TupleIdSequence *filter) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareValueAccessorAndStaticValue()");
   return compareValueAccessorAndStaticValueDefaultImpl<true, true>(
       left_accessor, left_id, right, filter);
 }
@@ -89,8 +79,6 @@ TupleIdSequence* UncheckedComparator::compareStaticValueAndValueAccessor(
     ValueAccessor *right_accessor,
     const attribute_id right_id,
     const TupleIdSequence *filter) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareStaticValueAndValueAccessor()");
   return compareStaticValueAndValueAccessorDefaultImpl<true, true>(
       left, right_accessor, right_id, filter);
 }
@@ -101,8 +89,6 @@ TupleIdSequence* UncheckedComparator::compareColumnVectorAndValueAccessor(
     const attribute_id right_id,
     const TupleIdSequence *filter,
     const TupleIdSequence *existence_bitmap) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareColumnVectorAndValueAccessor()");
   return compareColumnVectorAndValueAccessorDefaultImpl<true, true>(
       left, right_accessor, right_id, filter, existence_bitmap);
 }
@@ -113,8 +99,6 @@ TupleIdSequence* UncheckedComparator::compareValueAccessorAndColumnVector(
     const ColumnVector &right,
     const TupleIdSequence *filter,
     const TupleIdSequence *existence_bitmap) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::compareValueAccessorAndColumnVector()");
   return compareValueAccessorAndColumnVectorDefaultImpl<true, true>(
       left_accessor, left_id, right, filter, existence_bitmap);
 }
@@ -123,8 +107,6 @@ TypedValue UncheckedComparator::accumulateValueAccessor(
     const TypedValue &current,
     ValueAccessor *accessor,
     const attribute_id value_accessor_id) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::accumulateValueAccessor()");
   return accumulateValueAccessorDefaultImpl<true>(
       current, accessor, value_accessor_id);
 }
@@ -133,8 +115,6 @@ TypedValue UncheckedComparator::accumulateValueAccessor(
 TypedValue UncheckedComparator::accumulateColumnVector(
     const TypedValue &current,
     const ColumnVector &column_vector) const {
-  DEV_WARNING("Using fallback non-specialized implementation of "
-              "UncheckedComparator::accumulateColumnVector()");
   return accumulateColumnVectorDefaultImpl<true>(current, column_vector);
 }
 

--- a/types/operations/comparisons/LiteralComparators-inl.hpp
+++ b/types/operations/comparisons/LiteralComparators-inl.hpp
@@ -46,6 +46,7 @@
 
 namespace quickstep {
 
+#ifdef QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 template <template <typename LeftArgument, typename RightArgument> class ComparisonFunctor,
           typename LeftCppType, bool left_nullable,
           typename RightCppType, bool right_nullable>
@@ -662,6 +663,7 @@ TypedValue LiteralUncheckedComparator<ComparisonFunctor,
     return TypedValue(current.getTypeID());
   }
 }
+#endif  // QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 
 }  // namespace quickstep
 

--- a/types/operations/comparisons/LiteralComparators.hpp
+++ b/types/operations/comparisons/LiteralComparators.hpp
@@ -143,6 +143,7 @@ class LiteralUncheckedComparator : public UncheckedComparator {
                                right.getLiteral<RightCppType>());
   }
 
+#ifdef QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
   TupleIdSequence* compareColumnVectors(
       const ColumnVector &left,
       const ColumnVector &right,
@@ -223,8 +224,10 @@ class LiteralUncheckedComparator : public UncheckedComparator {
   TypedValue accumulateColumnVector(
       const TypedValue &current,
       const ColumnVector &column_vector) const override;
+#endif  // QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 
  private:
+#ifdef QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
   template <bool column_vector_on_left>
   TupleIdSequence* compareColumnVectorAndStaticValueHelper(
       const ColumnVector &column_vector,
@@ -248,6 +251,7 @@ class LiteralUncheckedComparator : public UncheckedComparator {
       const TupleIdSequence *filter,
       const TupleIdSequence *existence_bitmap) const;
 #endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
+#endif  // QUICKSTEP_ENABLE_COMPARISON_INLINE_EXPANSION
 
   template <bool arguments_in_order>
   inline bool compareDataPtrsHelper(const void *left, const void *right) const {


### PR DESCRIPTION
This PR adds a cmake option `ENABLE_COMPARISON_INLINE_EXPANSION` to allow disabling of method specialization in various `Comparison`'s.

Turing the flag `OFF` will greatly reduce Quickstep compile time -- thus improving development productivity as well as fixing the Travis CI timeout problem. Note that the flag is by default `ON`, and will be [turned off](https://github.com/apache/incubator-quickstep/blob/539e1ebe09b5d1a2d86069ed1fdc6e9fb38c5ce7/.travis.yml#L80) during the Travis test.