### PR TITLE
Quickstep-119: Added the rule that eliminates a node w/ an empty table.

### DIFF
--- a/cli/tests/CMakeLists.txt
+++ b/cli/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(quickstep_cli_tests_CommandExecutorTest
                       gtest
                       quickstep_catalog_CatalogDatabase
                       quickstep_cli_CommandExecutor
+                      quickstep_cli_DefaultsConfigurator
                       quickstep_cli_DropRelation
                       quickstep_cli_PrintToScreen
                       quickstep_parser_ParseStatement
@@ -59,10 +60,9 @@ target_link_libraries(quickstep_cli_tests_CommandExecutorTest
                       quickstep_queryexecution_QueryExecutionUtil
                       quickstep_queryexecution_Worker
                       quickstep_queryexecution_WorkerDirectory
-                      quickstep_queryoptimizer_Optimizer
-                      quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_QueryHandle
-                      quickstep_queryoptimizer_tests_TestDatabaseLoader
+                      quickstep_queryoptimizer_QueryProcessor
+                      quickstep_storage_StorageConstants
                       quickstep_utility_Macros
                       quickstep_utility_MemStream
                       quickstep_utility_SqlError

--- a/cli/tests/CommandExecutorTest.cpp
+++ b/cli/tests/CommandExecutorTest.cpp
@@ -45,8 +45,6 @@ int main(int argc, char** argv) {
           new quickstep::CommandExecutorTestRunner(argv[3]));
   test_driver.reset(
       new quickstep::TextBasedTestDriver(&input_file, test_runner.get()));
-  test_driver->registerOption(
-      quickstep::CommandExecutorTestRunner::kResetOption);
 
   ::testing::InitGoogleTest(&argc, argv);
   const int success = RUN_ALL_TESTS();

--- a/cli/tests/command_executor/Analyze.test
+++ b/cli/tests/command_executor/Analyze.test
@@ -1,0 +1,136 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CREATE TABLE r (src INT, dst INT);
+CREATE TABLE s (src INT, dst INT);
+CREATE TABLE t (src INT, dst INT);
+
+INSERT INTO s VALUES(0, 0);
+INSERT INTO s VALUES(1, 5);
+
+INSERT INTO t VALUES(0, 0);
+INSERT INTO t VALUES(0, 0);
+--
+==
+
+\analyze
+--
+Analyzing r ... done
+Analyzing s ... done
+Analyzing t ... done
+==
+
+SELECT r.src, r.dst FROM r;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
++-----------+-----------+
+==
+
+# One side of InnerJoin is empty.
+SELECT r.src, r.dst
+FROM r, t
+WHERE r.src = t.src AND r.dst = t.dst;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
++-----------+-----------+
+==
+
+# One side of LeftSemiJoin is empty.
+SELECT s.src, s.dst
+FROM s
+WHERE EXISTS(
+    SELECT r.src, r.dst FROM r WHERE s.src=r.src AND s.dst=r.dst);
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
++-----------+-----------+
+==
+
+# One side of LeftAntiJoin is empty.
+SELECT s.src, s.dst
+FROM s
+WHERE NOT EXISTS(
+    SELECT r.src, r.dst FROM r WHERE s.src=r.src AND s.dst=r.dst);
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
+|          0|          0|
+|          1|          5|
++-----------+-----------+
+==
+
+# Union between an empty relation and a non-empty.
+SELECT r.src, r.dst FROM r
+UNION
+SELECT t.src, t.dst FROM t;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
+|          0|          0|
++-----------+-----------+
+==
+
+# Union All between an empty relation and a non-empty.
+SELECT r.src, r.dst FROM r
+UNION ALL
+SELECT t.src, t.dst FROM t;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
+|          0|          0|
+|          0|          0|
++-----------+-----------+
+==
+
+# Union on two InnerJoins, one of which involves an empty relation.
+SELECT r.src, r.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
+UNION
+SELECT s.src, s.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
+|          0|          0|
++-----------+-----------+
+==
+
+# Union All on two InnerJoins, one of which involves an empty relation.
+SELECT r.src, r.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
+UNION ALL
+SELECT s.src, s.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
+|          0|          0|
+|          0|          0|
++-----------+-----------+
+==
+
+DROP TABLE r;
+DROP TABLE s;
+DROP TABLE t;
+--
+==

--- a/cli/tests/command_executor/CMakeLists.txt
+++ b/cli/tests/command_executor/CMakeLists.txt
@@ -15,6 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+add_test(quickstep_cli_tests_commandexecutor_analyze
+         "../quickstep_cli_tests_CommandExecutorTest"
+         "${CMAKE_CURRENT_SOURCE_DIR}/Analyze.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/Analyze.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/Analyze/")
 add_test(quickstep_cli_tests_commandexecutor_d
          "../quickstep_cli_tests_CommandExecutorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/D.test"
@@ -41,6 +46,7 @@ endif(ENABLE_DISTRIBUTED)
 
 # Create the folders where the unit tests will store their data blocks for the
 # duration of their test.
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Analyze)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/D)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Dt)
 

--- a/cli/tests/command_executor/D.test
+++ b/cli/tests/command_executor/D.test
@@ -44,7 +44,6 @@ PARTITION BY HASH(col1) PARTITIONS 4;
 INSERT INTO foo_hash_part
 SELECT i, i * 3.0 FROM generate_series(1, 100) AS gs(i);
 CREATE TABLE averylongtablenamethatseemstoneverend (col1 INT);
-DROP TABLE TEST;
 INSERT INTO averylongtablenamethatseemstoneverend VALUES (1);
 INSERT INTO averylongtablenamethatseemstoneverend VALUES (2);
 INSERT INTO averylongtablenamethatseemstoneverend VALUES (3);

--- a/cli/tests/command_executor/Dt.test
+++ b/cli/tests/command_executor/Dt.test
@@ -35,7 +35,6 @@ CREATE TABLE foo4 (col1 INT,
                    col3 DOUBLE,
                    col4 FLOAT,
                    col5 CHAR(5));
-DROP TABLE TEST;
 CREATE TABLE averylongtablenamethatseemstoneverend (col1 INT);
 INSERT INTO averylongtablenamethatseemstoneverend VALUES (1);
 INSERT INTO averylongtablenamethatseemstoneverend VALUES (2);

--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -226,6 +226,7 @@ target_link_libraries(quickstep_queryoptimizer_PhysicalGenerator
                       quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_rules_AttachLIPFilters
                       quickstep_queryoptimizer_rules_CollapseSelection
+                      quickstep_queryoptimizer_rules_EliminateEmptyNode
                       quickstep_queryoptimizer_rules_ExtractCommonSubexpression
                       quickstep_queryoptimizer_rules_FuseAggregateJoin
                       quickstep_queryoptimizer_rules_FuseHashSelect

--- a/query_optimizer/Optimizer.cpp
+++ b/query_optimizer/Optimizer.cpp
@@ -37,7 +37,8 @@ void Optimizer::generateQueryHandle(const ParseStatement &parse_statement,
 
   execution_generator.generatePlan(
       physical_generator.generatePlan(
-          logical_generator.generatePlan(*catalog_database, parse_statement)));
+          logical_generator.generatePlan(*catalog_database, parse_statement),
+          catalog_database));
 }
 
 void Optimizer::findReferencedBaseRelations(const ParseStatement &parse_statement,

--- a/query_optimizer/PhysicalGenerator.hpp
+++ b/query_optimizer/PhysicalGenerator.hpp
@@ -31,6 +31,9 @@
 #include "utility/Macros.hpp"
 
 namespace quickstep {
+
+class CatalogDatabase;
+
 namespace optimizer {
 
 class OptimizerContext;
@@ -68,9 +71,11 @@ class PhysicalGenerator : public LogicalToPhysicalMapper {
    * @brief Generates and optimizes a physical plan for \p logical_plan.
    *
    * @param logical_plan The logical plan to be converted to a physical plan.
+   * @param catalog_database The catalog database where this query is executed.
    * @return The physical plan.
    */
-  physical::PhysicalPtr generatePlan(const logical::LogicalPtr &logical_plan);
+  physical::PhysicalPtr generatePlan(const logical::LogicalPtr &logical_plan,
+                                     CatalogDatabase *catalog_database);
 
   /**
    * @brief Sets the best physical plan for \p logical_plan is \p physical_plan.
@@ -106,9 +111,10 @@ class PhysicalGenerator : public LogicalToPhysicalMapper {
   /**
    * @brief Applies physical rules to the initial physical plan.
    *
+   * @param catalog_database The catalog database where this query is executed.
    * @return The optimized physical plan.
    */
-  physical::PhysicalPtr optimizePlan();
+  physical::PhysicalPtr optimizePlan(CatalogDatabase *catalog_database);
 
   std::vector<std::unique_ptr<strategy::Strategy>> strategies_;
 

--- a/query_optimizer/physical/Aggregate.hpp
+++ b/query_optimizer/physical/Aggregate.hpp
@@ -103,6 +103,9 @@ class Aggregate : public Physical {
                   has_repartition, partition_scheme_header);
   }
 
+  PhysicalPtr copyWithNewProjectExpressions(
+      const std::vector<expressions::NamedExpressionPtr> &output_expressions) const override;
+
   bool maybeCopyWithPrunedExpressions(
       const expressions::UnorderedNamedExpressionSet &referenced_expressions,
       PhysicalPtr *output) const override {

--- a/query_optimizer/physical/CMakeLists.txt
+++ b/query_optimizer/physical/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(quickstep_queryoptimizer_physical_Aggregate
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
+                      quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_physical_PartitionSchemeHeader
                       quickstep_queryoptimizer_physical_Physical
@@ -220,6 +221,7 @@ target_link_libraries(quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
+                      quickstep_queryoptimizer_expressions_NamedExpression
                       quickstep_queryoptimizer_physical_PartitionSchemeHeader
                       quickstep_queryoptimizer_physical_PhysicalType
                       quickstep_utility_Macros)

--- a/query_optimizer/physical/HashJoin.cpp
+++ b/query_optimizer/physical/HashJoin.cpp
@@ -34,6 +34,8 @@ namespace quickstep {
 namespace optimizer {
 namespace physical {
 
+namespace E = ::quickstep::optimizer::expressions;
+
 std::vector<expressions::AttributeReferencePtr> HashJoin::getReferencedAttributes() const {
   std::vector<expressions::AttributeReferencePtr> referenced_attributes;
   for (const expressions::NamedExpressionPtr &project_expression :
@@ -65,6 +67,14 @@ std::vector<expressions::AttributeReferencePtr> HashJoin::getReferencedAttribute
                                  referenced_attributes_in_build.end());
   }
   return referenced_attributes;
+}
+
+PhysicalPtr HashJoin::copyWithNewProjectExpressions(
+    const std::vector<E::NamedExpressionPtr> &output_expressions) const {
+  DCHECK_EQ(project_expressions().size(), output_expressions.size());
+
+  return Create(left(), right(), left_join_attributes_, right_join_attributes_,
+                residual_predicate_, build_predicate_, output_expressions, join_type_);
 }
 
 bool HashJoin::maybeCopyWithPrunedExpressions(

--- a/query_optimizer/physical/HashJoin.hpp
+++ b/query_optimizer/physical/HashJoin.hpp
@@ -141,6 +141,9 @@ class HashJoin : public BinaryJoin {
                   has_repartition, partition_scheme_header);
   }
 
+  PhysicalPtr copyWithNewProjectExpressions(
+      const std::vector<expressions::NamedExpressionPtr> &output_expressions) const override;
+
   bool maybeCopyWithPrunedExpressions(
       const expressions::UnorderedNamedExpressionSet &referenced_expressions,
       PhysicalPtr *output) const override;

--- a/query_optimizer/physical/NestedLoopsJoin.cpp
+++ b/query_optimizer/physical/NestedLoopsJoin.cpp
@@ -31,6 +31,8 @@ namespace quickstep {
 namespace optimizer {
 namespace physical {
 
+namespace E = ::quickstep::optimizer::expressions;
+
 std::vector<expressions::AttributeReferencePtr> NestedLoopsJoin::getReferencedAttributes() const {
   std::vector<expressions::AttributeReferencePtr> referenced_attributes;
   for (const expressions::NamedExpressionPtr &project_expression :
@@ -47,6 +49,13 @@ std::vector<expressions::AttributeReferencePtr> NestedLoopsJoin::getReferencedAt
                                referenced_attributes_in_predicate.begin(),
                                referenced_attributes_in_predicate.end());
   return referenced_attributes;
+}
+
+PhysicalPtr NestedLoopsJoin::copyWithNewProjectExpressions(
+    const std::vector<E::NamedExpressionPtr> &output_expressions) const {
+  DCHECK_EQ(project_expressions().size(), output_expressions.size());
+
+  return Create(left(), right(), join_predicate_, output_expressions);
 }
 
 bool NestedLoopsJoin::maybeCopyWithPrunedExpressions(

--- a/query_optimizer/physical/NestedLoopsJoin.hpp
+++ b/query_optimizer/physical/NestedLoopsJoin.hpp
@@ -81,6 +81,9 @@ class NestedLoopsJoin : public BinaryJoin {
 
   std::vector<expressions::AttributeReferencePtr> getReferencedAttributes() const override;
 
+  PhysicalPtr copyWithNewProjectExpressions(
+      const std::vector<expressions::NamedExpressionPtr> &output_expressions) const override;
+
   bool maybeCopyWithPrunedExpressions(
       const expressions::UnorderedNamedExpressionSet &referenced_expressions,
       PhysicalPtr *output) const override;

--- a/query_optimizer/physical/PatternMatcher.hpp
+++ b/query_optimizer/physical/PatternMatcher.hpp
@@ -46,6 +46,7 @@ class SharedSubplanReference;
 class Sort;
 class TableReference;
 class TopLevelPlan;
+class UnionAll;
 class UpdateTable;
 
 /** \addtogroup OptimizerPhysical
@@ -127,6 +128,7 @@ using SomeSharedSubplanReference = SomePhysicalNode<SharedSubplanReference, Phys
 using SomeSort = SomePhysicalNode<Sort, PhysicalType::kSort>;
 using SomeTableReference = SomePhysicalNode<TableReference, PhysicalType::kTableReference>;
 using SomeTopLevelPlan = SomePhysicalNode<TopLevelPlan, PhysicalType::kTopLevelPlan>;
+using SomeUnionAll = SomePhysicalNode<UnionAll, PhysicalType::kUnionAll>;
 using SomeUpdateTable = SomePhysicalNode<UpdateTable, PhysicalType::kUpdateTable>;
 
 /** @} */

--- a/query_optimizer/physical/Physical.hpp
+++ b/query_optimizer/physical/Physical.hpp
@@ -26,6 +26,7 @@
 #include "query_optimizer/OptimizerTree.hpp"
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/ExpressionUtil.hpp"
+#include "query_optimizer/expressions/NamedExpression.hpp"
 #include "query_optimizer/physical/PartitionSchemeHeader.hpp"
 #include "query_optimizer/physical/PhysicalType.hpp"
 #include "utility/Macros.hpp"
@@ -105,6 +106,11 @@ class Physical : public OptimizerTree<Physical> {
       const bool has_repartition = true) const {
     std::unique_ptr<PartitionSchemeHeader> new_partition_scheme_header(partition_scheme_header);
     LOG(FATAL) << "copyWithNewOutputPartitionSchemeHeader is not implemented for " << getName();
+  }
+
+  virtual PhysicalPtr copyWithNewProjectExpressions(
+      const std::vector<expressions::NamedExpressionPtr> &output_expressions) const {
+    LOG(FATAL) << "copyWithNewProjectExpressions is not implemented for " << getName();
   }
 
   /**

--- a/query_optimizer/physical/Selection.cpp
+++ b/query_optimizer/physical/Selection.cpp
@@ -72,6 +72,13 @@ std::vector<E::AttributeReferencePtr> Selection::getReferencedAttributes() const
   return referenced_attributes;
 }
 
+PhysicalPtr Selection::copyWithNewProjectExpressions(
+    const std::vector<E::NamedExpressionPtr> &output_expressions) const {
+  DCHECK_EQ(project_expressions_.size(), output_expressions.size());
+
+  return Create(input(), output_expressions, filter_predicate_);
+}
+
 bool Selection::maybeCopyWithPrunedExpressions(
     const E::UnorderedNamedExpressionSet &referenced_attributes,
     PhysicalPtr *output) const {

--- a/query_optimizer/physical/Selection.hpp
+++ b/query_optimizer/physical/Selection.hpp
@@ -91,6 +91,9 @@ class Selection : public Physical {
                   has_repartition, partition_scheme_header);
   }
 
+  PhysicalPtr copyWithNewProjectExpressions(
+      const std::vector<expressions::NamedExpressionPtr> &output_expressions) const override;
+
   bool maybeCopyWithPrunedExpressions(
       const expressions::UnorderedNamedExpressionSet &referenced_attributes,
       PhysicalPtr *output) const override;

--- a/query_optimizer/physical/UnionAll.hpp
+++ b/query_optimizer/physical/UnionAll.hpp
@@ -132,6 +132,10 @@ class UnionAll : public Physical {
     return true;
   }
 
+  const std::vector<expressions::AttributeReferencePtr>& project_attributes() const {
+    return project_attributes_;
+  }
+
   /**
    * @brief Creates the physical node of UnionAll.
    *

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(quickstep_queryoptimizer_rules_AttachLIPFilters AttachLIPFilters.cpp
 add_library(quickstep_queryoptimizer_rules_BottomUpRule ../../empty_src.cpp BottomUpRule.hpp)
 add_library(quickstep_queryoptimizer_rules_CollapseProject CollapseProject.cpp CollapseProject.hpp)
 add_library(quickstep_queryoptimizer_rules_CollapseSelection CollapseSelection.cpp CollapseSelection.hpp)
+add_library(quickstep_queryoptimizer_rules_EliminateEmptyNode EliminateEmptyNode.cpp EliminateEmptyNode.hpp)
 add_library(quickstep_queryoptimizer_rules_ExtractCommonSubexpression
             ExtractCommonSubexpression.cpp
             ExtractCommonSubexpression.hpp)
@@ -100,6 +101,28 @@ target_link_libraries(quickstep_queryoptimizer_rules_CollapseSelection
                       quickstep_queryoptimizer_physical_Selection
                       quickstep_queryoptimizer_rules_BottomUpRule
                       quickstep_queryoptimizer_rules_RuleHelper
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_queryoptimizer_rules_EliminateEmptyNode
+                      quickstep_catalog_CatalogAttribute
+                      quickstep_catalog_CatalogDatabase
+                      quickstep_catalog_CatalogRelation
+                      quickstep_catalog_CatalogRelationStatistics
+                      quickstep_queryoptimizer_OptimizerContext
+                      quickstep_queryoptimizer_expressions_Alias
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExpressionUtil
+                      quickstep_queryoptimizer_expressions_NamedExpression
+                      quickstep_queryoptimizer_expressions_PatternMatcher
+                      quickstep_queryoptimizer_physical_Aggregate
+                      quickstep_queryoptimizer_physical_HashJoin
+                      quickstep_queryoptimizer_physical_PatternMatcher
+                      quickstep_queryoptimizer_physical_Physical
+                      quickstep_queryoptimizer_physical_PhysicalType
+                      quickstep_queryoptimizer_physical_Selection
+                      quickstep_queryoptimizer_physical_TableReference
+                      quickstep_queryoptimizer_physical_TopLevelPlan
+                      quickstep_queryoptimizer_physical_UnionAll
+                      quickstep_queryoptimizer_rules_Rule
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_ExtractCommonSubexpression
                       glog
@@ -434,6 +457,7 @@ target_link_libraries(quickstep_queryoptimizer_rules
                       quickstep_queryoptimizer_rules_BottomUpRule
                       quickstep_queryoptimizer_rules_CollapseProject
                       quickstep_queryoptimizer_rules_CollapseSelection
+                      quickstep_queryoptimizer_rules_EliminateEmptyNode
                       quickstep_queryoptimizer_rules_ExtractCommonSubexpression
                       quickstep_queryoptimizer_rules_FuseAggregateJoin
                       quickstep_queryoptimizer_rules_FuseHashSelect

--- a/query_optimizer/rules/EliminateEmptyNode.cpp
+++ b/query_optimizer/rules/EliminateEmptyNode.cpp
@@ -1,0 +1,358 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#include "query_optimizer/rules/EliminateEmptyNode.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "catalog/CatalogAttribute.hpp"
+#include "catalog/CatalogDatabase.hpp"
+#include "catalog/CatalogRelation.hpp"
+#include "catalog/CatalogRelationStatistics.hpp"
+#include "query_optimizer/OptimizerContext.hpp"
+#include "query_optimizer/expressions/Alias.hpp"
+#include "query_optimizer/expressions/AttributeReference.hpp"
+#include "query_optimizer/expressions/ExpressionUtil.hpp"
+#include "query_optimizer/expressions/NamedExpression.hpp"
+#include "query_optimizer/expressions/PatternMatcher.hpp"
+#include "query_optimizer/physical/Aggregate.hpp"
+#include "query_optimizer/physical/HashJoin.hpp"
+#include "query_optimizer/physical/PatternMatcher.hpp"
+#include "query_optimizer/physical/Physical.hpp"
+#include "query_optimizer/physical/PhysicalType.hpp"
+#include "query_optimizer/physical/Selection.hpp"
+#include "query_optimizer/physical/TableReference.hpp"
+#include "query_optimizer/physical/TopLevelPlan.hpp"
+#include "query_optimizer/physical/UnionAll.hpp"
+
+#include "glog/logging.h"
+
+namespace quickstep {
+namespace optimizer {
+
+namespace E = expressions;
+namespace P = physical;
+
+namespace {
+
+std::string GetNewRelationName(const std::size_t id) {
+  std::ostringstream out;
+  out << OptimizerContext::kInternalTemporaryRelationNamePrefix << id;
+  return out.str();
+}
+
+bool IsTableReferenceOnEmptyRelation(const P::PhysicalPtr &node) {
+  P::TableReferencePtr table_reference;
+  if (!P::SomeTableReference::MatchesWithConditionalCast(node, &table_reference)) {
+    return false;
+  }
+
+  const CatalogRelationStatistics &stat = table_reference->relation()->getStatistics();
+  return stat.isExact() && (stat.getNumTuples() == 0u);
+}
+
+P::PhysicalPtr ApplyToHashJoin(const P::HashJoinPtr &hash_join) {
+  const P::PhysicalPtr &left = hash_join->left();
+  if (IsTableReferenceOnEmptyRelation(left)) {
+    return nullptr;
+  }
+
+  const P::PhysicalPtr &right = hash_join->right();
+  switch (hash_join->join_type()) {
+    case P::HashJoin::JoinType::kInnerJoin:
+    case P::HashJoin::JoinType::kLeftSemiJoin:
+      if (IsTableReferenceOnEmptyRelation(right)) {
+        return nullptr;
+      }
+      break;
+    case P::HashJoin::JoinType::kLeftAntiJoin: {
+      const auto &project_expressions = hash_join->project_expressions();
+#ifdef QUICKSTEP_DEBUG
+      const auto left_output_attributes = left->getOutputAttributes();
+      if (!E::SubsetOfExpressions(project_expressions, left_output_attributes)) {
+        std::vector<E::NamedExpressionPtr> non_alias_expressions, alias_expressions;
+        for (const auto &project_expression : project_expressions) {
+          if (E::SomeAlias::Matches(project_expression)) {
+            for (const auto referenced_attribute : project_expression->getReferencedAttributes()) {
+              alias_expressions.push_back(referenced_attribute);
+            }
+          } else {
+            non_alias_expressions.push_back(project_expression);
+          }
+        }
+
+        CHECK(E::SubsetOfExpressions(non_alias_expressions, left_output_attributes));
+        CHECK(E::SubsetOfExpressions(alias_expressions, left_output_attributes));
+      }
+#endif
+
+      if (IsTableReferenceOnEmptyRelation(right)) {
+        if (hash_join->residual_predicate()) {
+          return nullptr;
+        }
+        return P::Selection::Create(left, project_expressions, nullptr);
+      }
+      break;
+    }
+    case P::HashJoin::JoinType::kLeftOuterJoin:
+      if (IsTableReferenceOnEmptyRelation(right)) {
+        if (hash_join->residual_predicate()) {
+          return nullptr;
+        }
+
+        const auto &project_expressions = hash_join->project_expressions();
+        if (E::SubsetOfExpressions(project_expressions, left->getOutputAttributes())) {
+          return P::Selection::Create(left, project_expressions, nullptr);
+        }
+      }
+      break;
+  }
+
+  return hash_join;
+}
+
+P::PhysicalPtr ApplyToNode(const P::PhysicalPtr &node) {
+  switch (node->getPhysicalType()) {
+    case P::PhysicalType::kHashJoin:
+      return ApplyToHashJoin(std::static_pointer_cast<const P::HashJoin>(node));
+    case P::PhysicalType::kTableReference:
+      if (IsTableReferenceOnEmptyRelation(node)) {
+        return nullptr;
+      }
+      break;
+    default:
+      break;
+  }
+
+  return node;
+}
+
+
+P::PhysicalPtr CopyWithNewProjectExpressions(const P::UnionAllPtr &union_all,
+                                             const P::PhysicalPtr &child) {
+  const auto &project_attributes = union_all->project_attributes();
+
+  std::vector<E::NamedExpressionPtr> alias_expressions;
+  P::AggregatePtr aggregate;
+  if (P::SomeAggregate::MatchesWithConditionalCast(child, &aggregate)) {
+    const auto &aggregate_expressions = aggregate->aggregate_expressions();
+    alias_expressions.reserve(aggregate_expressions.size());
+
+    int aid = 0;
+    for (const auto &project_attribute : project_attributes) {
+      const auto alias_referenced_attributes =
+          aggregate_expressions[aid]->getReferencedAttributes();
+      DCHECK_EQ(1u, alias_referenced_attributes.size());
+
+      alias_expressions.emplace_back(E::Alias::Create(
+          project_attribute->id(),
+          alias_referenced_attributes.front(),
+          project_attribute->attribute_name(),
+          project_attribute->attribute_alias(),
+          project_attribute->relation_name()));
+      ++aid;
+    }
+  } else {
+    const auto child_output_attributes = child->getOutputAttributes();
+    alias_expressions.reserve(child_output_attributes.size());
+
+    int aid = 0;
+    for (const auto &project_attribute : project_attributes) {
+      alias_expressions.emplace_back(E::Alias::Create(
+          project_attribute->id(),
+          child_output_attributes[aid],
+          project_attribute->attribute_name(),
+          project_attribute->attribute_alias(),
+          project_attribute->relation_name()));
+      ++aid;
+    }
+  }
+
+  return child->copyWithNewProjectExpressions(alias_expressions);
+}
+
+// TopDown approach.
+P::PhysicalPtr Apply(const P::PhysicalPtr &node) {
+  DCHECK(node);
+
+  const auto new_node = ApplyToNode(node);
+  if (new_node == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<P::PhysicalPtr> new_children;
+  bool has_changed_children = false;
+  for (const auto &child : new_node->children()) {
+    const auto new_child = Apply(child);
+    if (new_child == nullptr) {
+      if (P::SomeUnionAll::Matches(node)) {
+        has_changed_children = true;
+        continue;
+      }
+
+      return nullptr;
+    } else if (child != new_child && !has_changed_children) {
+      has_changed_children = true;
+    }
+    new_children.push_back(new_child);
+  }
+
+  if (has_changed_children) {
+    if (P::SomeUnionAll::Matches(node)) {
+      switch (new_children.size()) {
+        case 0u:
+          return nullptr;
+        case 1u:
+          return CopyWithNewProjectExpressions(
+              std::static_pointer_cast<const P::UnionAll>(node), new_children.front());
+        default:
+          break;
+      }
+    }
+
+    DCHECK(!new_children.empty());
+    return new_node->copyWithNewChildren(new_children);
+  } else {
+    return new_node;
+  }
+}
+
+}  // namespace
+
+P::PhysicalPtr EliminateEmptyNode::apply(const P::PhysicalPtr &input) {
+  DCHECK(P::SomeTopLevelPlan::Matches(input));
+  const P::TopLevelPlanPtr &top_level_plan =
+      std::static_pointer_cast<const P::TopLevelPlan>(input);
+
+  // TODO(quickstep-team): handle subquery.
+  if (!top_level_plan->shared_subplans().empty()) {
+    return input;
+  }
+
+  const auto &plan = top_level_plan->plan();
+
+  P::SelectionPtr selection;
+  if (P::SomeSelection::MatchesWithConditionalCast(plan, &selection) &&
+      P::SomeTableReference::Matches(selection->input())) {
+    return input;
+  }
+
+  const P::PhysicalType plan_type = plan->getPhysicalType();
+  std::vector<E::AttributeReferencePtr> project_expressions;
+  switch (plan_type) {
+    case P::PhysicalType::kAggregate:
+    case P::PhysicalType::kCrossReferenceCoalesceAggregate:
+    case P::PhysicalType::kFilterJoin:
+    case P::PhysicalType::kHashJoin:
+    case P::PhysicalType::kNestedLoopsJoin:
+    case P::PhysicalType::kSample:
+    case P::PhysicalType::kSelection:
+    case P::PhysicalType::kSort:
+    case P::PhysicalType::kUnionAll:
+    case P::PhysicalType::kWindowAggregate:
+      project_expressions = plan->getOutputAttributes();
+      break;
+    case P::PhysicalType::kCopyTo:
+    case P::PhysicalType::kInsertSelection:
+      project_expressions = plan->getReferencedAttributes();
+      break;
+    case P::PhysicalType::kCopyFrom:
+    case P::PhysicalType::kCreateIndex:
+    case P::PhysicalType::kCreateTable:
+    case P::PhysicalType::kDeleteTuples:
+    case P::PhysicalType::kDropTable:
+    case P::PhysicalType::kInsertTuple:
+    case P::PhysicalType::kSharedSubplanReference:
+    case P::PhysicalType::kTableGenerator:
+    case P::PhysicalType::kUpdateTable:
+      // TODO(quickstep-team): revisit the cases above.
+      return input;
+    case P::PhysicalType::kTableReference:
+    case P::PhysicalType::kTopLevelPlan:
+      LOG(FATAL) << "Unexpected PhysicalType.";
+  }
+  DCHECK(!project_expressions.empty());
+
+  auto output = Apply(plan);
+  if (output == plan) {
+    return input;
+  }
+
+  if (output) {
+    return input->copyWithNewChildren({output});
+  }
+
+  auto catalog_relation = std::make_unique<CatalogRelation>(
+      catalog_database_, GetNewRelationName(catalog_database_->size()), -1, true);
+
+  attribute_id aid = 0;
+  std::unordered_set<std::string> relation_name_alias;
+  for (const auto &project_expression : project_expressions) {
+    // The attribute name is simply set to the attribute id to make it distinct.
+    auto catalog_attribute = std::make_unique<CatalogAttribute>(
+        catalog_relation.get(), project_expression->attribute_name(),
+        project_expression->getValueType(), aid,
+        project_expression->attribute_alias());
+    catalog_relation->addAttribute(catalog_attribute.release());
+    ++aid;
+
+    relation_name_alias.insert(project_expression->relation_name());
+  }
+
+  // TODO(quickstep-team): use Nop physical node.
+  const auto temp_table =
+      P::TableReference::Create(catalog_relation.get(),
+                                relation_name_alias.size() == 1u ? *relation_name_alias.begin() : "",
+                                project_expressions);
+  catalog_database_->addRelation(catalog_relation.release());
+
+  switch (plan_type) {
+    case P::PhysicalType::kAggregate:
+    case P::PhysicalType::kCrossReferenceCoalesceAggregate:
+    case P::PhysicalType::kFilterJoin:
+    case P::PhysicalType::kHashJoin:
+    case P::PhysicalType::kNestedLoopsJoin:
+    case P::PhysicalType::kSample:
+    case P::PhysicalType::kSelection:
+    case P::PhysicalType::kSort:
+    case P::PhysicalType::kUnionAll:
+    case P::PhysicalType::kWindowAggregate:
+      output = P::Selection::Create(temp_table, E::ToNamedExpressions(project_expressions), nullptr);
+      break;
+    case P::PhysicalType::kCopyTo:
+      output = plan->copyWithNewChildren({ temp_table });
+      break;
+    case P::PhysicalType::kInsertSelection:
+      output = plan->copyWithNewChildren({ plan->children().front(), temp_table });
+      break;
+    default:
+      LOG(FATAL) << "Unexpected PhysicalType.";
+  }
+
+  DCHECK(output);
+  return input->copyWithNewChildren({output});
+}
+
+}  // namespace optimizer
+}  // namespace quickstep

--- a/query_optimizer/rules/EliminateEmptyNode.hpp
+++ b/query_optimizer/rules/EliminateEmptyNode.hpp
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ **/
+
+#ifndef QUICKSTEP_QUERY_OPTIMIZER_RULES_ELIMINATE_EMPTY_NODE_HPP_
+#define QUICKSTEP_QUERY_OPTIMIZER_RULES_ELIMINATE_EMPTY_NODE_HPP_
+
+#include <string>
+
+#include "query_optimizer/physical/Physical.hpp"
+#include "query_optimizer/rules/Rule.hpp"
+#include "utility/Macros.hpp"
+
+namespace quickstep {
+
+class CatalogDatabase;
+
+namespace optimizer {
+
+/** \addtogroup OptimizerRules
+ *  @{
+ */
+
+/**
+ * @brief Rule that applies to a physical plan to eliminate a node with an empty
+ *        TableReference to a Selection on a temp table.
+ */
+class EliminateEmptyNode : public Rule<physical::Physical> {
+ public:
+  /**
+   * @brief Constructor.
+   */
+  explicit EliminateEmptyNode(CatalogDatabase *catalog_database)
+      : catalog_database_(catalog_database) {}
+
+  ~EliminateEmptyNode() override {}
+
+  std::string getName() const override {
+    return "EliminateEmptyNode";
+  }
+
+  physical::PhysicalPtr apply(const physical::PhysicalPtr &input) override;
+
+ private:
+  CatalogDatabase *catalog_database_;
+
+  DISALLOW_COPY_AND_ASSIGN(EliminateEmptyNode);
+};
+
+/** @} */
+
+}  // namespace optimizer
+}  // namespace quickstep
+
+#endif  // QUICKSTEP_QUERY_OPTIMIZER_RULES_ELIMINATE_EMPTY_NODE_HPP_

--- a/query_optimizer/tests/OptimizerTextTestRunner.cpp
+++ b/query_optimizer/tests/OptimizerTextTestRunner.cpp
@@ -129,7 +129,8 @@ physical::PhysicalPtr OptimizerTextTestRunner::generatePhysicalPlan(
     const logical::LogicalPtr &logical_plan,
     OptimizerContext *optimizer_context) {
   PhysicalGenerator physical_generator(optimizer_context);
-  return physical_generator.generatePlan(logical_plan);
+  return physical_generator.generatePlan(logical_plan,
+                                         test_database_loader_.catalog_database());
 }
 
 }  // namespace optimizer

--- a/query_optimizer/tests/TestDatabaseLoader.cpp
+++ b/query_optimizer/tests/TestDatabaseLoader.cpp
@@ -51,7 +51,7 @@ CatalogRelation *TestDatabaseLoader::createTestRelation(bool allow_vchar) {
   catalog_relation.reset(new CatalogRelation(&catalog_database_,
                                              "Test" /* name */,
                                              0 /* id */,
-                                             true /* temporary */));
+                                             false /* temporary */));
   int attr_id = -1;
   catalog_relation->addAttribute(new CatalogAttribute(catalog_relation.get(),
                                                       "int_col" /* name */,


### PR DESCRIPTION
This PR adds an optimization rule that eliminates a physical node with an empty (determined by stats) `TableReference` into a `Selection` on a temp table.