### PR TITLE
Fix all CMakeLists.txt for automated processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,8 +625,8 @@ include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIR})
 
 # Add gtest unit-testing framework.
 set(gtest_force_shared_crt ON CACHE BOOL "Link gtest against shared DLLs on Windows")
-add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/googletest/googletest"
-                  "${CMAKE_CURRENT_BINARY_DIR}/third_party/googletest/googletest")
+add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/googletest/googletest"
+                 "${CMAKE_CURRENT_BINARY_DIR}/third_party/googletest/googletest")
 include_directories(SYSTEM "${THIRD_PARTY_SOURCE_DIR}/googletest/googletest/include")
 enable_testing()
 
@@ -644,18 +644,18 @@ if (UNIX)
                     "itself, as well as unit tests and other utilities are "
                     "not affected.")
   endif()
-  add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/benchmark" "${CMAKE_CURRENT_BINARY_DIR}/third_party/benchmark")
+  add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/benchmark" "${CMAKE_CURRENT_BINARY_DIR}/third_party/benchmark")
   include_directories("${THIRD_PARTY_SOURCE_DIR}/benchmark/include")
 endif()
 
 # Add required cmake-controlled third-party libraries (farmhash, gflags, glog, and re2).
-add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/farmhash" "${CMAKE_CURRENT_BINARY_DIR}/third_party/farmhash")
+add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/farmhash" "${CMAKE_CURRENT_BINARY_DIR}/third_party/farmhash")
 include_directories("${THIRD_PARTY_SOURCE_DIR}")
 
-add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/gflags" "${CMAKE_CURRENT_BINARY_DIR}/third_party/gflags")
+add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/gflags" "${CMAKE_CURRENT_BINARY_DIR}/third_party/gflags")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/third_party/gflags/include")
 
-add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/glog" "${CMAKE_CURRENT_BINARY_DIR}/third_party/glog")
+add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/glog" "${CMAKE_CURRENT_BINARY_DIR}/third_party/glog")
 if (WIN32)
   set_property(
     DIRECTORY
@@ -668,7 +668,7 @@ else()
 endif()
 
 include_directories("${THIRD_PARTY_SOURCE_DIR}/re2")
-add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/re2" "${CMAKE_CURRENT_BINARY_DIR}/third_party/re2")
+add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/re2" "${CMAKE_CURRENT_BINARY_DIR}/third_party/re2")
 
 # Add optional linenoise command-line editing library.
 if (USE_LINENOISE)
@@ -679,7 +679,7 @@ if (USE_LINENOISE)
                     "to fail, in which case you should try again with "
                     "-D USE_LINENOISE=0")
   endif()
-  add_subdirectory ("${THIRD_PARTY_SOURCE_DIR}/linenoise" "${CMAKE_CURRENT_BINARY_DIR}/third_party/linenoise")
+  add_subdirectory("${THIRD_PARTY_SOURCE_DIR}/linenoise" "${CMAKE_CURRENT_BINARY_DIR}/third_party/linenoise")
 endif()
 
 # Add optional libhdfs3 library
@@ -735,7 +735,8 @@ add_subdirectory(utility)
 add_subdirectory(yarn)
 
 # Build the quickstep_cli_shell executable.
-add_executable (quickstep_cli_shell cli/QuickstepCli.cpp)
+add_executable(quickstep_cli_shell cli/QuickstepCli.cpp)
+
 # Link against direct deps (will transitively pull in everything needed).
 target_link_libraries(quickstep_cli_shell
                       ${GFLAGS_LIB_NAME}
@@ -783,12 +784,14 @@ target_link_libraries(quickstep_cli_shell ${LIBS})
 
 if (ENABLE_DISTRIBUTED)
   # Build the quickstep_distributed_cli_shell executable.
-  add_executable (quickstep_distributed_cli_shell
-                  cli/distributed/Cli.hpp
-                  cli/distributed/Cli.cpp
-                  cli/distributed/QuickstepDistributedCli.cpp)
+  add_executable(quickstep_distributed_cli_shell
+                 cli/distributed/Cli.hpp
+                 cli/distributed/Cli.cpp
+                 cli/distributed/QuickstepDistributedCli.cpp)
   # Link against direct deps (will transitively pull in everything needed).
   target_link_libraries(quickstep_distributed_cli_shell
+                        ${GFLAGS_LIB_NAME}
+                        ${GRPCPLUSPLUS_LIBRARIES}
                         glog
                         quickstep_catalog_CatalogRelation
                         quickstep_cli_Constants
@@ -811,13 +814,11 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_utility_Macros
                         quickstep_utility_SqlError
                         quickstep_utility_StringUtil
-                        tmb
-                        ${GFLAGS_LIB_NAME}
-                        ${GRPCPLUSPLUS_LIBRARIES})
+                        tmb)
 endif(ENABLE_DISTRIBUTED)
 
 if (ENABLE_NETWORK_CLI)
-  add_executable (quickstep_client cli/NetworkCliClientMain.cpp)
+  add_executable(quickstep_client cli/NetworkCliClientMain.cpp)
   target_link_libraries(quickstep_client
                         ${GFLAGS_LIB_NAME}
                         ${GRPCPLUSPLUS_LIBRARIES}

--- a/catalog/CMakeLists.txt
+++ b/catalog/CMakeLists.txt
@@ -28,7 +28,6 @@ QS_PROTOBUF_GENERATE_CPP(catalog_Catalog_proto_srcs catalog_Catalog_proto_hdrs C
 
 # Declare micro-libs:
 add_library(quickstep_catalog_Catalog Catalog.cpp Catalog.hpp)
-add_library(quickstep_catalog_Catalog_proto ${catalog_Catalog_proto_srcs})
 add_library(quickstep_catalog_CatalogAttribute CatalogAttribute.cpp CatalogAttribute.hpp)
 add_library(quickstep_catalog_CatalogDatabase CatalogDatabase.cpp CatalogDatabase.hpp)
 add_library(quickstep_catalog_CatalogDatabaseCache CatalogDatabaseCache.cpp CatalogDatabaseCache.hpp)
@@ -42,12 +41,14 @@ add_library(quickstep_catalog_CatalogRelationStatistics
             CatalogRelationStatistics.cpp
             CatalogRelationStatistics.hpp)
 add_library(quickstep_catalog_CatalogTypedefs ../empty_src.cpp CatalogTypedefs.hpp)
+add_library(quickstep_catalog_Catalog_proto ${catalog_Catalog_proto_srcs})
 add_library(quickstep_catalog_IndexScheme IndexScheme.cpp IndexScheme.hpp)
+add_library(quickstep_catalog_PartitionScheme PartitionScheme.cpp PartitionScheme.hpp)
+add_library(quickstep_catalog_PartitionSchemeHeader PartitionSchemeHeader.cpp PartitionSchemeHeader.hpp)
+
 if(QUICKSTEP_HAVE_LIBNUMA)
   add_library(quickstep_catalog_NUMAPlacementScheme NUMAPlacementScheme.cpp NUMAPlacementScheme.hpp)
 endif()
-add_library(quickstep_catalog_PartitionScheme PartitionScheme.cpp PartitionScheme.hpp)
-add_library(quickstep_catalog_PartitionSchemeHeader PartitionSchemeHeader.cpp PartitionSchemeHeader.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_catalog_Catalog
@@ -58,11 +59,6 @@ target_link_libraries(quickstep_catalog_Catalog
                       quickstep_catalog_Catalog_proto
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector)
-target_link_libraries(quickstep_catalog_Catalog_proto
-                      quickstep_storage_StorageBlockLayout_proto
-                      quickstep_types_Type_proto
-                      quickstep_types_TypedValue_proto
-                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_catalog_CatalogAttribute
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -118,24 +114,6 @@ target_link_libraries(quickstep_catalog_CatalogRelation
                       quickstep_threading_SpinSharedMutex
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector)
-target_link_libraries(quickstep_catalog_CatalogRelationStatistics
-                      quickstep_catalog_CatalogTypedefs
-                      quickstep_catalog_Catalog_proto
-                      quickstep_types_LongType
-                      quickstep_types_NullType
-                      quickstep_types_TypedValue
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_catalog_IndexScheme
-                      glog
-                      quickstep_catalog_Catalog_proto
-                      quickstep_storage_IndexSubBlockDescriptionFactory
-                      quickstep_storage_StorageBlockLayout_proto
-                      quickstep_utility_Macros)
-
-if(QUICKSTEP_HAVE_LIBNUMA)
-target_link_libraries(quickstep_catalog_CatalogRelation
-                      quickstep_catalog_NUMAPlacementScheme)
-endif()
 target_link_libraries(quickstep_catalog_CatalogRelationSchema
                       glog
                       quickstep_catalog_CatalogAttribute
@@ -146,15 +124,24 @@ target_link_libraries(quickstep_catalog_CatalogRelationSchema
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
                       quickstep_utility_StringUtil)
-if(QUICKSTEP_HAVE_LIBNUMA)
-target_link_libraries(quickstep_catalog_NUMAPlacementScheme
-                      glog
+target_link_libraries(quickstep_catalog_CatalogRelationStatistics
                       quickstep_catalog_CatalogTypedefs
                       quickstep_catalog_Catalog_proto
-                      quickstep_storage_StorageBlockInfo
-                      quickstep_utility_Macros
-                      ${LIBNUMA_LIBRARY})
-endif()
+                      quickstep_types_LongType
+                      quickstep_types_NullType
+                      quickstep_types_TypedValue
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_catalog_Catalog_proto
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_storage_StorageBlockLayout_proto
+                      quickstep_types_Type_proto
+                      quickstep_types_TypedValue_proto)
+target_link_libraries(quickstep_catalog_IndexScheme
+                      glog
+                      quickstep_catalog_Catalog_proto
+                      quickstep_storage_IndexSubBlockDescriptionFactory
+                      quickstep_storage_StorageBlockLayout_proto
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_catalog_PartitionScheme
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -184,11 +171,22 @@ target_link_libraries(quickstep_catalog_PartitionSchemeHeader
                       quickstep_utility_CompositeHash
                       quickstep_utility_Macros)
 
+if(QUICKSTEP_HAVE_LIBNUMA)
+  target_link_libraries(quickstep_catalog_CatalogRelation
+                        quickstep_catalog_NUMAPlacementScheme)
+  target_link_libraries(quickstep_catalog_NUMAPlacementScheme
+                        ${LIBNUMA_LIBRARY}
+                        glog
+                        quickstep_catalog_CatalogTypedefs
+                        quickstep_catalog_Catalog_proto
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_utility_Macros)
+endif()
+
 # Module all-in-one library:
 add_library(quickstep_catalog ../empty_src.cpp CatalogModule.hpp)
 target_link_libraries(quickstep_catalog
                       quickstep_catalog_Catalog
-                      quickstep_catalog_Catalog_proto
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogDatabaseCache
@@ -198,12 +196,14 @@ target_link_libraries(quickstep_catalog
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogRelationStatistics
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_catalog_Catalog_proto
                       quickstep_catalog_IndexScheme
                       quickstep_catalog_PartitionScheme
                       quickstep_catalog_PartitionSchemeHeader)
+
 if(QUICKSTEP_HAVE_LIBNUMA)
-target_link_libraries(quickstep_catalog
-                      quickstep_catalog_NUMAPlacementScheme)
+  target_link_libraries(quickstep_catalog
+                        quickstep_catalog_NUMAPlacementScheme)
 endif()
 
 # Tests:
@@ -261,12 +261,12 @@ if(QUICKSTEP_HAVE_LIBNUMA)
 add_executable(NUMAPlacementScheme_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/NUMAPlacementScheme_unittest.cpp")
 target_link_libraries(NUMAPlacementScheme_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_NUMAPlacementScheme
                       quickstep_catalog_PartitionSchemeHeader
-                      quickstep_storage_StorageBlockInfo
-                      ${LIBS})
+                      quickstep_storage_StorageBlockInfo)
 add_test(NUMAPlacementScheme_unittest NUMAPlacementScheme_unittest)
 endif()
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -17,11 +17,6 @@
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-if (ENABLE_DISTRIBUTED)
-  add_subdirectory(distributed)
-endif(ENABLE_DISTRIBUTED)
-add_subdirectory(tests)
-
 if (WIN32)
   set(QUICKSTEP_OS_WINDOWS TRUE)
 endif()
@@ -65,6 +60,13 @@ if (ENABLE_NETWORK_CLI)
                     NetworkCli.proto)
 endif()
 
+# Include subdirectories
+add_subdirectory(tests)
+
+if (ENABLE_DISTRIBUTED)
+  add_subdirectory(distributed)
+endif(ENABLE_DISTRIBUTED)
+
 # Declare micro-libs and link dependencies:
 add_library(quickstep_cli_CommandExecutor CommandExecutor.cpp CommandExecutor.hpp)
 add_library(quickstep_cli_CommandExecutorUtil CommandExecutorUtil.cpp CommandExecutorUtil.hpp)
@@ -74,6 +76,9 @@ add_library(quickstep_cli_DropRelation DropRelation.cpp DropRelation.hpp)
 add_library(quickstep_cli_Flags Flags.cpp Flags.hpp)
 add_library(quickstep_cli_IOInterface ../empty_src.cpp IOInterface.hpp)
 add_library(quickstep_cli_InputParserUtil InputParserUtil.cpp InputParserUtil.hpp)
+add_library(quickstep_cli_LineReaderBuffered LineReaderBuffered.cpp LineReaderBuffered.hpp)
+add_library(quickstep_cli_LocalIO ../empty_src.cpp LocalIO.hpp)
+add_library(quickstep_cli_PrintToScreen PrintToScreen.cpp PrintToScreen.hpp)
 
 if(USE_LINENOISE)
   add_library(quickstep_cli_LineReader
@@ -89,13 +94,6 @@ else()
               LineReaderDumb.hpp)
 endif()
 
-add_library(quickstep_cli_LineReaderBuffered
-            LineReaderBuffered.cpp
-            LineReaderBuffered.hpp)
-add_library(quickstep_cli_LocalIO
-            ../empty_src.cpp
-            LocalIO.hpp)
-
 if (ENABLE_NETWORK_CLI)
   add_library(quickstep_cli_NetworkCli_proto
               ${cli_NetworkCli_proto_srcs}
@@ -107,8 +105,6 @@ if (ENABLE_NETWORK_CLI)
               NetworkIO.cpp
               NetworkIO.hpp)
 endif()
-
-add_library(quickstep_cli_PrintToScreen PrintToScreen.cpp PrintToScreen.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_cli_CommandExecutor
@@ -160,13 +156,9 @@ target_link_libraries(quickstep_cli_CommandExecutorUtil
 target_link_libraries(quickstep_cli_DefaultsConfigurator
                       glog
                       quickstep_catalog_Catalog
-                      quickstep_catalog_Catalog_proto
                       quickstep_catalog_CatalogDatabase
+                      quickstep_catalog_Catalog_proto
                       quickstep_utility_Macros)
-if(QUICKSTEP_HAVE_LIBNUMA)
-  target_link_libraries(quickstep_cli_DefaultsConfigurator
-                        ${LIBNUMA_LIBRARY})
-endif()
 target_link_libraries(quickstep_cli_DropRelation
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
@@ -174,19 +166,43 @@ target_link_libraries(quickstep_cli_DropRelation
                       quickstep_storage_StorageManager
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_cli_Flags
+                      ${GFLAGS_LIB_NAME}
                       quickstep_cli_DefaultsConfigurator
-                      quickstep_storage_StorageConstants
-                      ${GFLAGS_LIB_NAME})
+                      quickstep_storage_StorageConstants)
 target_link_libraries(quickstep_cli_IOInterface
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_cli_InputParserUtil
                       glog
                       quickstep_utility_Macros
                       quickstep_utility_StringUtil)
+target_link_libraries(quickstep_cli_LineReaderBuffered
+                      quickstep_cli_LineReader
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_cli_LocalIO
+                      quickstep_cli_IOInterface
+                      quickstep_cli_LineReader
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_cli_PrintToScreen
+                      ${GFLAGS_LIB_NAME}
+                      quickstep_catalog_CatalogAttribute
+                      quickstep_catalog_CatalogRelation
+                      quickstep_storage_StorageBlock
+                      quickstep_storage_StorageBlockInfo
+                      quickstep_storage_StorageManager
+                      quickstep_storage_TupleIdSequence
+                      quickstep_storage_TupleStorageSubBlock
+                      quickstep_types_IntType
+                      quickstep_types_Type
+                      quickstep_types_TypedValue
+                      quickstep_utility_Macros)
+
 if(QUICKSTEP_HAVE_LIBNUMA)
+  target_link_libraries(quickstep_cli_DefaultsConfigurator
+                        ${LIBNUMA_LIBRARY})
   target_link_libraries(quickstep_cli_InputParserUtil
                         ${LIBNUMA_LIBRARY})
 endif()
+
 if(USE_LINENOISE)
   target_link_libraries(quickstep_cli_LineReader
                         glog
@@ -197,13 +213,7 @@ else()
                         glog
                         quickstep_utility_Macros)
 endif()
-target_link_libraries(quickstep_cli_LineReaderBuffered
-                      quickstep_cli_LineReader
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_cli_LocalIO
-                      quickstep_cli_LineReader
-                      quickstep_cli_IOInterface
-                      quickstep_utility_Macros)
+
 if (ENABLE_NETWORK_CLI)
   target_link_libraries(quickstep_cli_NetworkCli_proto
                         ${GRPCPLUSPLUS_LIBRARIES}
@@ -228,19 +238,6 @@ if (ENABLE_NETWORK_CLI)
                         quickstep_utility_MemStream
                         quickstep_utility_ThreadSafeQueue)
 endif()
-target_link_libraries(quickstep_cli_PrintToScreen
-                      ${GFLAGS_LIB_NAME}
-                      quickstep_catalog_CatalogAttribute
-                      quickstep_catalog_CatalogRelation
-                      quickstep_storage_StorageBlock
-                      quickstep_storage_StorageBlockInfo
-                      quickstep_storage_StorageManager
-                      quickstep_storage_TupleIdSequence
-                      quickstep_storage_TupleStorageSubBlock
-                      quickstep_types_IntType
-                      quickstep_types_Type
-                      quickstep_types_TypedValue
-                      quickstep_utility_Macros)
 
 # Module all-in-one library:
 add_library(quickstep_cli ../empty_src.cpp CliModule.hpp)
@@ -258,9 +255,15 @@ target_link_libraries(quickstep_cli
                       quickstep_cli_LineReaderBuffered
                       quickstep_cli_LocalIO
                       quickstep_cli_PrintToScreen)
+
 if (ENABLE_NETWORK_CLI)
   target_link_libraries(quickstep_cli
-                        quickstep_cli_NetworkCli_proto
                         quickstep_cli_NetworkCliClient
+                        quickstep_cli_NetworkCli_proto
                         quickstep_cli_NetworkIO)
 endif()
+
+if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_cli
+                        quickstep_cli_distributed)
+endif(ENABLE_DISTRIBUTED)

--- a/cli/distributed/CMakeLists.txt
+++ b/cli/distributed/CMakeLists.txt
@@ -69,9 +69,9 @@ target_link_libraries(quickstep_cli_distributed_Executor
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_cli_distributed_Role
+                      ${GFLAGS_LIB_NAME}
                       quickstep_utility_Macros
-                      tmb
-                      ${GFLAGS_LIB_NAME})
+                      tmb)
 
 # Module all-in-one library:
 add_library(quickstep_cli_distributed ../../empty_src.cpp CliDistributedModule.hpp)

--- a/cli/tests/CMakeLists.txt
+++ b/cli/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ if (ENABLE_NETWORK_CLI)
 endif()
 
 target_link_libraries(quickstep_cli_tests_CommandExecutorTest
+                      ${LIBS}
                       glog
                       gtest
                       quickstep_catalog_CatalogDatabase
@@ -67,10 +68,11 @@ target_link_libraries(quickstep_cli_tests_CommandExecutorTest
                       quickstep_utility_MemStream
                       quickstep_utility_SqlError
                       quickstep_utility_TextBasedTestDriver
-                      tmb
-                      ${LIBS})
+                      tmb)
 if (ENABLE_DISTRIBUTED)
   target_link_libraries(quickstep_cli_tests_DistributedCommandExecutorTest
+                        ${GFLAGS_LIB_NAME}
+                        ${LIBS}
                         glog
                         gtest
                         quickstep_catalog_CatalogTypedefs
@@ -98,9 +100,7 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_utility_MemStream
                         quickstep_utility_SqlError
                         quickstep_utility_TextBasedTestDriver
-                        tmb
-                        ${GFLAGS_LIB_NAME}
-                        ${LIBS})
+                        tmb)
 endif(ENABLE_DISTRIBUTED)
 
 target_link_libraries(LineReaderBuffered_unittest

--- a/compression/CMakeLists.txt
+++ b/compression/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(quickstep_compression
 # Tests:
 add_executable(CompressionDictionary_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/CompressionDictionary_unittest.cpp")
 target_link_libraries(CompressionDictionary_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_compression_CompressionDictionary
@@ -73,6 +74,5 @@ target_link_libraries(CompressionDictionary_unittest
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(CompressionDictionary_unittest CompressionDictionary_unittest)

--- a/expressions/CMakeLists.txt
+++ b/expressions/CMakeLists.txt
@@ -61,10 +61,10 @@ target_link_libraries(quickstep_expressions_ExpressionFactories
                       quickstep_types_operations_unaryoperations_UnaryOperationFactory
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_Expressions_proto
+                      ${PROTOBUF_LIBRARY}
                       quickstep_types_Type_proto
                       quickstep_types_TypedValue_proto
-                      quickstep_types_operations_Operation_proto
-                      ${PROTOBUF_LIBRARY})
+                      quickstep_types_operations_Operation_proto)
 
 # Module all-in-one library:
 add_library(quickstep_expressions ../empty_src.cpp ExpressionsModule.hpp)
@@ -74,4 +74,5 @@ target_link_libraries(quickstep_expressions
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_aggregation
                       quickstep_expressions_predicate
-                      quickstep_expressions_scalar)
+                      quickstep_expressions_scalar
+                      quickstep_expressions_windowaggregation)

--- a/expressions/aggregation/CMakeLists.txt
+++ b/expressions/aggregation/CMakeLists.txt
@@ -23,8 +23,6 @@ QS_PROTOBUF_GENERATE_CPP(expressions_aggregation_AggregateFunction_proto_srcs
 add_library(quickstep_expressions_aggregation_AggregateFunction
             AggregateFunction.cpp
             AggregateFunction.hpp)
-add_library(quickstep_expressions_aggregation_AggregateFunction_proto
-            ${expressions_aggregation_AggregateFunction_proto_srcs})
 add_library(quickstep_expressions_aggregation_AggregateFunctionAvg
             AggregateFunctionAvg.cpp
             AggregateFunctionAvg.hpp)
@@ -43,6 +41,8 @@ add_library(quickstep_expressions_aggregation_AggregateFunctionMin
 add_library(quickstep_expressions_aggregation_AggregateFunctionSum
             AggregateFunctionSum.cpp
             AggregateFunctionSum.hpp)
+add_library(quickstep_expressions_aggregation_AggregateFunction_proto
+            ${expressions_aggregation_AggregateFunction_proto_srcs})
 add_library(quickstep_expressions_aggregation_AggregationConcreteHandle
             AggregationConcreteHandle.cpp
             AggregationConcreteHandle.hpp)
@@ -74,8 +74,6 @@ target_link_libraries(quickstep_expressions_aggregation_AggregateFunction
                       quickstep_expressions_aggregation_AggregateFunction_proto
                       quickstep_expressions_aggregation_AggregationID
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_expressions_aggregation_AggregateFunction_proto
-                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_expressions_aggregation_AggregateFunctionAvg
                       glog
                       quickstep_expressions_aggregation_AggregateFunction
@@ -99,12 +97,12 @@ target_link_libraries(quickstep_expressions_aggregation_AggregateFunctionCount
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_aggregation_AggregateFunctionFactory
                       glog
-                      quickstep_expressions_aggregation_AggregateFunction_proto
                       quickstep_expressions_aggregation_AggregateFunctionAvg
                       quickstep_expressions_aggregation_AggregateFunctionCount
                       quickstep_expressions_aggregation_AggregateFunctionMax
                       quickstep_expressions_aggregation_AggregateFunctionMin
                       quickstep_expressions_aggregation_AggregateFunctionSum
+                      quickstep_expressions_aggregation_AggregateFunction_proto
                       quickstep_expressions_aggregation_AggregationID
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_aggregation_AggregateFunctionMax
@@ -139,6 +137,8 @@ target_link_libraries(quickstep_expressions_aggregation_AggregateFunctionSum
                       quickstep_types_operations_binaryoperations_BinaryOperationFactory
                       quickstep_types_operations_binaryoperations_BinaryOperationID
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_expressions_aggregation_AggregateFunction_proto
+                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_expressions_aggregation_AggregationConcreteHandle
                       glog
                       quickstep_expressions_aggregation_AggregationHandle
@@ -237,13 +237,13 @@ target_link_libraries(quickstep_expressions_aggregation_AggregationHandleSum
 add_library(quickstep_expressions_aggregation ../../empty_src.cpp)
 target_link_libraries(quickstep_expressions_aggregation
                       quickstep_expressions_aggregation_AggregateFunction
-                      quickstep_expressions_aggregation_AggregateFunction_proto
                       quickstep_expressions_aggregation_AggregateFunctionAvg
                       quickstep_expressions_aggregation_AggregateFunctionCount
                       quickstep_expressions_aggregation_AggregateFunctionFactory
                       quickstep_expressions_aggregation_AggregateFunctionMax
                       quickstep_expressions_aggregation_AggregateFunctionMin
                       quickstep_expressions_aggregation_AggregateFunctionSum
+                      quickstep_expressions_aggregation_AggregateFunction_proto
                       quickstep_expressions_aggregation_AggregationConcreteHandle
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_expressions_aggregation_AggregationHandleAvg

--- a/expressions/predicate/CMakeLists.txt
+++ b/expressions/predicate/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(quickstep_expressions_predicate_TrivialPredicates
 
 # Link dependencies:
 target_link_libraries(quickstep_expressions_predicate_ComparisonPredicate
+                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_Expressions_proto

--- a/expressions/scalar/CMakeLists.txt
+++ b/expressions/scalar/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(quickstep_expressions_scalar_Scalar
                       quickstep_types_containers_ColumnVector
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_scalar_ScalarAttribute
+                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
@@ -59,6 +60,7 @@ target_link_libraries(quickstep_expressions_scalar_ScalarAttribute
                       quickstep_types_containers_ColumnVector
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_scalar_ScalarBinaryExpression
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_scalar_Scalar
@@ -73,6 +75,7 @@ target_link_libraries(quickstep_expressions_scalar_ScalarBinaryExpression
                       quickstep_types_operations_binaryoperations_BinaryOperationID
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_scalar_ScalarCaseExpression
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_predicate_Predicate
@@ -109,6 +112,7 @@ target_link_libraries(quickstep_expressions_scalar_ScalarSharedExpression
                       quickstep_utility_ColumnVectorCache
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_scalar_ScalarUnaryExpression
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_scalar_Scalar

--- a/expressions/table_generator/CMakeLists.txt
+++ b/expressions/table_generator/CMakeLists.txt
@@ -20,32 +20,37 @@ QS_PROTOBUF_GENERATE_CPP(expressions_tablegenerator_GeneratorFunction_proto_srcs
                          GeneratorFunction.proto)
 
 # Declare micro-libs:
-add_library(quickstep_expressions_tablegenerator_GenerateSeries
-            ../../empty_src.cpp
-            GeneratorFunction.hpp)
-add_library(quickstep_expressions_tablegenerator_GenerateSeriesHandle
-            ../../empty_src.cpp
-            GeneratorFunctionHandle.hpp)
-add_library(quickstep_expressions_tablegenerator_GeneratorFunction
-            ../../empty_src.cpp
-            GeneratorFunction.hpp)
-add_library(quickstep_expressions_tablegenerator_GeneratorFunction_proto
-            ${expressions_tablegenerator_GeneratorFunction_proto_srcs})
+add_library(quickstep_expressions_tablegenerator_GenerateSeries ../../empty_src.cpp GenerateSeries.hpp)
+add_library(quickstep_expressions_tablegenerator_GenerateSeriesHandle ../../empty_src.cpp GenerateSeriesHandle.hpp)
+add_library(quickstep_expressions_tablegenerator_GeneratorFunction ../../empty_src.cpp GeneratorFunction.hpp)
 add_library(quickstep_expressions_tablegenerator_GeneratorFunctionFactory
             GeneratorFunctionFactory.cpp
             GeneratorFunctionFactory.hpp)
 add_library(quickstep_expressions_tablegenerator_GeneratorFunctionHandle
             ../../empty_src.cpp
             GeneratorFunctionHandle.hpp)
+add_library(quickstep_expressions_tablegenerator_GeneratorFunction_proto
+            ${expressions_tablegenerator_GeneratorFunction_proto_srcs})
 
 # Link dependencies:
 target_link_libraries(quickstep_expressions_tablegenerator_GenerateSeries
+                      glog
+                      quickstep_expressions_tablegenerator_GenerateSeriesHandle
+                      quickstep_expressions_tablegenerator_GeneratorFunction
+                      quickstep_types_Type
+                      quickstep_types_TypeFactory
+                      quickstep_types_TypeID
+                      quickstep_types_TypedValue
+                      quickstep_types_operations_comparisons_GreaterComparison
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GenerateSeriesHandle
                       glog
-                      quickstep_expressions_tablegenerator_GeneratorFunction_proto
+                      quickstep_expressions_tablegenerator_GeneratorFunctionHandle
+                      quickstep_types_Type
+                      quickstep_types_TypeID
                       quickstep_types_TypedValue
-                      quickstep_types_TypedValue_proto
+                      quickstep_types_containers_ColumnVector
+                      quickstep_types_containers_ColumnVectorsValueAccessor
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunction
                       quickstep_utility_Macros)
@@ -62,5 +67,5 @@ target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunctionHand
                       quickstep_types_TypedValue_proto
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_expressions_tablegenerator_GeneratorFunction_proto
-                      quickstep_types_TypedValue_proto
-                      ${PROTOBUF_LIBRARY})
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_types_TypedValue_proto)

--- a/expressions/window_aggregation/CMakeLists.txt
+++ b/expressions/window_aggregation/CMakeLists.txt
@@ -23,8 +23,6 @@ QS_PROTOBUF_GENERATE_CPP(expressions_windowaggregation_WindowAggregateFunction_p
 add_library(quickstep_expressions_windowaggregation_WindowAggregateFunction
             WindowAggregateFunction.cpp
             WindowAggregateFunction.hpp)
-add_library(quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
-            ${expressions_windowaggregation_WindowAggregateFunction_proto_srcs})
 add_library(quickstep_expressions_windowaggregation_WindowAggregateFunctionAvg
             WindowAggregateFunctionAvg.cpp
             WindowAggregateFunctionAvg.hpp)
@@ -43,6 +41,8 @@ add_library(quickstep_expressions_windowaggregation_WindowAggregateFunctionMin
 add_library(quickstep_expressions_windowaggregation_WindowAggregateFunctionSum
             WindowAggregateFunctionSum.cpp
             WindowAggregateFunctionSum.hpp)
+add_library(quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
+            ${expressions_windowaggregation_WindowAggregateFunction_proto_srcs})
 add_library(quickstep_expressions_windowaggregation_WindowAggregationHandle
             WindowAggregationHandle.cpp
             WindowAggregationHandle.hpp)
@@ -61,8 +61,6 @@ target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregateFun
                       quickstep_expressions_windowaggregation_WindowAggregationID
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
-                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregateFunctionAvg
                       glog
                       quickstep_expressions_windowaggregation_WindowAggregateFunction
@@ -126,6 +124,8 @@ target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregateFun
                       quickstep_types_operations_binaryoperations_BinaryOperationFactory
                       quickstep_types_operations_binaryoperations_BinaryOperationID
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
+                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregationHandle
                       glog
                       quickstep_catalog_CatalogRelationSchema
@@ -165,13 +165,13 @@ target_link_libraries(quickstep_expressions_windowaggregation_WindowAggregationH
 add_library(quickstep_expressions_windowaggregation ../../empty_src.cpp)
 target_link_libraries(quickstep_expressions_windowaggregation
                       quickstep_expressions_windowaggregation_WindowAggregateFunction
-                      quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
                       quickstep_expressions_windowaggregation_WindowAggregateFunctionAvg
                       quickstep_expressions_windowaggregation_WindowAggregateFunctionCount
                       quickstep_expressions_windowaggregation_WindowAggregateFunctionFactory
                       quickstep_expressions_windowaggregation_WindowAggregateFunctionMax
                       quickstep_expressions_windowaggregation_WindowAggregateFunctionMin
                       quickstep_expressions_windowaggregation_WindowAggregateFunctionSum
+                      quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
                       quickstep_expressions_windowaggregation_WindowAggregationHandle
                       quickstep_expressions_windowaggregation_WindowAggregationHandleAvg
                       quickstep_expressions_windowaggregation_WindowAggregationID)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -51,7 +51,6 @@ else()
   message(WARNING "Unable to find flex. A preprocessed copy of the lexer sources will be used.")
 endif()
 
-
 if (RUN_BISON)
   BISON_TARGET(SqlParser SqlParser.ypp ${CMAKE_CURRENT_BINARY_DIR}/SqlParser_gen.cpp)
 else()
@@ -90,7 +89,9 @@ add_library(quickstep_parser_ParseBasicExpressions ParseBasicExpressions.cpp Par
 add_library(quickstep_parser_ParseBlockProperties ParseBlockProperties.cpp ParseBlockProperties.hpp)
 add_library(quickstep_parser_ParseCaseExpressions ParseCaseExpressions.cpp ParseCaseExpressions.hpp)
 add_library(quickstep_parser_ParseExpression ../empty_src.cpp ParseExpression.hpp)
-add_library(quickstep_parser_ParseGeneratorTableReference ParseGeneratorTableReference.cpp ParseGeneratorTableReference.hpp)
+add_library(quickstep_parser_ParseGeneratorTableReference
+            ParseGeneratorTableReference.cpp
+            ParseGeneratorTableReference.hpp)
 add_library(quickstep_parser_ParseGroupBy ParseGroupBy.cpp ParseGroupBy.hpp)
 add_library(quickstep_parser_ParseHaving ParseHaving.cpp ParseHaving.hpp)
 add_library(quickstep_parser_ParseIndexProperties ParseIndexProperties.cpp ParseIndexProperties.hpp)
@@ -112,14 +113,16 @@ add_library(quickstep_parser_ParseSimpleTableReference ParseSimpleTableReference
 add_library(quickstep_parser_ParseStatement ../empty_src.cpp ParseStatement.hpp)
 add_library(quickstep_parser_ParseString ParseString.cpp ParseString.hpp)
 add_library(quickstep_parser_ParseSubqueryExpression ParseSubqueryExpression.cpp ParseSubqueryExpression.hpp)
-add_library(quickstep_parser_ParseSubqueryTableReference ParseSubqueryTableReference.cpp ParseSubqueryTableReference.hpp)
+add_library(quickstep_parser_ParseSubqueryTableReference
+            ParseSubqueryTableReference.cpp
+            ParseSubqueryTableReference.hpp)
 add_library(quickstep_parser_ParseTableReference ParseTableReference.cpp ParseTableReference.hpp)
 add_library(quickstep_parser_ParseTreeNode ../empty_src.cpp ParseTreeNode.hpp)
 add_library(quickstep_parser_ParseWindow ../empty_src.cpp ParseWindow.hpp)
 add_library(quickstep_parser_ParserUtil ParserUtil.cpp ParserUtil.hpp)
-add_library(quickstep_parser_SqlParserWrapper SqlParserWrapper.cpp SqlParserWrapper.hpp)
-add_library(quickstep_parser_SqlParser ${BISON_SqlParser_OUTPUTS})
 add_library(quickstep_parser_SqlLexer ${FLEX_SqlLexer_OUTPUTS})
+add_library(quickstep_parser_SqlParser ${BISON_SqlParser_OUTPUTS})
+add_library(quickstep_parser_SqlParserWrapper SqlParserWrapper.cpp SqlParserWrapper.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_parser_ParseAssignment
@@ -184,9 +187,16 @@ target_link_libraries(quickstep_parser_ParseIndexProperties
                       quickstep_utility_PtrList
                       quickstep_utility_StringUtil)
 target_link_libraries(quickstep_parser_ParseJoinedTableReference
+                      glog
                       quickstep_parser_ParsePredicate
                       quickstep_parser_ParseTableReference
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_parser_ParseKeyValue
+                      quickstep_parser_ParseLiteralValue
+                      quickstep_parser_ParseString
+                      quickstep_parser_ParseTreeNode
+                      quickstep_utility_Macros
+                      quickstep_utility_PtrList)
 target_link_libraries(quickstep_parser_ParseLimit
                       quickstep_parser_ParseLiteralValue
                       quickstep_parser_ParseTreeNode
@@ -260,6 +270,7 @@ target_link_libraries(quickstep_parser_ParseSelectionClause
                       quickstep_utility_Macros
                       quickstep_utility_PtrList)
 target_link_libraries(quickstep_parser_ParseSetOperation
+                      glog
                       quickstep_parser_ParseTreeNode
                       quickstep_utility_Macros
                       quickstep_utility_PtrList)
@@ -291,12 +302,6 @@ target_link_libraries(quickstep_parser_ParseStatement
 target_link_libraries(quickstep_parser_ParseString
                       quickstep_parser_ParseTreeNode
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_parser_ParseKeyValue
-                      quickstep_parser_ParseLiteralValue
-                      quickstep_parser_ParseString
-                      quickstep_parser_ParseTreeNode
-                      quickstep_utility_Macros
-                      quickstep_utility_PtrList)
 target_link_libraries(quickstep_parser_ParseSubqueryExpression
                       glog
                       quickstep_parser_ParseExpression
@@ -314,19 +319,19 @@ target_link_libraries(quickstep_parser_ParseTableReference
 target_link_libraries(quickstep_parser_ParseTreeNode
                       quickstep_utility_Macros
                       quickstep_utility_TreeStringSerializable)
-target_link_libraries(quickstep_parser_ParserUtil
-                      quickstep_utility_SqlError)
 target_link_libraries(quickstep_parser_ParseWindow
                       quickstep_parser_ParseExpression
                       quickstep_parser_ParseOrderBy
                       quickstep_parser_ParseString
                       quickstep_parser_ParseTreeNode
                       quickstep_utility_PtrList)
+target_link_libraries(quickstep_parser_ParserUtil
+                      quickstep_utility_SqlError)
 target_link_libraries(quickstep_parser_SqlLexer
                       quickstep_parser_ParseJoinedTableReference
                       quickstep_parser_ParseLiteralValue
-                      quickstep_parser_ParserUtil
                       quickstep_parser_ParseString
+                      quickstep_parser_ParserUtil
                       quickstep_parser_SqlParser
                       quickstep_utility_PtrList
                       quickstep_utility_PtrVector)
@@ -422,6 +427,7 @@ target_link_libraries(quickstep_parser
                       quickstep_parser_ParseHaving
                       quickstep_parser_ParseIndexProperties
                       quickstep_parser_ParseJoinedTableReference
+                      quickstep_parser_ParseKeyValue
                       quickstep_parser_ParseLimit
                       quickstep_parser_ParseLiteralValue
                       quickstep_parser_ParseOrderBy
@@ -430,7 +436,6 @@ target_link_libraries(quickstep_parser
                       quickstep_parser_ParsePredicateExists
                       quickstep_parser_ParsePredicateInTableQuery
                       quickstep_parser_ParsePriority
-                      quickstep_parser_ParserUtil
                       quickstep_parser_ParseSample
                       quickstep_parser_ParseSelect
                       quickstep_parser_ParseSelectionClause
@@ -438,12 +443,12 @@ target_link_libraries(quickstep_parser
                       quickstep_parser_ParseSimpleTableReference
                       quickstep_parser_ParseStatement
                       quickstep_parser_ParseString
-                      quickstep_parser_ParseKeyValue
                       quickstep_parser_ParseSubqueryExpression
                       quickstep_parser_ParseSubqueryTableReference
                       quickstep_parser_ParseTableReference
                       quickstep_parser_ParseTreeNode
                       quickstep_parser_ParseWindow
+                      quickstep_parser_ParserUtil
                       quickstep_parser_SqlLexer
                       quickstep_parser_SqlParser
                       quickstep_parser_SqlParserWrapper)

--- a/parser/tests/CMakeLists.txt
+++ b/parser/tests/CMakeLists.txt
@@ -16,15 +16,16 @@
 # under the License.
 
 add_executable(quickstep_parser_tests_ParserTest
-              "${CMAKE_CURRENT_SOURCE_DIR}/ParserTest.cpp"
-              "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.cpp"
-              "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.hpp")
+               "${CMAKE_CURRENT_SOURCE_DIR}/ParserTest.cpp"
+               "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.cpp"
+               "${PROJECT_SOURCE_DIR}/utility/textbased_test/TextBasedTest.hpp")
 
 target_link_libraries(quickstep_parser_tests_ParserTest
                       glog
                       gtest
                       gtest_main
-                      quickstep_parser
+                      quickstep_parser_ParseStatement
+                      quickstep_parser_SqlParserWrapper
                       quickstep_utility_Macros
                       quickstep_utility_TextBasedTestDriver)
 

--- a/query_execution/CMakeLists.txt
+++ b/query_execution/CMakeLists.txt
@@ -25,20 +25,10 @@ set_gflags_lib_name ()
 
 # Declare micro-libs:
 add_library(quickstep_queryexecution_AdmitRequestMessage ../empty_src.cpp AdmitRequestMessage.hpp)
-if (ENABLE_DISTRIBUTED)
-  add_library(quickstep_queryexecution_BlockLocator BlockLocator.cpp BlockLocator.hpp)
-  add_library(quickstep_queryexecution_BlockLocatorUtil BlockLocatorUtil.cpp BlockLocatorUtil.hpp)
-endif(ENABLE_DISTRIBUTED)
 add_library(quickstep_queryexecution_ExecutionStats ../empty_src.cpp ExecutionStats.hpp)
 add_library(quickstep_queryexecution_ForemanBase ../empty_src.cpp ForemanBase.hpp)
-if (ENABLE_DISTRIBUTED)
-  add_library(quickstep_queryexecution_ForemanDistributed ForemanDistributed.cpp ForemanDistributed.hpp)
-endif(ENABLE_DISTRIBUTED)
 add_library(quickstep_queryexecution_ForemanSingleNode ForemanSingleNode.cpp ForemanSingleNode.hpp)
 add_library(quickstep_queryexecution_PolicyEnforcerBase PolicyEnforcerBase.cpp PolicyEnforcerBase.hpp)
-if (ENABLE_DISTRIBUTED)
-  add_library(quickstep_queryexecution_PolicyEnforcerDistributed PolicyEnforcerDistributed.cpp PolicyEnforcerDistributed.hpp)
-endif(ENABLE_DISTRIBUTED)
 add_library(quickstep_queryexecution_PolicyEnforcerSingleNode PolicyEnforcerSingleNode.cpp PolicyEnforcerSingleNode.hpp)
 add_library(quickstep_queryexecution_ProbabilityStore ../empty_src.cpp ProbabilityStore.hpp)
 add_library(quickstep_queryexecution_QueryContext QueryContext.cpp QueryContext.hpp)
@@ -52,83 +42,41 @@ add_library(quickstep_queryexecution_QueryExecutionState ../empty_src.cpp QueryE
 add_library(quickstep_queryexecution_QueryExecutionTypedefs ../empty_src.cpp QueryExecutionTypedefs.hpp)
 add_library(quickstep_queryexecution_QueryExecutionUtil ../empty_src.cpp QueryExecutionUtil.hpp)
 add_library(quickstep_queryexecution_QueryManagerBase QueryManagerBase.cpp QueryManagerBase.hpp)
-if (ENABLE_DISTRIBUTED)
-  add_library(quickstep_queryexecution_QueryManagerDistributed QueryManagerDistributed.cpp QueryManagerDistributed.hpp)
-endif(ENABLE_DISTRIBUTED)
 add_library(quickstep_queryexecution_QueryManagerSingleNode QueryManagerSingleNode.cpp QueryManagerSingleNode.hpp)
-if (ENABLE_DISTRIBUTED)
-  add_library(quickstep_queryexecution_Shiftboss Shiftboss.cpp Shiftboss.hpp)
-  add_library(quickstep_queryexecution_ShiftbossDirectory ../empty_src.cpp ShiftbossDirectory.hpp)
-endif(ENABLE_DISTRIBUTED)
 add_library(quickstep_queryexecution_WorkOrderProtosContainer ../empty_src.cpp WorkOrderProtosContainer.hpp)
+add_library(quickstep_queryexecution_WorkOrderSelectionPolicy ../empty_src.cpp WorkOrderSelectionPolicy.hpp)
 add_library(quickstep_queryexecution_WorkOrdersContainer WorkOrdersContainer.cpp WorkOrdersContainer.hpp)
 add_library(quickstep_queryexecution_Worker Worker.cpp Worker.hpp)
 add_library(quickstep_queryexecution_WorkerDirectory ../empty_src.cpp WorkerDirectory.hpp)
 add_library(quickstep_queryexecution_WorkerMessage ../empty_src.cpp WorkerMessage.hpp)
-add_library(quickstep_queryexecution_WorkOrderSelectionPolicy ../empty_src.cpp WorkOrderSelectionPolicy.hpp)
 add_library(quickstep_queryexecution_WorkerSelectionPolicy ../empty_src.cpp WorkerSelectionPolicy.hpp)
+
+if (ENABLE_DISTRIBUTED)
+  add_library(quickstep_queryexecution_BlockLocator BlockLocator.cpp BlockLocator.hpp)
+  add_library(quickstep_queryexecution_BlockLocatorUtil BlockLocatorUtil.cpp BlockLocatorUtil.hpp)
+  add_library(quickstep_queryexecution_ForemanDistributed ForemanDistributed.cpp ForemanDistributed.hpp)
+  add_library(quickstep_queryexecution_PolicyEnforcerDistributed
+              PolicyEnforcerDistributed.cpp
+              PolicyEnforcerDistributed.hpp)
+  add_library(quickstep_queryexecution_QueryManagerDistributed QueryManagerDistributed.cpp QueryManagerDistributed.hpp)
+  add_library(quickstep_queryexecution_Shiftboss Shiftboss.cpp Shiftboss.hpp)
+  add_library(quickstep_queryexecution_ShiftbossDirectory ../empty_src.cpp ShiftbossDirectory.hpp)
+endif(ENABLE_DISTRIBUTED)
 
 # Link dependencies:
 target_link_libraries(quickstep_queryexecution_AdmitRequestMessage
                       quickstep_utility_Macros)
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_queryexecution_BlockLocator
-                        glog
-                        quickstep_queryexecution_QueryExecutionMessages_proto
-                        quickstep_queryexecution_QueryExecutionTypedefs
-                        quickstep_queryexecution_QueryExecutionUtil
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageConstants
-                        quickstep_threading_SpinSharedMutex
-                        quickstep_threading_Thread
-                        quickstep_threading_ThreadUtil
-                        quickstep_utility_Macros
-                        tmb)
-  target_link_libraries(quickstep_queryexecution_BlockLocatorUtil
-                        glog
-                        quickstep_queryexecution_QueryExecutionMessages_proto
-                        quickstep_queryexecution_QueryExecutionTypedefs
-                        quickstep_storage_StorageBlockInfo
-                        tmb)
-endif(ENABLE_DISTRIBUTED)
+target_link_libraries(quickstep_queryexecution_ExecutionStats
+                      glog
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryexecution_ForemanBase
                       glog
                       quickstep_queryexecution_PolicyEnforcerBase
                       quickstep_threading_Thread
                       quickstep_utility_Macros
                       tmb)
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_queryexecution_ForemanDistributed
-                        glog
-                        quickstep_catalog_CatalogDatabase
-                        quickstep_catalog_CatalogRelation
-                        quickstep_catalog_CatalogTypedefs
-                        quickstep_catalog_Catalog_proto
-                        quickstep_cli_Flags
-                        quickstep_queryexecution_AdmitRequestMessage
-                        quickstep_queryexecution_BlockLocator
-                        quickstep_queryexecution_BlockLocatorUtil
-                        quickstep_queryexecution_ForemanBase
-                        quickstep_queryexecution_PolicyEnforcerBase
-                        quickstep_queryexecution_PolicyEnforcerDistributed
-                        quickstep_queryexecution_QueryContext
-                        quickstep_queryexecution_QueryExecutionMessages_proto
-                        quickstep_queryexecution_QueryExecutionTypedefs
-                        quickstep_queryexecution_QueryExecutionUtil
-                        quickstep_queryexecution_ShiftbossDirectory
-                        quickstep_relationaloperators_WorkOrder_proto
-                        quickstep_storage_DataExchangerAsync
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageManager
-                        quickstep_threading_ThreadUtil
-                        quickstep_utility_Macros
-                        tmb
-                        ${GFLAGS_LIB_NAME})
-endif(ENABLE_DISTRIBUTED)
-target_link_libraries(quickstep_queryexecution_ExecutionStats
-                      glog
-                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryexecution_ForemanSingleNode
+                      ${GFLAGS_LIB_NAME}
                       glog
                       quickstep_queryexecution_AdmitRequestMessage
                       quickstep_queryexecution_ForemanBase
@@ -140,9 +88,9 @@ target_link_libraries(quickstep_queryexecution_ForemanSingleNode
                       quickstep_queryexecution_WorkerMessage
                       quickstep_threading_ThreadUtil
                       quickstep_utility_Macros
-                      tmb
-                      ${GFLAGS_LIB_NAME})
+                      tmb)
 target_link_libraries(quickstep_queryexecution_PolicyEnforcerBase
+                      ${GFLAGS_LIB_NAME}
                       glog
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
@@ -153,42 +101,9 @@ target_link_libraries(quickstep_queryexecution_PolicyEnforcerBase
                       quickstep_queryexecution_QueryManagerBase
                       quickstep_relationaloperators_WorkOrder
                       quickstep_storage_StorageBlockInfo
-                      quickstep_utility_Macros
-                      tmb
-                      ${GFLAGS_LIB_NAME})
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_queryexecution_PolicyEnforcerDistributed
-                        glog
-                        quickstep_catalog_CatalogDatabase
-                        quickstep_catalog_CatalogRelation
-                        quickstep_catalog_CatalogRelationSchema
-                        quickstep_catalog_CatalogRelationStatistics
-                        quickstep_catalog_CatalogTypedefs
-                        quickstep_catalog_Catalog_proto
-                        quickstep_queryexecution_PolicyEnforcerBase
-                        quickstep_queryexecution_QueryContext
-                        quickstep_queryexecution_QueryContext_proto
-                        quickstep_queryexecution_QueryExecutionMessages_proto
-                        quickstep_queryexecution_QueryExecutionState
-                        quickstep_queryexecution_QueryExecutionTypedefs
-                        quickstep_queryexecution_QueryExecutionUtil
-                        quickstep_queryexecution_QueryManagerBase
-                        quickstep_queryexecution_QueryManagerDistributed
-                        quickstep_queryexecution_ShiftbossDirectory
-                        quickstep_queryoptimizer_QueryHandle
-                        quickstep_queryoptimizer_QueryProcessor
-                        quickstep_storage_StorageBlock
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageManager
-                        quickstep_storage_TupleIdSequence
-                        quickstep_storage_TupleStorageSubBlock
-                        quickstep_types_TypedValue
-                        quickstep_utility_ExecutionDAGVisualizer
-                        quickstep_utility_Macros
-                        tmb
-                        ${GFLAGS_LIB_NAME})
-endif(ENABLE_DISTRIBUTED)
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryexecution_PolicyEnforcerSingleNode
+                      ${GFLAGS_LIB_NAME}
                       glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_PolicyEnforcerBase
@@ -200,8 +115,7 @@ target_link_libraries(quickstep_queryexecution_PolicyEnforcerSingleNode
                       quickstep_queryexecution_WorkerMessage
                       quickstep_queryoptimizer_QueryHandle
                       quickstep_utility_Macros
-                      tmb
-                      ${GFLAGS_LIB_NAME})
+                      tmb)
 target_link_libraries(quickstep_queryexecution_ProbabilityStore
                       glog
                       quickstep_utility_Macros)
@@ -230,8 +144,10 @@ target_link_libraries(quickstep_queryexecution_QueryContext
                       quickstep_utility_SortConfiguration
                       quickstep_utility_lipfilter_LIPFilter
                       quickstep_utility_lipfilter_LIPFilterDeployment
-                      quickstep_utility_lipfilter_LIPFilterFactory)
+                      quickstep_utility_lipfilter_LIPFilterFactory
+                      tmb)
 target_link_libraries(quickstep_queryexecution_QueryContext_proto
+                      ${PROTOBUF_LIBRARY}
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_tablegenerator_GeneratorFunction_proto
                       quickstep_storage_AggregationOperationState_proto
@@ -240,13 +156,12 @@ target_link_libraries(quickstep_queryexecution_QueryContext_proto
                       quickstep_storage_WindowAggregationOperationState_proto
                       quickstep_types_containers_Tuple_proto
                       quickstep_utility_SortConfiguration_proto
-                      quickstep_utility_lipfilter_LIPFilter_proto
-                      ${PROTOBUF_LIBRARY})
+                      quickstep_utility_lipfilter_LIPFilter_proto)
 target_link_libraries(quickstep_queryexecution_QueryExecutionMessages_proto
+                      ${PROTOBUF_LIBRARY}
                       quickstep_catalog_Catalog_proto
                       quickstep_queryexecution_QueryContext_proto
-                      quickstep_relationaloperators_WorkOrder_proto
-                      ${PROTOBUF_LIBRARY})
+                      quickstep_relationaloperators_WorkOrder_proto)
 target_link_libraries(quickstep_queryexecution_QueryExecutionState
                       glog
                       quickstep_utility_Macros)
@@ -254,11 +169,14 @@ target_link_libraries(quickstep_queryexecution_QueryExecutionTypedefs
                       quickstep_threading_ThreadIDBasedMap
                       tmb)
 target_link_libraries(quickstep_queryexecution_QueryExecutionUtil
+                      glog
                       quickstep_queryexecution_AdmitRequestMessage
                       quickstep_queryexecution_QueryExecutionTypedefs
                       quickstep_utility_Macros
                       tmb)
 target_link_libraries(quickstep_queryexecution_QueryManagerBase
+                      ${GFLAGS_LIB_NAME}
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_queryexecution_QueryContext
                       quickstep_queryexecution_QueryExecutionState
@@ -269,9 +187,131 @@ target_link_libraries(quickstep_queryexecution_QueryManagerBase
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_DAG
                       quickstep_utility_ExecutionDAGVisualizer
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_queryexecution_QueryManagerSingleNode
+                      glog
+                      quickstep_catalog_CatalogDatabase
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_queryexecution_QueryContext
+                      quickstep_queryexecution_QueryExecutionState
+                      quickstep_queryexecution_QueryManagerBase
+                      quickstep_queryexecution_WorkOrdersContainer
+                      quickstep_queryexecution_WorkerMessage
+                      quickstep_queryoptimizer_QueryHandle
+                      quickstep_relationaloperators_RebuildWorkOrder
+                      quickstep_relationaloperators_RelationalOperator
+                      quickstep_storage_InsertDestination
+                      quickstep_storage_StorageBlock
+                      quickstep_utility_DAG
                       quickstep_utility_Macros
-                      ${GFLAGS_LIB_NAME})
+                      tmb)
+target_link_libraries(quickstep_queryexecution_WorkOrderProtosContainer
+                      glog
+                      quickstep_relationaloperators_WorkOrder_proto
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_queryexecution_WorkOrderSelectionPolicy
+                      glog
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_queryexecution_WorkOrdersContainer
+                      glog
+                      quickstep_queryexecution_WorkOrderSelectionPolicy
+                      quickstep_relationaloperators_WorkOrder
+                      quickstep_utility_Macros
+                      quickstep_utility_PtrVector)
+target_link_libraries(quickstep_queryexecution_Worker
+                      glog
+                      quickstep_queryexecution_QueryExecutionMessages_proto
+                      quickstep_queryexecution_QueryExecutionTypedefs
+                      quickstep_queryexecution_QueryExecutionUtil
+                      quickstep_queryexecution_WorkerMessage
+                      quickstep_relationaloperators_WorkOrder
+                      quickstep_threading_Thread
+                      quickstep_threading_ThreadIDBasedMap
+                      quickstep_threading_ThreadUtil
+                      quickstep_utility_Macros
+                      tmb)
+target_link_libraries(quickstep_queryexecution_WorkerDirectory
+                      quickstep_queryexecution_QueryExecutionTypedefs
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_queryexecution_WorkerSelectionPolicy
+                      quickstep_queryexecution_WorkerDirectory
+                      quickstep_utility_Macros)
+
 if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_queryexecution_BlockLocator
+                        glog
+                        quickstep_queryexecution_QueryExecutionMessages_proto
+                        quickstep_queryexecution_QueryExecutionTypedefs
+                        quickstep_queryexecution_QueryExecutionUtil
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageConstants
+                        quickstep_threading_SpinSharedMutex
+                        quickstep_threading_Thread
+                        quickstep_threading_ThreadUtil
+                        quickstep_utility_Macros
+                        tmb)
+  target_link_libraries(quickstep_queryexecution_BlockLocatorUtil
+                        glog
+                        quickstep_queryexecution_QueryExecutionMessages_proto
+                        quickstep_queryexecution_QueryExecutionTypedefs
+                        quickstep_storage_StorageBlockInfo
+                        tmb)
+  target_link_libraries(quickstep_queryexecution_ForemanDistributed
+                        ${GFLAGS_LIB_NAME}
+                        glog
+                        quickstep_catalog_CatalogDatabase
+                        quickstep_catalog_CatalogRelation
+                        quickstep_catalog_CatalogTypedefs
+                        quickstep_catalog_Catalog_proto
+                        quickstep_cli_Flags
+                        quickstep_queryexecution_AdmitRequestMessage
+                        quickstep_queryexecution_BlockLocator
+                        quickstep_queryexecution_BlockLocatorUtil
+                        quickstep_queryexecution_ForemanBase
+                        quickstep_queryexecution_PolicyEnforcerBase
+                        quickstep_queryexecution_PolicyEnforcerDistributed
+                        quickstep_queryexecution_QueryContext
+                        quickstep_queryexecution_QueryExecutionMessages_proto
+                        quickstep_queryexecution_QueryExecutionTypedefs
+                        quickstep_queryexecution_QueryExecutionUtil
+                        quickstep_queryexecution_ShiftbossDirectory
+                        quickstep_relationaloperators_WorkOrder_proto
+                        quickstep_storage_DataExchangerAsync
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageManager
+                        quickstep_threading_ThreadUtil
+                        quickstep_utility_Macros
+                        tmb)
+  target_link_libraries(quickstep_queryexecution_PolicyEnforcerDistributed
+                        ${GFLAGS_LIB_NAME}
+                        glog
+                        quickstep_catalog_CatalogDatabase
+                        quickstep_catalog_CatalogRelation
+                        quickstep_catalog_CatalogRelationSchema
+                        quickstep_catalog_CatalogRelationStatistics
+                        quickstep_catalog_CatalogTypedefs
+                        quickstep_catalog_Catalog_proto
+                        quickstep_queryexecution_PolicyEnforcerBase
+                        quickstep_queryexecution_QueryContext
+                        quickstep_queryexecution_QueryContext_proto
+                        quickstep_queryexecution_QueryExecutionMessages_proto
+                        quickstep_queryexecution_QueryExecutionState
+                        quickstep_queryexecution_QueryExecutionTypedefs
+                        quickstep_queryexecution_QueryExecutionUtil
+                        quickstep_queryexecution_QueryManagerBase
+                        quickstep_queryexecution_QueryManagerDistributed
+                        quickstep_queryexecution_ShiftbossDirectory
+                        quickstep_queryoptimizer_QueryHandle
+                        quickstep_queryoptimizer_QueryProcessor
+                        quickstep_storage_StorageBlock
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageManager
+                        quickstep_storage_TupleIdSequence
+                        quickstep_storage_TupleStorageSubBlock
+                        quickstep_types_TypedValue
+                        quickstep_utility_ExecutionDAGVisualizer
+                        quickstep_utility_Macros
+                        tmb)
   target_link_libraries(quickstep_queryexecution_QueryManagerDistributed
                         quickstep_catalog_CatalogTypedefs
                         quickstep_queryexecution_BlockLocator
@@ -290,24 +330,6 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_utility_Macros
                         quickstep_utility_lipfilter_LIPFilter_proto
                         tmb)
-endif(ENABLE_DISTRIBUTED)
-target_link_libraries(quickstep_queryexecution_QueryManagerSingleNode
-                      quickstep_catalog_CatalogDatabase
-                      quickstep_catalog_CatalogTypedefs
-                      quickstep_queryexecution_QueryContext
-                      quickstep_queryexecution_QueryExecutionState
-                      quickstep_queryexecution_QueryManagerBase
-                      quickstep_queryexecution_WorkOrdersContainer
-                      quickstep_queryexecution_WorkerMessage
-                      quickstep_queryoptimizer_QueryHandle
-                      quickstep_relationaloperators_RebuildWorkOrder
-                      quickstep_relationaloperators_RelationalOperator
-                      quickstep_storage_InsertDestination
-                      quickstep_storage_StorageBlock
-                      quickstep_utility_DAG
-                      quickstep_utility_Macros
-                      tmb)
-if (ENABLE_DISTRIBUTED)
   target_link_libraries(quickstep_queryexecution_Shiftboss
                         glog
                         quickstep_catalog_CatalogDatabase
@@ -335,37 +357,6 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_utility_Macros
                         tmb)
 endif(ENABLE_DISTRIBUTED)
-target_link_libraries(quickstep_queryexecution_WorkOrderProtosContainer
-                      glog
-                      quickstep_relationaloperators_WorkOrder_proto
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_queryexecution_WorkOrdersContainer
-                      glog
-                      quickstep_queryexecution_WorkOrderSelectionPolicy
-                      quickstep_relationaloperators_WorkOrder
-                      quickstep_utility_Macros
-                      quickstep_utility_PtrVector)
-target_link_libraries(quickstep_queryexecution_Worker
-                      glog
-                      quickstep_queryexecution_QueryExecutionMessages_proto
-                      quickstep_queryexecution_QueryExecutionTypedefs
-                      quickstep_queryexecution_QueryExecutionUtil
-                      quickstep_queryexecution_WorkerMessage
-                      quickstep_relationaloperators_WorkOrder
-                      quickstep_threading_Thread
-                      quickstep_threading_ThreadIDBasedMap
-                      quickstep_threading_ThreadUtil
-                      quickstep_utility_Macros
-                      tmb)
-target_link_libraries(quickstep_queryexecution_WorkerDirectory
-                      quickstep_queryexecution_QueryExecutionTypedefs
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_queryexecution_WorkOrderSelectionPolicy
-                      glog
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_queryexecution_WorkerSelectionPolicy
-                      quickstep_queryexecution_WorkerDirectory
-                      quickstep_utility_Macros)
 
 # Module all-in-one library:
 add_library(quickstep_queryexecution ../empty_src.cpp QueryExecutionModule.hpp)
@@ -386,12 +377,13 @@ target_link_libraries(quickstep_queryexecution
                       quickstep_queryexecution_QueryManagerBase
                       quickstep_queryexecution_QueryManagerSingleNode
                       quickstep_queryexecution_WorkOrderProtosContainer
+                      quickstep_queryexecution_WorkOrderSelectionPolicy
                       quickstep_queryexecution_WorkOrdersContainer
                       quickstep_queryexecution_Worker
                       quickstep_queryexecution_WorkerDirectory
                       quickstep_queryexecution_WorkerMessage
-                      quickstep_queryexecution_WorkOrderSelectionPolicy
                       quickstep_queryexecution_WorkerSelectionPolicy)
+
 if (ENABLE_DISTRIBUTED)
   target_link_libraries(quickstep_queryexecution
                         quickstep_queryexecution_BlockLocator
@@ -409,6 +401,7 @@ if (ENABLE_DISTRIBUTED)
                  "${CMAKE_CURRENT_SOURCE_DIR}/tests/BlockLocator_unittest.cpp")
   target_link_libraries(BlockLocator_unittest
                         ${GFLAGS_LIB_NAME}
+                        ${LIBS}
                         glog
                         gtest
                         quickstep_catalog_CatalogAttribute
@@ -425,13 +418,12 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_storage_StorageManager
                         quickstep_types_TypeFactory
                         quickstep_types_TypeID
-                        tmb
-                        ${LIBS})
+                        tmb)
   add_test(BlockLocator_unittest BlockLocator_unittest)
 endif(ENABLE_DISTRIBUTED)
 
 add_executable(ProbabilityStore_unittest
-        "${CMAKE_CURRENT_SOURCE_DIR}/tests/ProbabilityStore_unittest.cpp")
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/ProbabilityStore_unittest.cpp")
 target_link_libraries(ProbabilityStore_unittest
                       gtest
                       gtest_main
@@ -439,7 +431,7 @@ target_link_libraries(ProbabilityStore_unittest
 add_test(ProbabilityStore_unittest ProbabilityStore_unittest)
 
 add_executable(QueryManagerSingleNode_unittest
-  "${CMAKE_CURRENT_SOURCE_DIR}/tests/QueryManagerSingleNode_unittest.cpp")
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/QueryManagerSingleNode_unittest.cpp")
 target_link_libraries(QueryManagerSingleNode_unittest
                       glog
                       gtest
@@ -483,7 +475,7 @@ target_link_libraries(WorkOrdersContainer_unittest
 add_test(WorkOrdersContainer_unittest WorkOrdersContainer_unittest)
 
 add_executable(WorkerDirectory_unittest
-  "${CMAKE_CURRENT_SOURCE_DIR}/tests/WorkerDirectory_unittest.cpp")
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/WorkerDirectory_unittest.cpp")
 target_link_libraries(WorkerDirectory_unittest
                       gtest
                       gtest_main
@@ -492,7 +484,7 @@ target_link_libraries(WorkerDirectory_unittest
 add_test(WorkerDirectory_unittest WorkerDirectory_unittest)
 
 add_executable(WorkerSelectionPolicy_unittest
-  "${CMAKE_CURRENT_SOURCE_DIR}/tests/WorkerSelectionPolicy_unittest.cpp")
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/WorkerSelectionPolicy_unittest.cpp")
 target_link_libraries(WorkerSelectionPolicy_unittest
                       gtest
                       gtest_main

--- a/query_optimizer/CMakeLists.txt
+++ b/query_optimizer/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(quickstep_queryoptimizer_Validator ../empty_src.cpp Validator.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
+                      ${GFLAGS_LIB_NAME}
                       glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogDatabase
@@ -163,10 +164,6 @@ target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
                       quickstep_utility_BarrieredReadWriteConcurrentBitVector
                       quickstep_utility_Macros
                       quickstep_utility_SqlError)
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
-                        quickstep_catalog_Catalog_proto)
-endif()
 target_link_libraries(quickstep_queryoptimizer_LIPFilterGenerator
                       glog
                       quickstep_catalog_CatalogAttribute
@@ -189,6 +186,7 @@ target_link_libraries(quickstep_queryoptimizer_LogicalGenerator
                       glog
                       quickstep_parser_ParseStatement
                       quickstep_queryoptimizer_OptimizerContext
+                      quickstep_queryoptimizer_Validator
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_resolver_Resolver
                       quickstep_queryoptimizer_rules_CollapseProject
@@ -197,7 +195,6 @@ target_link_libraries(quickstep_queryoptimizer_LogicalGenerator
                       quickstep_queryoptimizer_rules_PushDownSemiAntiJoin
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_queryoptimizer_rules_UnnestSubqueries
-                      quickstep_queryoptimizer_Validator
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_LogicalToPhysicalMapper
                       quickstep_queryoptimizer_logical_Logical
@@ -214,12 +211,14 @@ target_link_libraries(quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_expressions_ExprId
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_OptimizerTree
+                      glog
                       quickstep_catalog_Catalog_proto
                       quickstep_storage_StorageBlockLayout_proto
                       quickstep_utility_Macros
                       quickstep_utility_TreeStringSerializable)
 target_link_libraries(quickstep_queryoptimizer_PhysicalGenerator
                       ${GFLAGS_LIB_NAME}
+                      glog
                       quickstep_queryoptimizer_LogicalToPhysicalMapper
                       quickstep_queryoptimizer_Validator
                       quickstep_queryoptimizer_logical_Logical
@@ -268,6 +267,11 @@ target_link_libraries(quickstep_queryoptimizer_Validator
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil)
 
+if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_queryoptimizer_ExecutionGenerator
+                        quickstep_catalog_Catalog_proto)
+endif()
+
 # Module all-in-one library:
 add_library(quickstep_queryoptimizer ../empty_src.cpp QueryOptimizerModule.hpp)
 target_link_libraries(quickstep_queryoptimizer
@@ -288,4 +292,5 @@ target_link_libraries(quickstep_queryoptimizer
                       quickstep_queryoptimizer_logical
                       quickstep_queryoptimizer_physical
                       quickstep_queryoptimizer_resolver
-                      quickstep_queryoptimizer_rules)
+                      quickstep_queryoptimizer_rules
+                      quickstep_queryoptimizer_strategy)

--- a/query_optimizer/cost_model/CMakeLists.txt
+++ b/query_optimizer/cost_model/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(quickstep_queryoptimizer_costmodel_SimpleCostModel
                       quickstep_queryoptimizer_physical_WindowAggregate
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
+                      ${GFLAGS_LIB_NAME}
                       glog
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationStatistics

--- a/query_optimizer/expressions/CMakeLists.txt
+++ b/query_optimizer/expressions/CMakeLists.txt
@@ -28,9 +28,9 @@ add_library(quickstep_queryoptimizer_expressions_ComparisonExpression
             ComparisonExpression.cpp
             ComparisonExpression.hpp)
 add_library(quickstep_queryoptimizer_expressions_Exists Exists.cpp Exists.hpp)
+add_library(quickstep_queryoptimizer_expressions_ExprId ../../empty_src.cpp ExprId.hpp)
 add_library(quickstep_queryoptimizer_expressions_Expression ../../empty_src.cpp Expression.hpp)
 add_library(quickstep_queryoptimizer_expressions_ExpressionType ../../empty_src.cpp ExpressionType.hpp)
-add_library(quickstep_queryoptimizer_expressions_ExprId ../../empty_src.cpp ExprId.hpp)
 add_library(quickstep_queryoptimizer_expressions_ExpressionUtil ExpressionUtil.cpp ExpressionUtil.hpp)
 add_library(quickstep_queryoptimizer_expressions_InTableQuery InTableQuery.cpp InTableQuery.hpp)
 add_library(quickstep_queryoptimizer_expressions_InValueList InValueList.cpp InValueList.hpp)
@@ -142,6 +142,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_ComparisonExpression
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_Exists
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExprId
@@ -149,9 +150,9 @@ target_link_libraries(quickstep_queryoptimizer_expressions_Exists
                       quickstep_queryoptimizer_expressions_ExpressionType
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_expressions_SubqueryExpression
-                      quickstep_utility_Macros
-                      glog)
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_Expression
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_ExpressionType
                       quickstep_types_Type
@@ -163,6 +164,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
                       quickstep_queryoptimizer_expressions_PatternMatcher)
 target_link_libraries(quickstep_queryoptimizer_expressions_InTableQuery
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExprId
@@ -173,9 +175,10 @@ target_link_libraries(quickstep_queryoptimizer_expressions_InTableQuery
                       quickstep_queryoptimizer_expressions_SubqueryExpression
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_InValueList
-                      quickstep_queryoptimizer_OptimizerTree
+                      glog
                       quickstep_expressions_predicate_DisjunctionPredicate
                       quickstep_expressions_predicate_Predicate
+                      quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ComparisonExpression
                       quickstep_queryoptimizer_expressions_ExprId
@@ -251,7 +254,6 @@ target_link_libraries(quickstep_queryoptimizer_expressions_PredicateLiteral
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_Scalar
-                      glog
                       quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_Expression
                       quickstep_utility_HashError
@@ -271,6 +273,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_ScalarLiteral
                       quickstep_utility_HashPair
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_SearchedCase
+                      glog
                       quickstep_expressions_predicate_Predicate
                       quickstep_expressions_scalar_Scalar
                       quickstep_expressions_scalar_ScalarCaseExpression
@@ -286,6 +289,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_SearchedCase
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_expressions_SimpleCase
+                      glog
                       quickstep_expressions_predicate_Predicate
                       quickstep_expressions_scalar_Scalar
                       quickstep_expressions_scalar_ScalarCaseExpression
@@ -342,7 +346,6 @@ target_link_libraries(quickstep_queryoptimizer_expressions_WindowAggregateFuncti
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 
-
 # Module all-in-one library:
 add_library(quickstep_queryoptimizer_expressions ../../empty_src.cpp OptimizerExpressionsModule.hpp)
 target_link_libraries(quickstep_queryoptimizer_expressions
@@ -354,9 +357,9 @@ target_link_libraries(quickstep_queryoptimizer_expressions
                       quickstep_queryoptimizer_expressions_CommonSubexpression
                       quickstep_queryoptimizer_expressions_ComparisonExpression
                       quickstep_queryoptimizer_expressions_Exists
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_Expression
                       quickstep_queryoptimizer_expressions_ExpressionType
-                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_InTableQuery
                       quickstep_queryoptimizer_expressions_InValueList

--- a/query_optimizer/logical/CMakeLists.txt
+++ b/query_optimizer/logical/CMakeLists.txt
@@ -41,8 +41,8 @@ add_library(quickstep_queryoptimizer_logical_SharedSubplanReference
             SharedSubplanReference.cpp
             SharedSubplanReference.hpp)
 add_library(quickstep_queryoptimizer_logical_Sort Sort.cpp Sort.hpp)
-add_library(quickstep_queryoptimizer_logical_TableReference TableReference.cpp TableReference.hpp)
 add_library(quickstep_queryoptimizer_logical_TableGenerator ../../empty_src.cpp TableGenerator.hpp)
+add_library(quickstep_queryoptimizer_logical_TableReference TableReference.cpp TableReference.hpp)
 add_library(quickstep_queryoptimizer_logical_TopLevelPlan TopLevelPlan.cpp TopLevelPlan.hpp)
 add_library(quickstep_queryoptimizer_logical_UpdateTable UpdateTable.cpp UpdateTable.hpp)
 add_library(quickstep_queryoptimizer_logical_WindowAggregate WindowAggregate.cpp WindowAggregate.hpp)
@@ -89,8 +89,8 @@ target_link_libraries(quickstep_queryoptimizer_logical_CopyTo
                       quickstep_utility_StringUtil)
 target_link_libraries(quickstep_queryoptimizer_logical_CreateIndex
                       glog
-                      quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_OptimizerTree
+                      quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
                       quickstep_storage_StorageBlockLayout_proto
@@ -166,6 +166,7 @@ target_link_libraries(quickstep_queryoptimizer_logical_Join
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_Logical
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_Expression
@@ -217,6 +218,7 @@ target_link_libraries(quickstep_queryoptimizer_logical_Sample
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_SetOperation
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_logical_Logical
@@ -232,7 +234,6 @@ target_link_libraries(quickstep_queryoptimizer_logical_SharedSubplanReference
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_Sort
-                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
@@ -253,9 +254,9 @@ target_link_libraries(quickstep_queryoptimizer_logical_TableGenerator
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_TableReference
                       glog
+                      quickstep_catalog_CatalogRelation
                       quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_OptimizerTree
-                      quickstep_catalog_CatalogRelation
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
@@ -282,6 +283,7 @@ target_link_libraries(quickstep_queryoptimizer_logical_UpdateTable
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_logical_WindowAggregate
                       glog
+                      quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_Expression
@@ -290,10 +292,8 @@ target_link_libraries(quickstep_queryoptimizer_logical_WindowAggregate
                       quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_logical_Logical
                       quickstep_queryoptimizer_logical_LogicalType
-                      quickstep_queryoptimizer_OptimizerTree
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
-
 
 # Module all-in-one library:
 add_library(quickstep_queryoptimizer_logical ../../empty_src.cpp OptimizerLogicalModule.hpp)

--- a/query_optimizer/physical/CMakeLists.txt
+++ b/query_optimizer/physical/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(quickstep_queryoptimizer_physical_WindowAggregate WindowAggregate.cp
 
 # Link dependencies:
 target_link_libraries(quickstep_queryoptimizer_physical_Aggregate
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference
@@ -66,7 +67,6 @@ target_link_libraries(quickstep_queryoptimizer_physical_Aggregate
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_physical_BinaryJoin
-                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_NamedExpression
                       quickstep_queryoptimizer_physical_Join
@@ -116,6 +116,7 @@ target_link_libraries(quickstep_queryoptimizer_physical_CreateTable
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_physical_CrossReferenceCoalesceAggregate
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference
@@ -304,6 +305,7 @@ target_link_libraries(quickstep_queryoptimizer_physical_TopLevelPlan
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_physical_UnionAll
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
@@ -324,6 +326,7 @@ target_link_libraries(quickstep_queryoptimizer_physical_UpdateTable
                       quickstep_utility_Cast
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_physical_WindowAggregate
+                      glog
                       quickstep_queryoptimizer_OptimizerTree
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference

--- a/query_optimizer/resolver/CMakeLists.txt
+++ b/query_optimizer/resolver/CMakeLists.txt
@@ -124,8 +124,8 @@ target_link_libraries(quickstep_queryoptimizer_resolver_Resolver
                       quickstep_storage_StorageConstants
                       quickstep_types_IntType
                       quickstep_types_Type
-                      quickstep_types_TypedValue
                       quickstep_types_TypeFactory
+                      quickstep_types_TypedValue
                       quickstep_types_operations_binaryoperations_BinaryOperation
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -54,12 +54,12 @@ add_library(quickstep_queryoptimizer_rules_StarSchemaHashJoinOrderOptimization
             StarSchemaHashJoinOrderOptimization.hpp)
 add_library(quickstep_queryoptimizer_rules_SwapProbeBuild SwapProbeBuild.cpp SwapProbeBuild.hpp)
 add_library(quickstep_queryoptimizer_rules_TopDownRule ../../empty_src.cpp TopDownRule.hpp)
-add_library(quickstep_queryoptimizer_rules_UpdateExpression UpdateExpression.cpp UpdateExpression.hpp)
 add_library(quickstep_queryoptimizer_rules_UnnestSubqueries UnnestSubqueries.cpp UnnestSubqueries.hpp)
-
+add_library(quickstep_queryoptimizer_rules_UpdateExpression UpdateExpression.cpp UpdateExpression.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_queryoptimizer_rules_AttachLIPFilters
+                      glog
                       quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExprId
@@ -103,6 +103,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_CollapseSelection
                       quickstep_queryoptimizer_rules_RuleHelper
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_EliminateEmptyNode
+                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
@@ -145,6 +146,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_ExtractCommonSubexpression
                       quickstep_utility_HashError
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_FuseAggregateJoin
+                      glog
                       quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
                       quickstep_queryoptimizer_expressions_AggregateFunction
                       quickstep_queryoptimizer_expressions_Alias
@@ -166,6 +168,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_FuseAggregateJoin
                       quickstep_queryoptimizer_rules_BottomUpRule
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_FuseHashSelect
+                      glog
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_physical_HashJoin
                       quickstep_queryoptimizer_physical_PatternMatcher
@@ -195,9 +198,30 @@ target_link_libraries(quickstep_queryoptimizer_rules_GenerateJoins
                       quickstep_utility_Macros
                       quickstep_utility_SqlError
                       quickstep_utility_VectorUtil)
-target_link_libraries(quickstep_queryoptimizer_rules_Partition
+target_link_libraries(quickstep_queryoptimizer_rules_InjectJoinFilters
                       glog
-                      gtest
+                      quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
+                      quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExpressionUtil
+                      quickstep_queryoptimizer_expressions_Predicate
+                      quickstep_queryoptimizer_physical_Aggregate
+                      quickstep_queryoptimizer_physical_FilterJoin
+                      quickstep_queryoptimizer_physical_HashJoin
+                      quickstep_queryoptimizer_physical_LIPFilterConfiguration
+                      quickstep_queryoptimizer_physical_PatternMatcher
+                      quickstep_queryoptimizer_physical_Physical
+                      quickstep_queryoptimizer_physical_PhysicalType
+                      quickstep_queryoptimizer_physical_Selection
+                      quickstep_queryoptimizer_physical_TopLevelPlan
+                      quickstep_queryoptimizer_rules_PruneColumns
+                      quickstep_queryoptimizer_rules_Rule
+                      quickstep_types_TypeID
+                      quickstep_types_TypedValue
+                      quickstep_utility_Macros
+                      quickstep_utility_lipfilter_LIPFilter)
+target_link_libraries(quickstep_queryoptimizer_rules_Partition
+                      ${GFLAGS_LIB_NAME}
+                      glog
                       quickstep_expressions_aggregation_AggregateFunction
                       quickstep_expressions_aggregation_AggregateFunctionFactory
                       quickstep_expressions_aggregation_AggregationID
@@ -226,9 +250,9 @@ target_link_libraries(quickstep_queryoptimizer_rules_Partition
                       quickstep_types_operations_binaryoperations_BinaryOperationID
                       quickstep_utility_Cast
                       quickstep_utility_EqualsAnyConstant
-                      quickstep_utility_Macros
-                      ${GFLAGS_LIB_NAME})
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_PruneColumns
+                      glog
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
@@ -251,6 +275,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_PushDownFilter
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_PushDownLowCostDisjunctivePredicate
                       ${GFLAGS_LIB_NAME}
+                      glog
                       quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
@@ -279,6 +304,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_PushDownSemiAntiJoin
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_ReduceGroupByAttributes
                       ${GFLAGS_LIB_NAME}
+                      glog
                       quickstep_catalog_CatalogRelation
                       quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
@@ -306,6 +332,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_ReferencedBaseRelations
                       quickstep_queryoptimizer_rules_UnnestSubqueries
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_ReorderColumns
+                      glog
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_NamedExpression
@@ -359,6 +386,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_RuleHelper
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_rules_UpdateExpression)
 target_link_libraries(quickstep_queryoptimizer_rules_StarSchemaHashJoinOrderOptimization
+                      glog
                       quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExprId
@@ -385,29 +413,11 @@ target_link_libraries(quickstep_queryoptimizer_rules_SwapProbeBuild
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_queryoptimizer_rules_TopDownRule
+                      glog
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_queryoptimizer_rules_InjectJoinFilters
-                      quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
-                      quickstep_queryoptimizer_expressions_AttributeReference
-                      quickstep_queryoptimizer_expressions_ExpressionUtil
-                      quickstep_queryoptimizer_expressions_Predicate
-                      quickstep_queryoptimizer_physical_Aggregate
-                      quickstep_queryoptimizer_physical_FilterJoin
-                      quickstep_queryoptimizer_physical_HashJoin
-                      quickstep_queryoptimizer_physical_LIPFilterConfiguration
-                      quickstep_queryoptimizer_physical_PatternMatcher
-                      quickstep_queryoptimizer_physical_Physical
-                      quickstep_queryoptimizer_physical_PhysicalType
-                      quickstep_queryoptimizer_physical_Selection
-                      quickstep_queryoptimizer_physical_TopLevelPlan
-                      quickstep_queryoptimizer_rules_Rule
-                      quickstep_queryoptimizer_rules_PruneColumns
-                      quickstep_types_TypeID
-                      quickstep_types_TypedValue
-                      quickstep_utility_Macros
-                      quickstep_utility_lipfilter_LIPFilter)
 target_link_libraries(quickstep_queryoptimizer_rules_UnnestSubqueries
+                      glog
                       quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ComparisonExpression

--- a/query_optimizer/rules/Partition.hpp
+++ b/query_optimizer/rules/Partition.hpp
@@ -30,8 +30,6 @@
 #include "query_optimizer/rules/BottomUpRule.hpp"
 #include "utility/Macros.hpp"
 
-#include "gtest/gtest_prod.h"
-
 namespace quickstep {
 namespace optimizer {
 

--- a/query_optimizer/rules/tests/CMakeLists.txt
+++ b/query_optimizer/rules/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ add_executable(quickstep_queryoptimizer_rules_tests
                "${CMAKE_CURRENT_SOURCE_DIR}/UpdateExpression_unittest.cpp")
 
 target_link_libraries(quickstep_queryoptimizer_rules_tests
+                      ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       gtest_main
@@ -93,7 +95,5 @@ target_link_libraries(quickstep_queryoptimizer_rules_tests
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Cast
-                      quickstep_utility_Macros
-                      ${GFLAGS_LIB_NAME}
-                      ${LIBS})
+                      quickstep_utility_Macros)
 add_test(quickstep_queryoptimizer_rules_tests quickstep_queryoptimizer_rules_tests)

--- a/query_optimizer/strategy/tests/CMakeLists.txt
+++ b/query_optimizer/strategy/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(quickstep_queryoptimizer_strategy_tests
                "${CMAKE_CURRENT_SOURCE_DIR}/Selection_unittest.cpp")
 
 target_link_libraries(quickstep_queryoptimizer_strategy_tests
+                      ${LIBS}
                       glog
                       gtest
                       gtest_main
@@ -79,7 +80,6 @@ target_link_libraries(quickstep_queryoptimizer_strategy_tests
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Cast
-                      quickstep_utility_Macros
-                      ${LIBS})
+                      quickstep_utility_Macros)
 
 add_test(quickstep_queryoptimizer_strategy_tests quickstep_queryoptimizer_strategy_tests)

--- a/query_optimizer/tests/CMakeLists.txt
+++ b/query_optimizer/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(quickstep_queryoptimizer_tests_TestDatabaseLoader TestDatabaseLoader
 
 target_link_libraries(quickstep_queryoptimizer_tests_OptimizerTest
                       gtest
+                      gtest_main
                       quickstep_catalog_Catalog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogDatabase
@@ -103,6 +104,8 @@ add_executable(quickstep_queryoptimizer_tests_OptimizerTextTest
 
 if (ENABLE_DISTRIBUTED)
   target_link_libraries(quickstep_queryoptimizer_tests_DistributedExecutionGeneratorTest
+                        ${GFLAGS_LIB_NAME}
+                        ${LIBS}
                         glog
                         gtest
                         quickstep_catalog_CatalogTypedefs
@@ -128,11 +131,11 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_utility_MemStream
                         quickstep_utility_SqlError
                         quickstep_utility_TextBasedTestDriver
-                        tmb
-                        ${GFLAGS_LIB_NAME}
-                        ${LIBS})
+                        tmb)
 endif(ENABLE_DISTRIBUTED)
 target_link_libraries(quickstep_queryoptimizer_tests_ExecutionGeneratorTest
+                      ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       quickstep_catalog_CatalogDatabase
@@ -154,11 +157,10 @@ target_link_libraries(quickstep_queryoptimizer_tests_ExecutionGeneratorTest
                       quickstep_utility_MemStream
                       quickstep_utility_SqlError
                       quickstep_utility_TextBasedTestDriver
-                      tmb
-                      ${GFLAGS_LIB_NAME}
-                      ${LIBS})
+                      tmb)
 target_link_libraries(quickstep_queryoptimizer_tests_OptimizerTextTest
                       ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       gtest_main
@@ -172,5 +174,4 @@ target_link_libraries(quickstep_queryoptimizer_tests_OptimizerTextTest
                       quickstep_queryoptimizer_tests_TestDatabaseLoader
                       quickstep_utility_Macros
                       quickstep_utility_SqlError
-                      quickstep_utility_TextBasedTestDriver
-                      ${LIBS})
+                      quickstep_utility_TextBasedTestDriver)

--- a/query_optimizer/tests/logical_generator/CMakeLists.txt
+++ b/query_optimizer/tests/logical_generator/CMakeLists.txt
@@ -28,6 +28,6 @@ add_test(quickstep_queryoptimizer_tests_logicalgenerator_join
          "${CMAKE_CURRENT_SOURCE_DIR}/Join.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Join.test")
 add_test(quickstep_queryoptimizer_tests_logicalgenerator_select
-        "../quickstep_queryoptimizer_tests_OptimizerTextTest"
-        "${CMAKE_CURRENT_SOURCE_DIR}/Select.test"
-        "${CMAKE_CURRENT_BINARY_DIR}/Select.test")
+         "../quickstep_queryoptimizer_tests_OptimizerTextTest"
+         "${CMAKE_CURRENT_SOURCE_DIR}/Select.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/Select.test")

--- a/query_optimizer/tests/physical_generator/CMakeLists.txt
+++ b/query_optimizer/tests/physical_generator/CMakeLists.txt
@@ -36,9 +36,9 @@ add_test(quickstep_queryoptimizer_tests_physicalgenerator_drop
          "${CMAKE_CURRENT_SOURCE_DIR}/Drop.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Drop.test")
 add_test(quickstep_queryoptimizer_tests_physicalgenerator_index
-        "../quickstep_queryoptimizer_tests_OptimizerTextTest"
-        "${CMAKE_CURRENT_SOURCE_DIR}/Index.test"
-        "${CMAKE_CURRENT_BINARY_DIR}/Index.test")
+         "../quickstep_queryoptimizer_tests_OptimizerTextTest"
+         "${CMAKE_CURRENT_SOURCE_DIR}/Index.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/Index.test")
 add_test(quickstep_queryoptimizer_tests_physicalgenerator_insert
          "../quickstep_queryoptimizer_tests_OptimizerTextTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Insert.test"

--- a/query_optimizer/tests/resolver/CMakeLists.txt
+++ b/query_optimizer/tests/resolver/CMakeLists.txt
@@ -36,9 +36,9 @@ add_test(quickstep_queryoptimizer_tests_resolver_drop
          "${CMAKE_CURRENT_SOURCE_DIR}/Drop.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Drop.test")
 add_test(quickstep_queryoptimizer_tests_resolver_index
-        "../quickstep_queryoptimizer_tests_OptimizerTextTest"
-        "${CMAKE_CURRENT_SOURCE_DIR}/Index.test"
-        "${CMAKE_CURRENT_BINARY_DIR}/Index.test")
+         "../quickstep_queryoptimizer_tests_OptimizerTextTest"
+         "${CMAKE_CURRENT_SOURCE_DIR}/Index.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/Index.test")
 add_test(quickstep_queryoptimizer_tests_resolver_insert
          "../quickstep_queryoptimizer_tests_OptimizerTextTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Insert.test"

--- a/relational_operators/CMakeLists.txt
+++ b/relational_operators/CMakeLists.txt
@@ -40,10 +40,10 @@ add_library(quickstep_relationaloperators_BuildHashOperator BuildHashOperator.cp
 add_library(quickstep_relationaloperators_BuildLIPFilterOperator BuildLIPFilterOperator.cpp BuildLIPFilterOperator.hpp)
 add_library(quickstep_relationaloperators_CreateIndexOperator ../empty_src.cpp CreateIndexOperator.hpp)
 add_library(quickstep_relationaloperators_CreateTableOperator ../empty_src.cpp CreateTableOperator.hpp)
+add_library(quickstep_relationaloperators_DeleteOperator DeleteOperator.cpp DeleteOperator.hpp)
 add_library(quickstep_relationaloperators_DestroyAggregationStateOperator
             DestroyAggregationStateOperator.cpp
             DestroyAggregationStateOperator.hpp)
-add_library(quickstep_relationaloperators_DeleteOperator DeleteOperator.cpp DeleteOperator.hpp)
 add_library(quickstep_relationaloperators_DestroyHashOperator DestroyHashOperator.cpp DestroyHashOperator.hpp)
 add_library(quickstep_relationaloperators_DropTableOperator DropTableOperator.cpp DropTableOperator.hpp)
 add_library(quickstep_relationaloperators_FinalizeAggregationOperator
@@ -62,21 +62,26 @@ add_library(quickstep_relationaloperators_RelationalOperator ../empty_src.cpp Re
 add_library(quickstep_relationaloperators_SampleOperator SampleOperator.cpp SampleOperator.hpp)
 add_library(quickstep_relationaloperators_SaveBlocksOperator SaveBlocksOperator.cpp SaveBlocksOperator.hpp)
 add_library(quickstep_relationaloperators_SelectOperator SelectOperator.cpp SelectOperator.hpp)
-add_library(quickstep_relationaloperators_SortMergeRunOperator SortMergeRunOperator.cpp
+add_library(quickstep_relationaloperators_SortMergeRunOperator
+            SortMergeRunOperator.cpp
             SortMergeRunOperator.hpp)
+add_library(quickstep_relationaloperators_SortMergeRunOperatorHelpers
+            SortMergeRunOperatorHelpers.cpp
+            SortMergeRunOperatorHelpers.hpp)
 add_library(quickstep_relationaloperators_SortMergeRunOperator_proto
             ${relationaloperators_SortMergeRunOperator_proto_srcs}
             ${relationaloperators_SortMergeRunOperator_proto_hdrs})
-add_library(quickstep_relationaloperators_SortMergeRunOperatorHelpers SortMergeRunOperatorHelpers.cpp
-            SortMergeRunOperatorHelpers.hpp)
-add_library(quickstep_relationaloperators_SortRunGenerationOperator SortRunGenerationOperator.cpp
+add_library(quickstep_relationaloperators_SortRunGenerationOperator
+            SortRunGenerationOperator.cpp
             SortRunGenerationOperator.hpp)
 add_library(quickstep_relationaloperators_TableExportOperator TableExportOperator.cpp TableExportOperator.hpp)
 add_library(quickstep_relationaloperators_TableGeneratorOperator TableGeneratorOperator.cpp TableGeneratorOperator.hpp)
 add_library(quickstep_relationaloperators_TextScanOperator TextScanOperator.cpp TextScanOperator.hpp)
 add_library(quickstep_relationaloperators_UnionAllOperator UnionAllOperator.cpp UnionAllOperator.hpp)
 add_library(quickstep_relationaloperators_UpdateOperator UpdateOperator.cpp UpdateOperator.hpp)
-add_library(quickstep_relationaloperators_WindowAggregationOperator WindowAggregationOperator.cpp WindowAggregationOperator.hpp)
+add_library(quickstep_relationaloperators_WindowAggregationOperator
+            WindowAggregationOperator.cpp
+            WindowAggregationOperator.hpp)
 add_library(quickstep_relationaloperators_WorkOrder ../empty_src.cpp WorkOrder.hpp)
 add_library(quickstep_relationaloperators_WorkOrderFactory WorkOrderFactory.cpp WorkOrderFactory.hpp)
 add_library(quickstep_relationaloperators_WorkOrder_proto
@@ -412,10 +417,6 @@ target_link_libraries(quickstep_relationaloperators_SelectOperator
                       quickstep_utility_lipfilter_LIPFilterAdaptiveProber
                       quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
-if(QUICKSTEP_HAVE_LIBNUMA)
-target_link_libraries(quickstep_relationaloperators_SelectOperator
-                      quickstep_catalog_NUMAPlacementScheme)
-endif()
 target_link_libraries(quickstep_relationaloperators_SortMergeRunOperator
                       glog
                       quickstep_catalog_CatalogRelation
@@ -434,8 +435,6 @@ target_link_libraries(quickstep_relationaloperators_SortMergeRunOperator
                       quickstep_utility_Macros
                       quickstep_utility_SortConfiguration
                       tmb)
-target_link_libraries(quickstep_relationaloperators_SortMergeRunOperator_proto
-                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_relationaloperators_SortMergeRunOperatorHelpers
                       glog
                       quickstep_catalog_CatalogTypedefs
@@ -456,6 +455,8 @@ target_link_libraries(quickstep_relationaloperators_SortMergeRunOperatorHelpers
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector
                       quickstep_utility_SortConfiguration)
+target_link_libraries(quickstep_relationaloperators_SortMergeRunOperator_proto
+                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_relationaloperators_SortRunGenerationOperator
                       glog
                       quickstep_catalog_CatalogRelation
@@ -493,7 +494,8 @@ target_link_libraries(quickstep_relationaloperators_TableExportOperator
                       quickstep_types_containers_Tuple
                       quickstep_utility_BulkIoConfiguration
                       quickstep_utility_Macros
-                      quickstep_utility_StringUtil)
+                      quickstep_utility_StringUtil
+                      tmb)
 target_link_libraries(quickstep_relationaloperators_TableGeneratorOperator
                       glog
                       quickstep_catalog_CatalogRelation
@@ -533,10 +535,6 @@ target_link_libraries(quickstep_relationaloperators_TextScanOperator
                       quickstep_utility_Glob
                       quickstep_utility_Macros
                       tmb)
-if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
-  target_link_libraries(quickstep_relationaloperators_TextScanOperator
-                        ${LIBHDFS3_LIBRARIES})
-endif(QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
 target_link_libraries(quickstep_relationaloperators_UnionAllOperator
                       glog
                       quickstep_catalog_CatalogRelation
@@ -629,16 +627,26 @@ target_link_libraries(quickstep_relationaloperators_WorkOrderFactory
                       quickstep_utility_lipfilter_LIPFilterUtil
                       tmb)
 target_link_libraries(quickstep_relationaloperators_WorkOrder_proto
-                      quickstep_relationaloperators_SortMergeRunOperator_proto
-                      ${PROTOBUF_LIBRARY})
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_relationaloperators_SortMergeRunOperator_proto)
+
+if(QUICKSTEP_HAVE_LIBNUMA)
+  target_link_libraries(quickstep_relationaloperators_SelectOperator
+                        quickstep_catalog_NUMAPlacementScheme)
+endif()
+
+if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
+  target_link_libraries(quickstep_relationaloperators_TextScanOperator
+                        ${LIBHDFS3_LIBRARIES})
+endif(QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
 
 # Module all-in-one library:
 add_library(quickstep_relationaloperators ../empty_src.cpp RelationalOperatorsModule.hpp)
 target_link_libraries(quickstep_relationaloperators
                       quickstep_relationaloperators_AggregationOperator
                       quickstep_relationaloperators_BuildAggregationExistenceMapOperator
-                      quickstep_relationaloperators_BuildLIPFilterOperator
                       quickstep_relationaloperators_BuildHashOperator
+                      quickstep_relationaloperators_BuildLIPFilterOperator
                       quickstep_relationaloperators_CreateIndexOperator
                       quickstep_relationaloperators_CreateTableOperator
                       quickstep_relationaloperators_DeleteOperator
@@ -674,6 +682,7 @@ add_executable(AggregationOperator_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/AggregationOperator_unittest.cpp")
 target_link_libraries(AggregationOperator_unittest
                       ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       quickstep_catalog_CatalogAttribute
@@ -720,14 +729,14 @@ target_link_libraries(AggregationOperator_unittest
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Macros
                       quickstep_utility_PtrList
-                      tmb
-                      ${LIBS})
+                      tmb)
 add_test(AggregationOperator_unittest AggregationOperator_unittest)
 
 add_executable(HashJoinOperator_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/HashJoinOperator_unittest.cpp")
 target_link_libraries(HashJoinOperator_unittest
                       ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       quickstep_catalog_CatalogAttribute
@@ -750,8 +759,8 @@ target_link_libraries(HashJoinOperator_unittest
                       quickstep_relationaloperators_HashJoinOperator
                       quickstep_relationaloperators_RelationalOperator
                       quickstep_relationaloperators_WorkOrder
-                      quickstep_storage_HashTable_proto
                       quickstep_storage_HashTableBase
+                      quickstep_storage_HashTable_proto
                       quickstep_storage_InsertDestination
                       quickstep_storage_InsertDestination_proto
                       quickstep_storage_StorageBlock
@@ -772,14 +781,14 @@ target_link_libraries(HashJoinOperator_unittest
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_Macros
-                      tmb
-                      ${LIBS})
+                      tmb)
 add_test(HashJoinOperator_unittest HashJoinOperator_unittest)
 
 add_executable(SortMergeRunOperator_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/SortMergeRunOperator_unittest.cpp")
 target_link_libraries(SortMergeRunOperator_unittest
                       ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       quickstep_catalog_CatalogAttribute
@@ -822,14 +831,14 @@ target_link_libraries(SortMergeRunOperator_unittest
                       quickstep_utility_PtrVector
                       quickstep_utility_SortConfiguration
                       quickstep_utility_SortConfiguration_proto
-                      tmb
-                      ${LIBS})
+                      tmb)
 add_test(SortMergeRunOperator_unittest SortMergeRunOperator_unittest)
 
 add_executable(SortRunGenerationOperator_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/SortRunGenerationOperator_unittest.cpp")
 target_link_libraries(SortRunGenerationOperator_unittest
                       ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       glog
                       gtest
                       quickstep_catalog_CatalogAttribute
@@ -869,8 +878,7 @@ target_link_libraries(SortRunGenerationOperator_unittest
                       quickstep_types_containers_Tuple
                       quickstep_utility_SortConfiguration
                       quickstep_utility_SortConfiguration_proto
-                      tmb
-                      ${LIBS})
+                      tmb)
 add_test(SortRunGenerationOperator_unittest SortRunGenerationOperator_unittest)
 
 add_executable(TextScanOperator_unittest

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -152,19 +152,7 @@ add_library(quickstep_storage_BasicColumnStoreValueAccessor
             ../empty_src.cpp
             BasicColumnStoreValueAccessor.hpp)
 add_library(quickstep_storage_BloomFilterIndexSubBlock BloomFilterIndexSubBlock.cpp BloomFilterIndexSubBlock.hpp)
-# CMAKE_VALIDATE_IGNORE_BEGIN
-if(QUICKSTEP_HAVE_BITWEAVING)
-  add_library(quickstep_storage_BitWeavingIndexSubBlock
-              bitweaving/BitWeavingIndexSubBlock.cpp
-              bitweaving/BitWeavingIndexSubBlock.hpp)
-  add_library(quickstep_storage_BitWeavingHIndexSubBlock
-              bitweaving/BitWeavingHIndexSubBlock.cpp
-              bitweaving/BitWeavingHIndexSubBlock.hpp)
-  add_library(quickstep_storage_BitWeavingVIndexSubBlock
-              bitweaving/BitWeavingVIndexSubBlock.cpp
-              bitweaving/BitWeavingVIndexSubBlock.hpp)
-endif()
-# CMAKE_VALIDATE_IGNORE_END
+add_library(quickstep_storage_CSBTreeIndexSubBlock CSBTreeIndexSubBlock.cpp CSBTreeIndexSubBlock.hpp)
 add_library(quickstep_storage_CollisionFreeVectorTable
             CollisionFreeVectorTable.cpp
             CollisionFreeVectorTable.hpp)
@@ -187,33 +175,16 @@ add_library(quickstep_storage_CompressedTupleStorageSubBlock
             CompressedTupleStorageSubBlock.cpp
             CompressedTupleStorageSubBlock.hpp)
 add_library(quickstep_storage_CountedReference ../empty_src.cpp CountedReference.hpp)
-add_library(quickstep_storage_CSBTreeIndexSubBlock CSBTreeIndexSubBlock.cpp CSBTreeIndexSubBlock.hpp)
-
-if (ENABLE_DISTRIBUTED)
-  add_library(quickstep_storage_DataExchange_proto
-              ${storage_DataExchange_proto_srcs}
-              ${storage_DataExchange_proto_hdrs})
-  add_library(quickstep_storage_DataExchangerAsync DataExchangerAsync.cpp DataExchangerAsync.hpp)
-endif()
-
 add_library(quickstep_storage_EvictionPolicy EvictionPolicy.cpp EvictionPolicy.hpp)
 add_library(quickstep_storage_FileManager ../empty_src.cpp FileManager.hpp)
-if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
-  add_library(quickstep_storage_FileManagerHdfs FileManagerHdfs.cpp FileManagerHdfs.hpp)
-endif()
 add_library(quickstep_storage_FileManagerLocal ../empty_src.cpp FileManagerLocal.hpp)
-if (QUICKSTEP_HAVE_FILE_MANAGER_POSIX)
-  add_library(quickstep_storage_FileManagerPosix FileManagerPosix.cpp FileManagerPosix.hpp)
-elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
-  add_library(quickstep_storage_FileManagerWindows FileManagerWindows.cpp FileManagerWindows.hpp)
-endif()
 add_library(quickstep_storage_Flags Flags.cpp Flags.hpp)
 add_library(quickstep_storage_HashTable ../empty_src.cpp HashTable.hpp)
-add_library(quickstep_storage_HashTable_proto ${storage_HashTable_proto_srcs})
 add_library(quickstep_storage_HashTableBase ../empty_src.cpp HashTableBase.hpp)
 add_library(quickstep_storage_HashTableFactory HashTableFactory.cpp HashTableFactory.hpp)
 add_library(quickstep_storage_HashTableKeyManager ../empty_src.cpp HashTableKeyManager.hpp)
 add_library(quickstep_storage_HashTablePool ../empty_src.cpp HashTablePool.hpp)
+add_library(quickstep_storage_HashTable_proto ${storage_HashTable_proto_srcs})
 add_library(quickstep_storage_IndexSubBlock ../empty_src.cpp IndexSubBlock.hpp)
 add_library(quickstep_storage_IndexSubBlockDescriptionFactory ../empty_src.cpp IndexSubBlockDescriptionFactory.hpp)
 add_library(quickstep_storage_InsertDestination InsertDestination.cpp InsertDestination.hpp)
@@ -260,10 +231,40 @@ add_library(quickstep_storage_ValueAccessor ../empty_src.cpp ValueAccessor.hpp)
 add_library(quickstep_storage_ValueAccessorMultiplexer ../empty_src.cpp ValueAccessorMultiplexer.hpp)
 add_library(quickstep_storage_ValueAccessorUtil ../empty_src.cpp ValueAccessorUtil.hpp)
 add_library(quickstep_storage_WindowAggregationOperationState
-            WindowAggregationOperationState.hpp
-            WindowAggregationOperationState.cpp)
-add_library(quickstep_storage_WindowAggregationOperationState_proto ${storage_WindowAggregationOperationState_proto_srcs})
+            WindowAggregationOperationState.cpp
+            WindowAggregationOperationState.hpp)
+add_library(quickstep_storage_WindowAggregationOperationState_proto
+            ${storage_WindowAggregationOperationState_proto_srcs})
 
+# CMAKE_VALIDATE_IGNORE_BEGIN
+if(QUICKSTEP_HAVE_BITWEAVING)
+  add_library(quickstep_storage_BitWeavingIndexSubBlock
+              bitweaving/BitWeavingIndexSubBlock.cpp
+              bitweaving/BitWeavingIndexSubBlock.hpp)
+  add_library(quickstep_storage_BitWeavingHIndexSubBlock
+              bitweaving/BitWeavingHIndexSubBlock.cpp
+              bitweaving/BitWeavingHIndexSubBlock.hpp)
+  add_library(quickstep_storage_BitWeavingVIndexSubBlock
+              bitweaving/BitWeavingVIndexSubBlock.cpp
+              bitweaving/BitWeavingVIndexSubBlock.hpp)
+endif()
+# CMAKE_VALIDATE_IGNORE_END
+
+if (ENABLE_DISTRIBUTED)
+  add_library(quickstep_storage_DataExchange_proto
+              ${storage_DataExchange_proto_srcs}
+              ${storage_DataExchange_proto_hdrs})
+  add_library(quickstep_storage_DataExchangerAsync DataExchangerAsync.cpp DataExchangerAsync.hpp)
+endif()
+
+if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
+  add_library(quickstep_storage_FileManagerHdfs FileManagerHdfs.cpp FileManagerHdfs.hpp)
+endif()
+if (QUICKSTEP_HAVE_FILE_MANAGER_POSIX)
+  add_library(quickstep_storage_FileManagerPosix FileManagerPosix.cpp FileManagerPosix.hpp)
+elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
+  add_library(quickstep_storage_FileManagerWindows FileManagerWindows.cpp FileManagerWindows.hpp)
+endif()
 
 # Link dependencies:
 target_link_libraries(quickstep_storage_AggregationOperationState
@@ -285,8 +286,8 @@ target_link_libraries(quickstep_storage_AggregationOperationState
                       quickstep_storage_HashTablePool
                       quickstep_storage_HashTable_proto
                       quickstep_storage_InsertDestination
-                      quickstep_storage_PartitionedHashTablePool
                       quickstep_storage_PackedPayloadHashTable
+                      quickstep_storage_PartitionedHashTablePool
                       quickstep_storage_StorageBlock
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageManager
@@ -305,11 +306,12 @@ target_link_libraries(quickstep_storage_AggregationOperationState
                       quickstep_utility_Macros
                       quickstep_utility_lipfilter_LIPFilterAdaptiveProber)
 target_link_libraries(quickstep_storage_AggregationOperationState_proto
+                      ${PROTOBUF_LIBRARY}
                       quickstep_expressions_Expressions_proto
                       quickstep_expressions_aggregation_AggregateFunction_proto
-                      quickstep_storage_HashTable_proto
-                      ${PROTOBUF_LIBRARY})
+                      quickstep_storage_HashTable_proto)
 target_link_libraries(quickstep_storage_BasicColumnStoreTupleStorageSubBlock
+                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
@@ -351,6 +353,7 @@ target_link_libraries(quickstep_storage_BasicColumnStoreValueAccessor
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector)
 target_link_libraries(quickstep_storage_BloomFilterIndexSubBlock
+                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_catalog_CatalogTypedefs
@@ -372,75 +375,37 @@ target_link_libraries(quickstep_storage_BloomFilterIndexSubBlock
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_utility_BloomFilter
                       quickstep_utility_Macros)
-# CMAKE_VALIDATE_IGNORE_BEGIN
-if(QUICKSTEP_HAVE_BITWEAVING)
-  target_link_libraries(quickstep_storage_BitWeavingHIndexSubBlock
-                        glog
-                        quickstep_catalog_CatalogTypedefs
-                        quickstep_compression_CompressionDictionary
-                        quickstep_compression_CompressionDictionaryBuilder
-                        quickstep_expressions_predicate_ComparisonPredicate
-                        quickstep_expressions_predicate_PredicateCost
-                        quickstep_storage_BitWeavingIndexSubBlock
-                        quickstep_storage_CompressedTupleStorageSubBlock
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageBlockLayout_proto
-                        quickstep_storage_SubBlockTypeRegistry
-                        quickstep_storage_SubBlockTypeRegistryMacros
-                        quickstep_storage_TupleStorageSubBlock
-                        quickstep_types_TypedValue
-                        quickstep_types_operations_comparisons_ComparisonID
-                        quickstep_utility_Macros)
-  target_link_libraries(quickstep_storage_BitWeavingIndexSubBlock
-                        glog
-                        quickstep_catalog_CatalogAttribute
-                        quickstep_catalog_CatalogRelationSchema
-                        quickstep_catalog_CatalogTypedefs
-                        quickstep_compression_CompressionDictionary
-                        quickstep_compression_CompressionDictionaryBuilder
-                        quickstep_expressions_predicate_ComparisonPredicate
-                        quickstep_expressions_predicate_Predicate
-                        quickstep_expressions_scalar_Scalar
-                        quickstep_expressions_scalar_ScalarAttribute
-                        quickstep_storage_CompressedStoreUtil
-                        quickstep_storage_CompressedTupleStorageSubBlock
-                        quickstep_storage_IndexSubBlock
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageBlockLayout_proto
-                        quickstep_storage_StorageConstants
-                        quickstep_storage_StorageErrors
-                        quickstep_storage_TupleIdSequence
-                        quickstep_storage_TupleStorageSubBlock
-                        quickstep_storage_ValueAccessor
-                        quickstep_storage_ValueAccessorUtil
-                        quickstep_types_Type
-                        quickstep_types_TypedValue
-                        quickstep_types_operations_comparisons_ComparisonID
-                        quickstep_utility_BitManipulation
-                        quickstep_utility_Macros)
-  target_link_libraries(quickstep_storage_BitWeavingVIndexSubBlock
-                        glog
-                        quickstep_catalog_CatalogTypedefs
-                        quickstep_compression_CompressionDictionary
-                        quickstep_compression_CompressionDictionaryBuilder
-                        quickstep_expressions_predicate_ComparisonPredicate
-                        quickstep_expressions_predicate_PredicateCost
-                        quickstep_storage_BitWeavingIndexSubBlock
-                        quickstep_storage_CompressedTupleStorageSubBlock
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageBlockLayout_proto
-                        quickstep_storage_StorageConstants
-                        quickstep_storage_SubBlockTypeRegistry
-                        quickstep_storage_SubBlockTypeRegistryMacros
-                        quickstep_storage_TupleStorageSubBlock
-                        quickstep_storage_ValueAccessor
-                        quickstep_storage_ValueAccessorUtil
-                        quickstep_types_TypedValue
-                        quickstep_types_operations_comparisons_ComparisonID
-                        quickstep_utility_Macros)
-endif()
-# CMAKE_VALIDATE_IGNORE_END
+target_link_libraries(quickstep_storage_CSBTreeIndexSubBlock
+                      quickstep_catalog_CatalogAttribute
+                      quickstep_catalog_CatalogRelationSchema
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_compression_CompressionDictionary
+                      quickstep_expressions_predicate_ComparisonPredicate
+                      quickstep_expressions_predicate_PredicateCost
+                      quickstep_expressions_scalar_Scalar
+                      quickstep_expressions_scalar_ScalarAttribute
+                      quickstep_storage_CompressedTupleStorageSubBlock
+                      quickstep_storage_IndexSubBlock
+                      quickstep_storage_StorageBlockInfo
+                      quickstep_storage_StorageBlockLayout_proto
+                      quickstep_storage_StorageConstants
+                      quickstep_storage_StorageErrors
+                      quickstep_storage_SubBlockTypeRegistry
+                      quickstep_storage_SubBlockTypeRegistryMacros
+                      quickstep_storage_TupleIdSequence
+                      quickstep_storage_TupleStorageSubBlock
+                      quickstep_types_Type
+                      quickstep_types_TypedValue
+                      quickstep_types_operations_comparisons_Comparison
+                      quickstep_types_operations_comparisons_ComparisonFactory
+                      quickstep_types_operations_comparisons_ComparisonID
+                      quickstep_types_operations_comparisons_ComparisonUtil
+                      quickstep_utility_BitVector
+                      quickstep_utility_Macros
+                      quickstep_utility_PtrVector
+                      quickstep_utility_ScopedBuffer)
 target_link_libraries(quickstep_storage_CollisionFreeVectorTable
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_expressions_aggregation_AggregationID
@@ -605,50 +570,8 @@ target_link_libraries(quickstep_storage_CountedReference
                       quickstep_storage_EvictionPolicy
                       quickstep_storage_StorageBlockBase
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_storage_CSBTreeIndexSubBlock
-                      quickstep_catalog_CatalogAttribute
-                      quickstep_catalog_CatalogRelationSchema
-                      quickstep_catalog_CatalogTypedefs
-                      quickstep_compression_CompressionDictionary
-                      quickstep_expressions_predicate_ComparisonPredicate
-                      quickstep_expressions_predicate_PredicateCost
-                      quickstep_expressions_scalar_Scalar
-                      quickstep_expressions_scalar_ScalarAttribute
-                      quickstep_storage_CompressedTupleStorageSubBlock
-                      quickstep_storage_IndexSubBlock
-                      quickstep_storage_StorageBlockInfo
-                      quickstep_storage_StorageBlockLayout_proto
-                      quickstep_storage_StorageConstants
-                      quickstep_storage_StorageErrors
-                      quickstep_storage_SubBlockTypeRegistry
-                      quickstep_storage_SubBlockTypeRegistryMacros
-                      quickstep_storage_TupleIdSequence
-                      quickstep_storage_TupleStorageSubBlock
-                      quickstep_types_Type
-                      quickstep_types_TypedValue
-                      quickstep_types_operations_comparisons_Comparison
-                      quickstep_types_operations_comparisons_ComparisonFactory
-                      quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_types_operations_comparisons_ComparisonUtil
-                      quickstep_utility_BitVector
-                      quickstep_utility_Macros
-                      quickstep_utility_PtrVector
-                      quickstep_utility_ScopedBuffer)
-
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_storage_DataExchange_proto
-                        ${PROTOBUF3_LIBRARY})
-  target_link_libraries(quickstep_storage_DataExchangerAsync
-                        glog
-                        quickstep_storage_DataExchange_proto
-                        quickstep_storage_StorageManager
-                        quickstep_threading_Thread
-                        quickstep_utility_Macros
-                        quickstep_utility_NetworkUtil
-                        ${GRPCPLUSPLUS_LIBRARIES})
-endif()
-
 target_link_libraries(quickstep_storage_EvictionPolicy
+                      glog
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_StorageConstants
                       quickstep_threading_Mutex
@@ -659,41 +582,6 @@ target_link_libraries(quickstep_storage_FileManager
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_Macros
                       quickstep_utility_StringUtil)
-if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
-  target_link_libraries(quickstep_storage_FileManagerHdfs
-                        glog
-                        quickstep_storage_FileManager
-                        quickstep_storage_Flags
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageConstants
-                        quickstep_storage_StorageErrors
-                        quickstep_utility_Macros
-                        quickstep_utility_StringUtil
-                        ${LIBHDFS3_LIBRARIES})
-endif()
-if (QUICKSTEP_HAVE_FILE_MANAGER_POSIX)
-  target_link_libraries(quickstep_storage_FileManagerLocal
-                        quickstep_storage_FileManagerPosix)
-  target_link_libraries(quickstep_storage_FileManagerPosix
-                        glog
-                        quickstep_storage_FileManager
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageConstants
-                        quickstep_storage_StorageErrors
-                        quickstep_utility_Macros
-                        quickstep_utility_StringUtil)
-elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
-  target_link_libraries(quickstep_storage_FileManagerLocal
-                        quickstep_storage_FileManagerWindows)
-  target_link_libraries(quickstep_storage_FileManagerWindows
-                        glog
-                        quickstep_storage_FileManager
-                        quickstep_storage_StorageBlockInfo
-                        quickstep_storage_StorageConstants
-                        quickstep_storage_StorageErrors
-                        quickstep_utility_Macros
-                        quickstep_utility_StringUtil)
-endif()
 target_link_libraries(quickstep_storage_Flags
                       ${GFLAGS_LIB_NAME})
 target_link_libraries(quickstep_storage_HashTable
@@ -715,15 +603,12 @@ target_link_libraries(quickstep_storage_HashTable
 target_link_libraries(quickstep_storage_HashTableBase
                       quickstep_storage_ValueAccessorMultiplexer
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_storage_HashTable_proto
-                      quickstep_types_Type_proto
-                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_storage_HashTableFactory
                       glog
                       quickstep_storage_CollisionFreeVectorTable
                       quickstep_storage_HashTable
-                      quickstep_storage_HashTable_proto
                       quickstep_storage_HashTableBase
+                      quickstep_storage_HashTable_proto
                       quickstep_storage_LinearOpenAddressingHashTable
                       quickstep_storage_PackedPayloadHashTable
                       quickstep_storage_SeparateChainingHashTable
@@ -749,6 +634,9 @@ target_link_libraries(quickstep_storage_HashTablePool
                       quickstep_storage_HashTableFactory
                       quickstep_threading_SpinMutex
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_storage_HashTable_proto
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_types_Type_proto)
 target_link_libraries(quickstep_storage_IndexSubBlock
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_predicate_PredicateCost
@@ -789,9 +677,9 @@ target_link_libraries(quickstep_storage_InsertDestinationInterface
                       quickstep_catalog_PartitionSchemeHeader
                       quickstep_types_containers_Tuple)
 target_link_libraries(quickstep_storage_InsertDestination_proto
+                      ${PROTOBUF_LIBRARY}
                       quickstep_catalog_Catalog_proto
-                      quickstep_storage_StorageBlockLayout_proto
-                      ${PROTOBUF_LIBRARY})
+                      quickstep_storage_StorageBlockLayout_proto)
 target_link_libraries(quickstep_storage_LinearOpenAddressingHashTable
                       quickstep_storage_HashTable
                       quickstep_storage_HashTableKeyManager
@@ -806,6 +694,7 @@ target_link_libraries(quickstep_storage_LinearOpenAddressingHashTable
                       quickstep_utility_Macros
                       quickstep_utility_PrimeNumber)
 target_link_libraries(quickstep_storage_PackedPayloadHashTable
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_expressions_aggregation_AggregationHandle
                       quickstep_storage_HashTableBase
@@ -844,10 +733,6 @@ target_link_libraries(quickstep_storage_PreloaderThread
                       quickstep_threading_Thread
                       quickstep_threading_ThreadUtil
                       quickstep_utility_Macros)
-if (QUICKSTEP_HAVE_LIBNUMA)
-  target_link_libraries(quickstep_storage_PreloaderThread
-                        quickstep_catalog_NUMAPlacementScheme)
-endif()
 target_link_libraries(quickstep_storage_SMAIndexSubBlock
                       glog
                       quickstep_catalog_CatalogAttribute
@@ -908,6 +793,7 @@ target_link_libraries(quickstep_storage_SimpleScalarSeparateChainingHashTable
                       quickstep_utility_PrimeNumber)
 target_link_libraries(quickstep_storage_SplitRowStoreTupleStorageSubBlock
                       glog
+                      gtest
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_expressions_predicate_PredicateCost
                       quickstep_storage_SplitRowStoreValueAccessor
@@ -972,14 +858,6 @@ target_link_libraries(quickstep_storage_StorageBlock
                       quickstep_utility_ColumnVectorCache
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector)
-# CMAKE_VALIDATE_IGNORE_BEGIN
-if(QUICKSTEP_HAVE_BITWEAVING)
-  target_link_libraries(quickstep_storage_StorageBlock
-                        quickstep_storage_BitWeavingHIndexSubBlock
-                        quickstep_storage_BitWeavingIndexSubBlock
-                        quickstep_storage_BitWeavingVIndexSubBlock)
-endif()
-# CMAKE_VALIDATE_IGNORE_END
 target_link_libraries(quickstep_storage_StorageBlockBase
                       glog
                       quickstep_storage_StorageBlockInfo
@@ -995,12 +873,11 @@ target_link_libraries(quickstep_storage_StorageBlockLayout
                       quickstep_storage_StorageConstants
                       quickstep_storage_StorageErrors
                       quickstep_storage_SubBlockTypeRegistry
-                      quickstep_utility_Macros
+                      quickstep_utility_Macros)
+target_link_libraries(quickstep_storage_StorageBlockLayout_proto
                       ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_storage_StorageErrors
                       quickstep_storage_StorageBlockInfo)
-target_link_libraries(quickstep_storage_StorageBlockLayout_proto
-                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_storage_StorageManager
                       ${GFLAGS_LIB_NAME}
                       glog
@@ -1025,22 +902,6 @@ target_link_libraries(quickstep_storage_StorageManager
                       quickstep_utility_Macros
                       quickstep_utility_ShardedLockManager
                       tmb)
-if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
-target_link_libraries(quickstep_storage_StorageManager
-                      quickstep_storage_FileManagerHdfs)
-endif()
-if (QUICKSTEP_HAVE_LIBNUMA)
-  target_link_libraries(quickstep_storage_StorageManager
-                        ${LIBNUMA_LIBRARY})
-endif()
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_storage_StorageManager
-                        quickstep_queryexecution_QueryExecutionMessages_proto
-                        quickstep_queryexecution_QueryExecutionTypedefs
-                        quickstep_queryexecution_QueryExecutionUtil
-                        quickstep_storage_DataExchange_proto
-                        ${GRPCPLUSPLUS_LIBRARIES})
-endif(ENABLE_DISTRIBUTED)
 target_link_libraries(quickstep_storage_SubBlockTypeRegistry
                       glog
                       quickstep_storage_StorageBlockLayout_proto
@@ -1095,7 +956,6 @@ target_link_libraries(quickstep_storage_ValueAccessor
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_ValueAccessorMultiplexer
-                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_ValueAccessorUtil
@@ -1133,9 +993,147 @@ target_link_libraries(quickstep_storage_WindowAggregationOperationState
                       quickstep_utility_ColumnVectorCache
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_storage_WindowAggregationOperationState_proto
+                      ${PROTOBUF_LIBRARY}
                       quickstep_expressions_Expressions_proto
-                      quickstep_expressions_windowaggregation_WindowAggregateFunction_proto
-                      ${PROTOBUF_LIBRARY})
+                      quickstep_expressions_windowaggregation_WindowAggregateFunction_proto)
+
+# CMAKE_VALIDATE_IGNORE_BEGIN
+if(QUICKSTEP_HAVE_BITWEAVING)
+  target_link_libraries(quickstep_storage_BitWeavingHIndexSubBlock
+                        glog
+                        quickstep_catalog_CatalogTypedefs
+                        quickstep_compression_CompressionDictionary
+                        quickstep_compression_CompressionDictionaryBuilder
+                        quickstep_expressions_predicate_ComparisonPredicate
+                        quickstep_expressions_predicate_PredicateCost
+                        quickstep_storage_BitWeavingIndexSubBlock
+                        quickstep_storage_CompressedTupleStorageSubBlock
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageBlockLayout_proto
+                        quickstep_storage_SubBlockTypeRegistry
+                        quickstep_storage_SubBlockTypeRegistryMacros
+                        quickstep_storage_TupleStorageSubBlock
+                        quickstep_types_TypedValue
+                        quickstep_types_operations_comparisons_ComparisonID
+                        quickstep_utility_Macros)
+  target_link_libraries(quickstep_storage_BitWeavingIndexSubBlock
+                        glog
+                        quickstep_catalog_CatalogAttribute
+                        quickstep_catalog_CatalogRelationSchema
+                        quickstep_catalog_CatalogTypedefs
+                        quickstep_compression_CompressionDictionary
+                        quickstep_compression_CompressionDictionaryBuilder
+                        quickstep_expressions_predicate_ComparisonPredicate
+                        quickstep_expressions_predicate_Predicate
+                        quickstep_expressions_scalar_Scalar
+                        quickstep_expressions_scalar_ScalarAttribute
+                        quickstep_storage_CompressedStoreUtil
+                        quickstep_storage_CompressedTupleStorageSubBlock
+                        quickstep_storage_IndexSubBlock
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageBlockLayout_proto
+                        quickstep_storage_StorageConstants
+                        quickstep_storage_StorageErrors
+                        quickstep_storage_TupleIdSequence
+                        quickstep_storage_TupleStorageSubBlock
+                        quickstep_storage_ValueAccessor
+                        quickstep_storage_ValueAccessorUtil
+                        quickstep_types_Type
+                        quickstep_types_TypedValue
+                        quickstep_types_operations_comparisons_ComparisonID
+                        quickstep_utility_BitManipulation
+                        quickstep_utility_Macros)
+  target_link_libraries(quickstep_storage_BitWeavingVIndexSubBlock
+                        glog
+                        quickstep_catalog_CatalogTypedefs
+                        quickstep_compression_CompressionDictionary
+                        quickstep_compression_CompressionDictionaryBuilder
+                        quickstep_expressions_predicate_ComparisonPredicate
+                        quickstep_expressions_predicate_PredicateCost
+                        quickstep_storage_BitWeavingIndexSubBlock
+                        quickstep_storage_CompressedTupleStorageSubBlock
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageBlockLayout_proto
+                        quickstep_storage_StorageConstants
+                        quickstep_storage_SubBlockTypeRegistry
+                        quickstep_storage_SubBlockTypeRegistryMacros
+                        quickstep_storage_TupleStorageSubBlock
+                        quickstep_storage_ValueAccessor
+                        quickstep_storage_ValueAccessorUtil
+                        quickstep_types_TypedValue
+                        quickstep_types_operations_comparisons_ComparisonID
+                        quickstep_utility_Macros)
+  target_link_libraries(quickstep_storage_StorageBlock
+                        quickstep_storage_BitWeavingHIndexSubBlock
+                        quickstep_storage_BitWeavingIndexSubBlock
+                        quickstep_storage_BitWeavingVIndexSubBlock)
+endif()
+# CMAKE_VALIDATE_IGNORE_END
+
+if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_storage_DataExchange_proto
+                        ${PROTOBUF3_LIBRARY})
+  target_link_libraries(quickstep_storage_DataExchangerAsync
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        glog
+                        quickstep_storage_DataExchange_proto
+                        quickstep_storage_StorageManager
+                        quickstep_threading_Thread
+                        quickstep_utility_Macros
+                        quickstep_utility_NetworkUtil)
+  target_link_libraries(quickstep_storage_StorageManager
+                        ${GRPCPLUSPLUS_LIBRARIES}
+                        quickstep_queryexecution_QueryExecutionMessages_proto
+                        quickstep_queryexecution_QueryExecutionTypedefs
+                        quickstep_queryexecution_QueryExecutionUtil
+                        quickstep_storage_DataExchange_proto)
+endif()
+
+if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
+  target_link_libraries(quickstep_storage_FileManagerHdfs
+                        ${LIBHDFS3_LIBRARIES}
+                        glog
+                        quickstep_storage_FileManager
+                        quickstep_storage_Flags
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageConstants
+                        quickstep_storage_StorageErrors
+                        quickstep_utility_Macros
+                        quickstep_utility_StringUtil)
+  target_link_libraries(quickstep_storage_StorageManager
+                        quickstep_storage_FileManagerHdfs)
+endif()
+
+if (QUICKSTEP_HAVE_FILE_MANAGER_POSIX)
+  target_link_libraries(quickstep_storage_FileManagerLocal
+                        quickstep_storage_FileManagerPosix)
+  target_link_libraries(quickstep_storage_FileManagerPosix
+                        glog
+                        quickstep_storage_FileManager
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageConstants
+                        quickstep_storage_StorageErrors
+                        quickstep_utility_Macros
+                        quickstep_utility_StringUtil)
+elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
+  target_link_libraries(quickstep_storage_FileManagerLocal
+                        quickstep_storage_FileManagerWindows)
+  target_link_libraries(quickstep_storage_FileManagerWindows
+                        glog
+                        quickstep_storage_FileManager
+                        quickstep_storage_StorageBlockInfo
+                        quickstep_storage_StorageConstants
+                        quickstep_storage_StorageErrors
+                        quickstep_utility_Macros
+                        quickstep_utility_StringUtil)
+endif()
+
+if (QUICKSTEP_HAVE_LIBNUMA)
+  target_link_libraries(quickstep_storage_PreloaderThread
+                        quickstep_catalog_NUMAPlacementScheme)
+  target_link_libraries(quickstep_storage_StorageManager
+                        ${LIBNUMA_LIBRARY})
+endif()
 
 # Module all-in-one library:
 add_library(quickstep_storage ../empty_src.cpp StorageModule.hpp)
@@ -1172,8 +1170,8 @@ target_link_libraries(quickstep_storage
                       quickstep_storage_InsertDestinationInterface
                       quickstep_storage_InsertDestination_proto
                       quickstep_storage_LinearOpenAddressingHashTable
-                      quickstep_storage_PartitionedHashTablePool
                       quickstep_storage_PackedPayloadHashTable
+                      quickstep_storage_PartitionedHashTablePool
                       quickstep_storage_PreloaderThread
                       quickstep_storage_SMAIndexSubBlock
                       quickstep_storage_SeparateChainingHashTable
@@ -1201,22 +1199,7 @@ target_link_libraries(quickstep_storage
                       quickstep_storage_ValueAccessorUtil
                       quickstep_storage_WindowAggregationOperationState
                       quickstep_storage_WindowAggregationOperationState_proto)
-if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
-  target_link_libraries(quickstep_storage
-                        quickstep_storage_FileManagerHdfs)
-endif()
-if (QUICKSTEP_HAVE_FILE_MANAGER_POSIX)
-  target_link_libraries(quickstep_storage
-                        quickstep_storage_FileManagerPosix)
-elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
-  target_link_libraries(quickstep_storage
-                        quickstep_storage_FileManagerWindows)
-endif()
-if (ENABLE_DISTRIBUTED)
-  target_link_libraries(quickstep_storage
-                        quickstep_storage_DataExchange_proto
-                        quickstep_storage_DataExchangerAsync)
-endif()
+
 # CMAKE_VALIDATE_IGNORE_BEGIN
 if(QUICKSTEP_HAVE_BITWEAVING)
   target_link_libraries(quickstep_storage
@@ -1225,6 +1208,25 @@ if(QUICKSTEP_HAVE_BITWEAVING)
                         quickstep_storage_BitWeavingVIndexSubBlock)
 endif()
 # CMAKE_VALIDATE_IGNORE_END
+
+if (ENABLE_DISTRIBUTED)
+  target_link_libraries(quickstep_storage
+                        quickstep_storage_DataExchange_proto
+                        quickstep_storage_DataExchangerAsync)
+endif()
+
+if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
+  target_link_libraries(quickstep_storage
+                        quickstep_storage_FileManagerHdfs)
+endif()
+
+if (QUICKSTEP_HAVE_FILE_MANAGER_POSIX)
+  target_link_libraries(quickstep_storage
+                        quickstep_storage_FileManagerPosix)
+elseif (QUICKSTEP_HAVE_FILE_MANAGER_WINDOWS)
+  target_link_libraries(quickstep_storage
+                        quickstep_storage_FileManagerWindows)
+endif()
 
 # Tests:
 include(CheckTypeSize)
@@ -1268,7 +1270,7 @@ target_link_libraries(quickstep_storage_tests_HashTable_unittest_common
 
 add_library(quickstep_storage_tests_TupleStorePredicateUtil
             ../empty_src.cpp
-             "${CMAKE_CURRENT_SOURCE_DIR}/tests/TupleStorePredicateUtil.hpp")
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/TupleStorePredicateUtil.hpp")
 target_link_libraries(quickstep_storage_tests_TupleStorePredicateUtil
                       quickstep_expressions_predicate_Predicate
                       quickstep_storage_IndexSubBlock
@@ -1282,19 +1284,20 @@ target_link_libraries(quickstep_storage_tests_TupleStorePredicateUtil
 add_executable(AggregationOperationState_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/AggregationOperationState_unittest.cpp")
 target_link_libraries(AggregationOperationState_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_AggregationOperationState
-                      quickstep_storage_AggregationOperationState_proto
-                      ${LIBS})
+                      quickstep_storage_AggregationOperationState_proto)
 add_test(AggregationOperationState_unittest AggregationOperationState_unittest)
 
 add_executable(BasicColumnStoreTupleStorageSubBlock_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/BasicColumnStoreTupleStorageSubBlock_unittest.cpp")
 target_link_libraries(BasicColumnStoreTupleStorageSubBlock_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogAttribute
@@ -1326,15 +1329,16 @@ target_link_libraries(BasicColumnStoreTupleStorageSubBlock_unittest
                       quickstep_types_operations_comparisons_ComparisonID
                       quickstep_types_operations_comparisons_ComparisonUtil
                       quickstep_utility_BitVector
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(BasicColumnStoreTupleStorageSubBlock_unittest BasicColumnStoreTupleStorageSubBlock_unittest)
 
-add_executable(BloomFilterIndexSubBlock_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/BloomFilterIndexSubBlock_unittest.cpp")
+add_executable(BloomFilterIndexSubBlock_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/BloomFilterIndexSubBlock_unittest.cpp")
 target_link_libraries(BloomFilterIndexSubBlock_unittest
+                      ${LIBS}
+                      glog
                       gtest
                       gtest_main
-                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
@@ -1359,14 +1363,14 @@ target_link_libraries(BloomFilterIndexSubBlock_unittest
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(BloomFilterIndexSubBlock_unittest BloomFilterIndexSubBlock_unittest)
 
 if(QUICKSTEP_HAVE_BITWEAVING)
   add_executable(BitWeavingIndexSubBlock_unittest
                  "${CMAKE_CURRENT_SOURCE_DIR}/bitweaving/tests/BitWeavingIndexSubBlock_unittest.cpp")
   target_link_libraries(BitWeavingIndexSubBlock_unittest
+                        ${LIBS}
                         glog
                         gtest
                         gtest_main
@@ -1401,13 +1405,14 @@ if(QUICKSTEP_HAVE_BITWEAVING)
                         quickstep_types_operations_comparisons_ComparisonID
                         quickstep_types_operations_comparisons_ComparisonUtil
                         quickstep_utility_Macros
-                        quickstep_utility_ScopedBuffer
-                        ${LIBS})
+                        quickstep_utility_ScopedBuffer)
   add_test(BitWeavingIndexSubBlock_unittest BitWeavingIndexSubBlock_unittest)
 endif()
 
-add_executable(CompressedColumnStoreTupleStorageSubBlock_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/CompressedColumnStoreTupleStorageSubBlock_unittest.cpp")
+add_executable(CompressedColumnStoreTupleStorageSubBlock_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/CompressedColumnStoreTupleStorageSubBlock_unittest.cpp")
 target_link_libraries(CompressedColumnStoreTupleStorageSubBlock_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogAttribute
@@ -1442,12 +1447,13 @@ target_link_libraries(CompressedColumnStoreTupleStorageSubBlock_unittest
                       quickstep_utility_Macros
                       quickstep_utility_PtrMap
                       quickstep_utility_PtrVector
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(CompressedColumnStoreTupleStorageSubBlock_unittest CompressedColumnStoreTupleStorageSubBlock_unittest)
 
-add_executable(CompressedPackedRowStoreTupleStorageSubBlock_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/CompressedPackedRowStoreTupleStorageSubBlock_unittest.cpp")
+add_executable(CompressedPackedRowStoreTupleStorageSubBlock_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/CompressedPackedRowStoreTupleStorageSubBlock_unittest.cpp")
 target_link_libraries(CompressedPackedRowStoreTupleStorageSubBlock_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogAttribute
@@ -1482,8 +1488,7 @@ target_link_libraries(CompressedPackedRowStoreTupleStorageSubBlock_unittest
                       quickstep_utility_Macros
                       quickstep_utility_PtrMap
                       quickstep_utility_PtrVector
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(CompressedPackedRowStoreTupleStorageSubBlock_unittest CompressedPackedRowStoreTupleStorageSubBlock_unittest)
 
 if (ENABLE_DISTRIBUTED)
@@ -1491,6 +1496,7 @@ if (ENABLE_DISTRIBUTED)
                  "${CMAKE_CURRENT_SOURCE_DIR}/tests/DataExchange_unittest.cpp")
   target_link_libraries(DataExchange_unittest
                         ${GFLAGS_LIB_NAME}
+                        ${LIBS}
                         glog
                         gtest
                         quickstep_catalog_CatalogAttribute
@@ -1512,13 +1518,13 @@ if (ENABLE_DISTRIBUTED)
                         quickstep_types_TypeID
                         quickstep_types_TypedValue
                         quickstep_types_containers_Tuple
-                        tmb
-                        ${LIBS})
+                        tmb)
   add_test(DataExchange_unittest DataExchange_unittest)
 endif(ENABLE_DISTRIBUTED)
 
 add_executable(CSBTreeIndexSubBlock_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/CSBTreeIndexSubBlock_unittest.cpp")
 target_link_libraries(CSBTreeIndexSubBlock_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogAttribute
@@ -1549,56 +1555,56 @@ target_link_libraries(CSBTreeIndexSubBlock_unittest
                       quickstep_types_operations_comparisons_ComparisonUtil
                       quickstep_utility_BitVector
                       quickstep_utility_Macros
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(CSBTreeIndexSubBlock_unittest CSBTreeIndexSubBlock_unittest)
 
 add_executable(EvictionPolicy_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/EvictionPolicy_unittest.cpp")
 target_link_libraries(EvictionPolicy_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_storage_EvictionPolicy
-                      quickstep_storage_StorageBlockInfo
-                      ${LIBS})
+                      quickstep_storage_StorageBlockInfo)
 add_test(EvictionPolicy_unittest EvictionPolicy_unittest)
 
 if (QUICKSTEP_HAVE_FILE_MANAGER_HDFS)
 add_executable(FileManagerHdfs_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/FileManagerHdfs_unittest.cpp")
 target_link_libraries(FileManagerHdfs_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_storage_FileManagerHdfs
-                      quickstep_storage_tests_FileManager_unittest_common
-                      ${LIBS})
+                      quickstep_storage_tests_FileManager_unittest_common)
 endif()
 
 add_executable(FileManagerLocal_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/FileManagerLocal_unittest.cpp")
 target_link_libraries(FileManagerLocal_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_storage_FileManagerLocal
-                      quickstep_storage_tests_FileManager_unittest_common
-                      ${LIBS})
+                      quickstep_storage_tests_FileManager_unittest_common)
 add_test(FileManagerLocal_unittest FileManagerLocal_unittest)
 
 add_executable(LinearOpenAddressingHashTable_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/LinearOpenAddressingHashTable_unittest.cpp")
 target_link_libraries(LinearOpenAddressingHashTable_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_storage_LinearOpenAddressingHashTable
-                      quickstep_storage_tests_HashTable_unittest_common
-                      ${LIBS})
+                      quickstep_storage_tests_HashTable_unittest_common)
 add_test(LinearOpenAddressingHashTable_unittest LinearOpenAddressingHashTable_unittest)
 
 add_executable(SMAIndexSubBlock_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/SMAIndexSubBlock_unittest.cpp")
 target_link_libraries(SMAIndexSubBlock_unittest
+                      ${LIBS}
+                      glog
                       gtest
                       gtest_main
-                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
@@ -1624,34 +1630,34 @@ target_link_libraries(SMAIndexSubBlock_unittest
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonFactory
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(SMAIndexSubBlock_unittest SMAIndexSubBlock_unittest)
 
 add_executable(SeparateChainingHashTable_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/SeparateChainingHashTable_unittest.cpp")
 target_link_libraries(SeparateChainingHashTable_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_storage_SeparateChainingHashTable
-                      quickstep_storage_tests_HashTable_unittest_common
-                      ${LIBS})
+                      quickstep_storage_tests_HashTable_unittest_common)
 add_test(SeparateChainingHashTable_unittest SeparateChainingHashTable_unittest)
 
 add_executable(SimpleScalarSeparateChainingHashTable_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/SimpleScalarSeparateChainingHashTable_unittest.cpp")
 target_link_libraries(SimpleScalarSeparateChainingHashTable_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_storage_SimpleScalarSeparateChainingHashTable
-                      quickstep_storage_tests_HashTable_unittest_common
-                      ${LIBS})
+                      quickstep_storage_tests_HashTable_unittest_common)
 add_test(SimpleScalarSeparateChainingHashTable_unittest
          SimpleScalarSeparateChainingHashTable_unittest)
 
 add_executable(SplitRowStoreTupleStorageSubBlock_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/SplitRowStoreTupleStorageSubBlock_unittest.cpp")
 target_link_libraries(SplitRowStoreTupleStorageSubBlock_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogAttribute
@@ -1675,16 +1681,16 @@ target_link_libraries(SplitRowStoreTupleStorageSubBlock_unittest
                       quickstep_types_containers_Tuple
                       quickstep_utility_BitVector
                       quickstep_utility_EqualsAnyConstant
-                      quickstep_utility_ScopedBuffer
-                      ${LIBS})
+                      quickstep_utility_ScopedBuffer)
 add_test(SplitRowStoreTupleStorageSubBlock_unittest SplitRowStoreTupleStorageSubBlock_unittest)
 
 add_executable(StorageBlockSort_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/StorageBlockSort_unittest.cpp")
 target_link_libraries(StorageBlockSort_unittest
+                      ${LIBS}
+                      glog
                       gtest
                       gtest_main
-                      glog
                       quickstep_catalog_CatalogAttribute
                       quickstep_catalog_CatalogRelation
                       quickstep_expressions_scalar_Scalar
@@ -1695,8 +1701,7 @@ target_link_libraries(StorageBlockSort_unittest
                       quickstep_types_FloatType
                       quickstep_types_IntType
                       quickstep_types_LongType
-                      quickstep_types_containers_Tuple
-                      ${LIBS})
+                      quickstep_types_containers_Tuple)
 add_test(StorageBlockSort_unittest StorageBlockSort_unittest)
 
 add_executable(StorageManager_unittest
@@ -1713,14 +1718,14 @@ target_link_libraries(StorageManager_unittest
 add_executable(WindowAggregationOperationState_unittest
                "${CMAKE_CURRENT_SOURCE_DIR}/tests/WindowAggregationOperationState_unittest.cpp")
 target_link_libraries(WindowAggregationOperationState_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_catalog_CatalogDatabase
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_WindowAggregationOperationState
-                      quickstep_storage_WindowAggregationOperationState_proto
-                      ${LIBS})
+                      quickstep_storage_WindowAggregationOperationState_proto)
 if (QUICKSTEP_HAVE_LIBNUMA)
   target_link_libraries(StorageManager_unittest
                         ${LIBNUMA_LIBRARY})

--- a/storage/TupleStorageSubBlock.cpp
+++ b/storage/TupleStorageSubBlock.cpp
@@ -19,21 +19,16 @@
 
 #include "storage/TupleStorageSubBlock.hpp"
 
-#ifdef QUICKSTEP_DEBUG
 #include <cassert>
-#endif
 
-#include "storage/TupleIdSequence.hpp"
-#include "storage/ValueAccessor.hpp"
-#include "utility/Macros.hpp"
-
-#ifdef QUICKSTEP_DEBUG
 #include "catalog/CatalogAttribute.hpp"
 #include "catalog/CatalogRelationSchema.hpp"
+#include "storage/TupleIdSequence.hpp"
+#include "storage/ValueAccessor.hpp"
 #include "types/Type.hpp"
 #include "types/TypedValue.hpp"
 #include "types/containers/Tuple.hpp"
-#endif
+#include "utility/Macros.hpp"
 
 namespace quickstep {
 

--- a/threading/CMakeLists.txt
+++ b/threading/CMakeLists.txt
@@ -114,7 +114,6 @@ if(NOT FOUND_THREADS)
   message(FATAL_ERROR "No viable threading library found.")
 endif()
 
-
 # Try to find some yield function we can use.
 set(FOUND_YIELD FALSE)
 
@@ -269,7 +268,12 @@ if (QUICKSTEP_HAVE_CPP11_THREADS)
               Mutex.cpp
               Mutex.hpp
               cpp11/Mutex.hpp)
-  if (QUICKSTEP_HAVE_CPP14_SHARED_MUTEX)
+  if (QUICKSTEP_HAVE_CPP17_SHARED_MUTEX)
+    add_library(quickstep_threading_SharedMutex
+                ../empty_src.cpp
+                SharedMutex.hpp
+                cpp11/cpp17/SharedMutex.hpp)
+  elseif (QUICKSTEP_HAVE_CPP14_SHARED_MUTEX)
     add_library(quickstep_threading_SharedMutex
                 ../empty_src.cpp
                 SharedMutex.hpp
@@ -324,6 +328,7 @@ add_library(quickstep_threading_SpinMutex ../empty_src.cpp SpinMutex.hpp)
 add_library(quickstep_threading_SpinSharedMutex ../empty_src.cpp SpinSharedMutex.hpp)
 add_library(quickstep_threading_ThreadIDBasedMap ../empty_src.cpp ThreadIDBasedMap.hpp)
 add_library(quickstep_threading_ThreadUtil ../empty_src.cpp ThreadUtil.hpp)
+add_library(quickstep_threading_WinThreadsAPI ../empty_src.cpp WinThreadsAPI.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_threading_ConditionVariable
@@ -334,17 +339,6 @@ target_link_libraries(quickstep_threading_Mutex
                       quickstep_threading_ConditionVariable
                       quickstep_utility_Macros
                       quickstep_utility_PtrVector)
-if (QUICKSTEP_HAVE_CPP11_THREADS AND NOT QUICKSTEP_HAVE_CPP14_SHARED_MUTEX)
-  target_link_libraries(quickstep_threading_SharedMutex
-                        glog
-                        quickstep_threading_ConditionVariable
-                        quickstep_threading_Mutex
-                        quickstep_utility_Macros)
-else()
-  target_link_libraries(quickstep_threading_SharedMutex
-                        quickstep_threading_Mutex
-                        quickstep_utility_Macros)
-endif()
 target_link_libraries(quickstep_threading_SpinMutex
                       quickstep_threading_Mutex
                       quickstep_utility_Macros)
@@ -363,7 +357,20 @@ target_link_libraries(quickstep_threading_ThreadIDBasedMap
                       quickstep_threading_SpinSharedMutex
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_threading_ThreadUtil
+                      quickstep_threading_WinThreadsAPI
                       quickstep_utility_Macros)
+
+if (QUICKSTEP_HAVE_CPP11_THREADS AND NOT QUICKSTEP_HAVE_CPP14_SHARED_MUTEX)
+  target_link_libraries(quickstep_threading_SharedMutex
+                        glog
+                        quickstep_threading_ConditionVariable
+                        quickstep_threading_Mutex
+                        quickstep_utility_Macros)
+else()
+  target_link_libraries(quickstep_threading_SharedMutex
+                        quickstep_threading_Mutex
+                        quickstep_utility_Macros)
+endif()
 
 # Module all-in-one library:
 add_library(quickstep_threading ../empty_src.cpp ThreadingModule.hpp)
@@ -375,28 +382,29 @@ target_link_libraries(quickstep_threading
                       quickstep_threading_SpinSharedMutex
                       quickstep_threading_Thread
                       quickstep_threading_ThreadIDBasedMap
-                      quickstep_threading_ThreadUtil)
+                      quickstep_threading_ThreadUtil
+                      quickstep_threading_WinThreadsAPI)
 
 # Tests:
 add_executable(Mutex_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/Mutex_unittest.cpp")
 target_link_libraries(Mutex_unittest
+                      ${CMAKE_THREAD_LIBS_INIT}
                       gtest
                       gtest_main
                       quickstep_threading_Mutex
                       quickstep_threading_SpinMutex
                       quickstep_threading_Thread
-                      quickstep_utility_Macros
-                      ${CMAKE_THREAD_LIBS_INIT})
+                      quickstep_utility_Macros)
 add_test(Mutex_unittest Mutex_unittest)
 
 add_executable(SharedMutex_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/SharedMutex_unittest.cpp")
 target_link_libraries(SharedMutex_unittest
+                      ${CMAKE_THREAD_LIBS_INIT}
                       gtest
                       gtest_main
                       quickstep_threading_Mutex
                       quickstep_threading_SharedMutex
                       quickstep_threading_SpinSharedMutex
                       quickstep_threading_Thread
-                      quickstep_utility_Macros
-                      ${CMAKE_THREAD_LIBS_INIT})
+                      quickstep_utility_Macros)
 add_test(SharedMutex_unittest SharedMutex_unittest)

--- a/transaction/CMakeLists.txt
+++ b/transaction/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(quickstep_transaction_CycleDetector
             CycleDetector.hpp)
 add_library(quickstep_transaction_DeadLockDetector
             DeadLockDetector.cpp
-            DeadLockDetector.cpp)
+            DeadLockDetector.hpp)
 add_library(quickstep_transaction_DirectedGraph
             ../empty_src.cpp
             DirectedGraph.hpp)
@@ -33,8 +33,8 @@ add_library(quickstep_transaction_Lock
             ../empty_src.cpp
             Lock.hpp)
 add_library(quickstep_transaction_LockManager
-            LockManager.hpp
-            LockManager.cpp)
+            LockManager.cpp
+            LockManager.hpp)
 add_library(quickstep_transaction_LockRequest
             ../empty_src.cpp
             LockRequest.hpp)
@@ -60,6 +60,7 @@ target_link_libraries(quickstep_transaction_CycleDetector
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_transaction_DeadLockDetector
                       glog
+                      quickstep_threading_Thread
                       quickstep_transaction_CycleDetector
                       quickstep_transaction_DirectedGraph
                       quickstep_transaction_LockTable
@@ -74,7 +75,6 @@ target_link_libraries(quickstep_transaction_Lock
 target_link_libraries(quickstep_transaction_LockManager
                       ${GFLAGS_LIB_NAME}
                       glog
-                      quickstep_utility_ThreadSafeQueue
                       quickstep_threading_Thread
                       quickstep_transaction_AccessMode
                       quickstep_transaction_DeadLockDetector
@@ -82,7 +82,8 @@ target_link_libraries(quickstep_transaction_LockManager
                       quickstep_transaction_LockTable
                       quickstep_transaction_ResourceId
                       quickstep_transaction_Transaction
-                      quickstep_transaction_TransactionTable)
+                      quickstep_transaction_TransactionTable
+                      quickstep_utility_ThreadSafeQueue)
 target_link_libraries(quickstep_transaction_LockRequest
                       quickstep_transaction_AccessMode
                       quickstep_transaction_ResourceId
@@ -95,11 +96,15 @@ target_link_libraries(quickstep_transaction_LockTable
                       quickstep_transaction_Transaction
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_transaction_ResourceId
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_HashPair)
 target_link_libraries(quickstep_transaction_ResourceId
-                      glog)
+                      glog
+                      quickstep_catalog_CatalogTypedefs
+                      quickstep_storage_StorageBlockInfo
+                      quickstep_utility_HashPair)
 target_link_libraries(quickstep_transaction_StronglyConnectedComponents
                       quickstep_transaction_DirectedGraph
                       quickstep_utility_Macros)
@@ -146,7 +151,7 @@ target_link_libraries(CycleDetector_unittest
 add_test(CycleDetector_unittest CycleDetector_unittest)
 
 add_executable(DeadLockDetector_unittest
-  "${CMAKE_CURRENT_SOURCE_DIR}/tests/DeadLockDetector_unittest.cpp")
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/DeadLockDetector_unittest.cpp")
 target_link_libraries(DeadLockDetector_unittest
                       gtest
                       gtest_main

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(quickstep_types_CharType
                       quickstep_utility_Macros
                       quickstep_utility_PtrMap)
 target_link_libraries(quickstep_types_DateOperatorOverloads
+                      glog
                       quickstep_types_DatetimeLit
                       quickstep_types_IntervalLit
                       quickstep_types_port_gmtime_r
@@ -107,6 +108,7 @@ target_link_libraries(quickstep_types_DatetimeType
                       quickstep_utility_CheckSnprintf
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_DoubleType
+                      glog
                       quickstep_types_NullCoercibilityCheckMacro
                       quickstep_types_NumericSuperType
                       quickstep_types_Type
@@ -115,6 +117,7 @@ target_link_libraries(quickstep_types_DoubleType
                       quickstep_utility_EqualsAnyConstant
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_FloatType
+                      glog
                       quickstep_types_NullCoercibilityCheckMacro
                       quickstep_types_NumericSuperType
                       quickstep_types_Type
@@ -161,8 +164,8 @@ target_link_libraries(quickstep_types_NumericSuperType
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_Type
                       glog
-                      quickstep_types_Type_proto
                       quickstep_types_TypeID
+                      quickstep_types_Type_proto
                       quickstep_types_TypedValue
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_TypeFactory
@@ -182,6 +185,8 @@ target_link_libraries(quickstep_types_TypeFactory
                       quickstep_types_VarCharType
                       quickstep_types_YearMonthIntervalType
                       quickstep_utility_Macros)
+target_link_libraries(quickstep_types_Type_proto
+                      ${PROTOBUF_LIBRARY})
 target_link_libraries(quickstep_types_TypedValue
                       farmhash
                       glog
@@ -194,10 +199,8 @@ target_link_libraries(quickstep_types_TypedValue
                       quickstep_utility_HashPair
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_TypedValue_proto
-                      quickstep_types_Type_proto
-                      ${PROTOBUF_LIBRARY})
-target_link_libraries(quickstep_types_Type_proto
-                      ${PROTOBUF_LIBRARY})
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_types_Type_proto)
 target_link_libraries(quickstep_types_VarCharType
                       glog
                       quickstep_types_NullCoercibilityCheckMacro
@@ -209,6 +212,7 @@ target_link_libraries(quickstep_types_VarCharType
                       quickstep_utility_Macros
                       quickstep_utility_PtrMap)
 target_link_libraries(quickstep_types_YearMonthIntervalType
+                      glog
                       quickstep_types_IntervalLit
                       quickstep_types_IntervalParser
                       quickstep_types_NullCoercibilityCheckMacro
@@ -238,10 +242,10 @@ target_link_libraries(quickstep_types
                       quickstep_types_NumericSuperType
                       quickstep_types_NumericTypeUnifier
                       quickstep_types_Type
-                      quickstep_types_Type_proto
                       quickstep_types_TypeErrors
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID
+                      quickstep_types_Type_proto
                       quickstep_types_TypedValue
                       quickstep_types_TypedValue_proto
                       quickstep_types_VarCharType
@@ -256,6 +260,7 @@ add_library(quickstep_types_tests_TypeTest_common
             "${CMAKE_CURRENT_SOURCE_DIR}/tests/TypeTest_common.hpp")
 target_link_libraries(quickstep_types_tests_TypeTest_common
                       gtest
+                      gtest_main
                       quickstep_types_DoubleType
                       quickstep_types_FloatType
                       quickstep_types_IntType
@@ -282,8 +287,8 @@ add_executable(DateType_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/DateType_uni
 target_link_libraries(DateType_unittest
                       gtest
                       gtest_main
-                      quickstep_types_DatetimeLit
                       quickstep_types_DateType
+                      quickstep_types_DatetimeLit
                       quickstep_types_NullType
                       quickstep_types_Type
                       quickstep_types_TypeFactory
@@ -384,9 +389,9 @@ target_link_libraries(Type_unittest
                       gtest_main
                       quickstep_types_CharType
                       quickstep_types_Type
-                      quickstep_types_Type_proto
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID
+                      quickstep_types_Type_proto
                       quickstep_types_VarCharType
                       quickstep_utility_Macros)
 add_test(Type_unittest Type_unittest)

--- a/types/containers/CMakeLists.txt
+++ b/types/containers/CMakeLists.txt
@@ -51,8 +51,8 @@ target_link_libraries(quickstep_types_containers_Tuple
                       quickstep_utility_CompositeHash
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_containers_Tuple_proto
-                      quickstep_types_TypedValue_proto
-                      ${PROTOBUF_LIBRARY})
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_types_TypedValue_proto)
 
 # Module all-in-one library:
 add_library(quickstep_types_containers ../../empty_src.cpp)
@@ -66,12 +66,12 @@ target_link_libraries(quickstep_types_containers
 # Tests:
 add_executable(ColumnVector_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/ColumnVector_unittest.cpp")
 target_link_libraries(ColumnVector_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_types_Type
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID
                       quickstep_types_TypedValue
-                      quickstep_types_containers_ColumnVector
-                      ${LIBS})
+                      quickstep_types_containers_ColumnVector)
 add_test(ColumnVector_unittest ColumnVector_unittest)

--- a/types/operations/CMakeLists.txt
+++ b/types/operations/CMakeLists.txt
@@ -31,8 +31,8 @@ add_library(quickstep_types_operations_Operation_proto ${types_operations_Operat
 target_link_libraries(quickstep_types_operations_Operation
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_operations_Operation_proto
-                      quickstep_types_Type_proto
-                      ${PROTOBUF_LIBRARY})
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_types_Type_proto)
 
 # Module all-in-one library:
 add_library(quickstep_types_operations ../../empty_src.cpp)

--- a/types/operations/binary_operations/ArithmeticBinaryOperators.hpp
+++ b/types/operations/binary_operations/ArithmeticBinaryOperators.hpp
@@ -29,12 +29,8 @@
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/StorageBlockInfo.hpp"
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/operations/binary_operations/BinaryOperation.hpp"

--- a/types/operations/binary_operations/CMakeLists.txt
+++ b/types/operations/binary_operations/CMakeLists.txt
@@ -202,6 +202,7 @@ add_library(quickstep_types_operations_binaryoperations_tests_BinaryOperationTes
             "${CMAKE_CURRENT_SOURCE_DIR}/tests/BinaryOperationTestUtil.hpp")
 target_link_libraries(quickstep_types_operations_binaryoperations_tests_BinaryOperationTestUtil
                       gtest
+                      gtest_main
                       quickstep_types_Type
                       quickstep_types_TypeFactory
                       quickstep_types_TypeID

--- a/types/operations/comparisons/AsciiStringComparators-inl.hpp
+++ b/types/operations/comparisons/AsciiStringComparators-inl.hpp
@@ -31,12 +31,8 @@
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/TupleIdSequence.hpp"
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/containers/ColumnVectorUtil.hpp"

--- a/types/operations/comparisons/CMakeLists.txt
+++ b/types/operations/comparisons/CMakeLists.txt
@@ -148,6 +148,7 @@ target_link_libraries(quickstep_types_operations_comparisons_LessOrEqualComparis
                       quickstep_types_operations_comparisons_LiteralComparators
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_operations_comparisons_LiteralComparators
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_TupleIdSequence
                       quickstep_storage_ValueAccessor
@@ -174,13 +175,14 @@ target_link_libraries(quickstep_types_operations_comparisons_PatternMatchingComp
                       quickstep_types_port_strnlen
                       re2)
 target_link_libraries(quickstep_types_operations_comparisons_PatternMatchingComparison
+                      glog
                       quickstep_types_Type
                       quickstep_types_TypeID
-                      quickstep_types_operations_comparisons_PatternMatchingComparators
                       quickstep_types_operations_comparisons_Comparison
                       quickstep_types_operations_comparisons_ComparisonID
-                      quickstep_utility_TemplateUtil
-                      quickstep_utility_Macros)
+                      quickstep_types_operations_comparisons_PatternMatchingComparators
+                      quickstep_utility_Macros
+                      quickstep_utility_TemplateUtil)
 
 # Module all-in-one library:
 add_library(quickstep_types_operations_comparisons ../../../empty_src.cpp)

--- a/types/operations/comparisons/Comparison-inl.hpp
+++ b/types/operations/comparisons/Comparison-inl.hpp
@@ -27,12 +27,8 @@
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/TupleIdSequence.hpp"
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/containers/ColumnVectorUtil.hpp"

--- a/types/operations/comparisons/Comparison.cpp
+++ b/types/operations/comparisons/Comparison.cpp
@@ -21,9 +21,7 @@
 
 #include "types/TypedValue.hpp"
 #include "types/operations/Operation.pb.h"
-
 #include "types/operations/comparisons/Comparison-inl.hpp"
-
 #include "utility/Macros.hpp"
 
 namespace quickstep {

--- a/types/operations/comparisons/LiteralComparators-inl.hpp
+++ b/types/operations/comparisons/LiteralComparators-inl.hpp
@@ -32,12 +32,8 @@
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/TupleIdSequence.hpp"
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/operations/comparisons/LiteralComparators.hpp"

--- a/types/operations/comparisons/PatternMatchingComparators-inl.hpp
+++ b/types/operations/comparisons/PatternMatchingComparators-inl.hpp
@@ -28,12 +28,8 @@
 
 #include "catalog/CatalogTypedefs.hpp"
 #include "storage/TupleIdSequence.hpp"
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/containers/ColumnVectorUtil.hpp"

--- a/types/operations/unary_operations/ArithmeticUnaryOperators.hpp
+++ b/types/operations/unary_operations/ArithmeticUnaryOperators.hpp
@@ -25,13 +25,9 @@
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
 #include "storage/StorageBlockInfo.hpp"
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_SELECTION
-
 #include "types/TypedValue.hpp"
 #include "types/containers/ColumnVector.hpp"
 #include "types/operations/unary_operations/UnaryOperation.hpp"

--- a/types/operations/unary_operations/CMakeLists.txt
+++ b/types/operations/unary_operations/CMakeLists.txt
@@ -16,13 +16,23 @@
 # under the License.
 
 # Declare micro-libs:
-add_library(quickstep_types_operations_unaryoperations_ArithmeticUnaryOperations ArithmeticUnaryOperations.cpp ArithmeticUnaryOperations.hpp)
-add_library(quickstep_types_operations_unaryoperations_ArithmeticUnaryOperators ../../../empty_src.cpp ArithmeticUnaryOperators.hpp)
-add_library(quickstep_types_operations_unaryoperations_DateExtractOperation DateExtractOperation.cpp DateExtractOperation.hpp)
-add_library(quickstep_types_operations_unaryoperations_NumericCastOperation ../../../empty_src.cpp NumericCastOperation.hpp)
+add_library(quickstep_types_operations_unaryoperations_ArithmeticUnaryOperations
+            ArithmeticUnaryOperations.cpp
+            ArithmeticUnaryOperations.hpp)
+add_library(quickstep_types_operations_unaryoperations_ArithmeticUnaryOperators
+            ../../../empty_src.cpp
+            ArithmeticUnaryOperators.hpp)
+add_library(quickstep_types_operations_unaryoperations_DateExtractOperation
+            DateExtractOperation.cpp
+            DateExtractOperation.hpp)
+add_library(quickstep_types_operations_unaryoperations_NumericCastOperation
+            ../../../empty_src.cpp
+            NumericCastOperation.hpp)
 add_library(quickstep_types_operations_unaryoperations_SubstringOperation SubstringOperation.cpp SubstringOperation.hpp)
 add_library(quickstep_types_operations_unaryoperations_UnaryOperation UnaryOperation.cpp UnaryOperation.hpp)
-add_library(quickstep_types_operations_unaryoperations_UnaryOperationFactory UnaryOperationFactory.cpp UnaryOperationFactory.hpp)
+add_library(quickstep_types_operations_unaryoperations_UnaryOperationFactory
+            UnaryOperationFactory.cpp
+            UnaryOperationFactory.hpp)
 add_library(quickstep_types_operations_unaryoperations_UnaryOperationID UnaryOperationID.cpp UnaryOperationID.hpp)
 
 # Link dependencies:
@@ -90,6 +100,7 @@ target_link_libraries(quickstep_types_operations_unaryoperations_NumericCastOper
                       quickstep_utility_Macros
                       quickstep_utility_PtrMap)
 target_link_libraries(quickstep_types_operations_unaryoperations_SubstringOperation
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_ValueAccessor
                       quickstep_storage_ValueAccessorUtil

--- a/types/operations/unary_operations/DateExtractOperation.cpp
+++ b/types/operations/unary_operations/DateExtractOperation.cpp
@@ -24,15 +24,11 @@
 #include <memory>
 #include <string>
 #include <type_traits>
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_JOIN
 #include <utility>
 #include <vector>
 
-#include "storage/StorageBlockInfo.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_JOIN
-
 #include "catalog/CatalogTypedefs.hpp"
+#include "storage/StorageBlockInfo.hpp"
 #include "storage/ValueAccessor.hpp"
 #include "storage/ValueAccessorUtil.hpp"
 #include "types/DatetimeLit.hpp"

--- a/types/operations/unary_operations/DateExtractOperation.hpp
+++ b/types/operations/unary_operations/DateExtractOperation.hpp
@@ -22,15 +22,11 @@
 
 #include <cstdint>
 #include <string>
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_JOIN
 #include <utility>
 #include <vector>
 
-#include "storage/StorageBlockInfo.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_JOIN
-
 #include "catalog/CatalogTypedefs.hpp"
+#include "storage/StorageBlockInfo.hpp"
 #include "types/LongType.hpp"
 #include "types/Type.hpp"
 #include "types/TypeID.hpp"

--- a/types/operations/unary_operations/UnaryOperation.hpp
+++ b/types/operations/unary_operations/UnaryOperation.hpp
@@ -23,15 +23,11 @@
 #include <cstddef>
 #include <string>
 #include <type_traits>
-
-#ifdef QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_JOIN
 #include <utility>
 #include <vector>
 
-#include "storage/StorageBlockInfo.hpp"
-#endif  // QUICKSTEP_ENABLE_VECTOR_COPY_ELISION_JOIN
-
 #include "catalog/CatalogTypedefs.hpp"
+#include "storage/StorageBlockInfo.hpp"
 #include "types/operations/Operation.hpp"
 #include "types/operations/Operation.pb.h"
 #include "types/TypedValue.hpp"

--- a/types/port/CMakeLists.txt
+++ b/types/port/CMakeLists.txt
@@ -48,17 +48,18 @@ endif()
 CHECK_CXX_SYMBOL_EXISTS(setenv "stdlib.h" QUICKSTEP_HAVE_SETENV)
 CHECK_CXX_SYMBOL_EXISTS(tzset "time.h" QUICKSTEP_HAVE_TZSET)
 
-
 configure_file (
   "${CMAKE_CURRENT_SOURCE_DIR}/TypesPortConfig.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/TypesPortConfig.h"
 )
 
+# Declare micro-libs:
 add_library(quickstep_types_port_gmtime_r ../../empty_src.cpp gmtime_r.hpp)
 add_library(quickstep_types_port_localtime_r ../../empty_src.cpp localtime_r.hpp)
 add_library(quickstep_types_port_strnlen ../../empty_src.cpp strnlen.hpp)
 add_library(quickstep_types_port_timegm timegm.cpp timegm.hpp)
 
+# Link dependencies:
 target_link_libraries(quickstep_types_port_gmtime_r
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_types_port_localtime_r
@@ -67,6 +68,7 @@ target_link_libraries(quickstep_types_port_timegm
                       quickstep_types_port_gmtime_r
                       quickstep_utility_Macros)
 
+# Module all-in-one library:
 add_library(quickstep_types_port ../../empty_src.cpp)
 target_link_libraries(quickstep_types_port
                       quickstep_types_port_gmtime_r
@@ -87,7 +89,7 @@ add_test(timegm_unittest timegm_unittest)
 if (UNIX)
   add_executable(timegm_benchmark "${CMAKE_CURRENT_SOURCE_DIR}/tests/timegm_benchmark.cpp")
   target_link_libraries(timegm_benchmark
+                        ${LIBS}
                         benchmark
-                        quickstep_types_port_timegm
-                        ${LIBS})
+                        quickstep_types_port_timegm)
 endif()

--- a/types/port/gmtime_r.hpp
+++ b/types/port/gmtime_r.hpp
@@ -23,10 +23,7 @@
 #include <ctime>
 
 #include "types/port/TypesPortConfig.h"
-
-#if defined(QUICKSTEP_HAVE_GMTIME_S)
 #include "utility/Macros.hpp"
-#endif  // QUICKSTEP_HAVE_GMTIME_S
 
 namespace quickstep {
 

--- a/types/port/localtime_r.hpp
+++ b/types/port/localtime_r.hpp
@@ -23,10 +23,7 @@
 #include <ctime>
 
 #include "types/port/TypesPortConfig.h"
-
-#if defined(QUICKSTEP_HAVE_LOCALTIME_S)
 #include "utility/Macros.hpp"
-#endif  // QUICKSTEP_HAVE_LOCALTIME_S
 
 namespace quickstep {
 

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -162,6 +162,9 @@ add_subdirectory(lip_filter)
 
 # Declare micro-libs:
 add_library(quickstep_utility_Alignment ../empty_src.cpp Alignment.hpp)
+add_library(quickstep_utility_BarrieredReadWriteConcurrentBitVector
+            ../empty_src.cpp
+            BarrieredReadWriteConcurrentBitVector.hpp)
 add_library(quickstep_utility_BitManipulation ../empty_src.cpp BitManipulation.hpp)
 add_library(quickstep_utility_BitVector ../empty_src.cpp BitVector.hpp)
 add_library(quickstep_utility_BloomFilter ../empty_src.cpp BloomFilter.hpp)
@@ -174,9 +177,6 @@ add_library(quickstep_utility_Cast ../empty_src.cpp Cast.hpp)
 add_library(quickstep_utility_CheckSnprintf ../empty_src.cpp CheckSnprintf.hpp)
 add_library(quickstep_utility_ColumnVectorCache ../empty_src.cpp ColumnVectorCache.hpp)
 add_library(quickstep_utility_CompositeHash ../empty_src.cpp CompositeHash.hpp)
-add_library(quickstep_utility_BarrieredReadWriteConcurrentBitVector
-            ../empty_src.cpp
-            BarrieredReadWriteConcurrentBitVector.hpp)
 add_library(quickstep_utility_DAG ../empty_src.cpp DAG.hpp)
 add_library(quickstep_utility_DisjointTreeForest ../empty_src.cpp DisjointTreeForest.hpp)
 add_library(quickstep_utility_EqualsAnyConstant ../empty_src.cpp EqualsAnyConstant.hpp)
@@ -205,6 +205,10 @@ add_library(quickstep_utility_SortConfiguration_proto
 add_library(quickstep_utility_SqlError SqlError.cpp SqlError.hpp)
 add_library(quickstep_utility_StringUtil StringUtil.cpp StringUtil.hpp)
 add_library(quickstep_utility_TemplateUtil ../empty_src.cpp TemplateUtil.hpp)
+add_library(quickstep_utility_ThreadSafeQueue ../empty_src.cpp ThreadSafeQueue.hpp)
+add_library(quickstep_utility_TreeStringSerializable ../empty_src.cpp TreeStringSerializable.hpp)
+add_library(quickstep_utility_VectorUtil ../empty_src.cpp VectorUtil.hpp)
+
 # Note that TextBasedTest.{hpp, cpp} are not in this static library.
 # Any tests that use them need to include them in the
 # executable.
@@ -212,17 +216,15 @@ add_library(quickstep_utility_TextBasedTestDriver
             textbased_test/TextBasedTestDriver.cpp
             textbased_test/TextBasedTestDriver.hpp
             textbased_test/TextBasedTestRunner.hpp)
-add_library(quickstep_utility_ThreadSafeQueue ../empty_src.cpp ThreadSafeQueue.hpp)
-add_library(quickstep_utility_TreeStringSerializable ../empty_src.cpp TreeStringSerializable.hpp)
-add_library(quickstep_utility_VectorUtil ../empty_src.cpp VectorUtil.hpp)
 
 # Link dependencies:
 target_link_libraries(quickstep_utility_Alignment
+                      glog
                       quickstep_utility_Macros)
-if (QUICKSTEP_HAVE_TCMALLOC)
-  target_link_libraries(quickstep_utility_Alignment
-                        libtcmalloc_minimal)
-endif()
+target_link_libraries(quickstep_utility_BarrieredReadWriteConcurrentBitVector
+                      glog
+                      quickstep_utility_BitManipulation
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_BitVector
                       glog
                       quickstep_utility_BitManipulation
@@ -237,28 +239,29 @@ target_link_libraries(quickstep_utility_BloomFilter
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_BloomFilter_proto
                       ${PROTOBUF_LIBRARY})
+target_link_libraries(quickstep_utility_BulkIoConfiguration
+                      glog
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_CalculateInstalledMemory
                       glog)
 target_link_libraries(quickstep_utility_CheckSnprintf
                       glog)
 target_link_libraries(quickstep_utility_ColumnVectorCache
+                      glog
                       quickstep_types_containers_ColumnVector
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_CompositeHash
+                      glog
                       quickstep_types_TypedValue
-                      quickstep_utility_HashPair
-                      glog)
-target_link_libraries(quickstep_utility_BarrieredReadWriteConcurrentBitVector
-                      quickstep_utility_BitManipulation
-                      quickstep_utility_Macros)
-target_link_libraries(quickstep_utility_BulkIoConfiguration
-                      quickstep_utility_Macros)
+                      quickstep_utility_HashPair)
 target_link_libraries(quickstep_utility_DAG
                       glog
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_DisjointTreeForest
                       glog)
 target_link_libraries(quickstep_utility_ExecutionDAGVisualizer
+                      ${GFLAGS_LIB_NAME}
+                      glog
                       quickstep_catalog_CatalogRelation
                       quickstep_catalog_CatalogRelationSchema
                       quickstep_queryexecution_QueryExecutionTypedefs
@@ -274,19 +277,17 @@ target_link_libraries(quickstep_utility_ExecutionDAGVisualizer
                       quickstep_relationaloperators_UnionAllOperator
                       quickstep_utility_DAG
                       quickstep_utility_Macros
-                      quickstep_utility_StringUtil
-                      ${GFLAGS_LIB_NAME})
+                      quickstep_utility_StringUtil)
 target_link_libraries(quickstep_utility_Glob
                       glog)
 target_link_libraries(quickstep_utility_MemStream
                       glog
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_NetworkUtil
-                      glog
-                      ${GFLAGS_LIB_NAME})
-target_link_libraries(quickstep_utility_PrimeNumber
+                      ${GFLAGS_LIB_NAME}
                       glog)
 target_link_libraries(quickstep_utility_PlanVisualizer
+                      glog
                       quickstep_catalog_CatalogRelation
                       quickstep_queryoptimizer_costmodel_StarSchemaSimpleCostModel
                       quickstep_queryoptimizer_expressions_AttributeReference
@@ -301,6 +302,8 @@ target_link_libraries(quickstep_utility_PlanVisualizer
                       quickstep_queryoptimizer_physical_TopLevelPlan
                       quickstep_utility_Macros
                       quickstep_utility_StringUtil)
+target_link_libraries(quickstep_utility_PrimeNumber
+                      glog)
 target_link_libraries(quickstep_utility_PtrList
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_PtrMap
@@ -316,8 +319,12 @@ target_link_libraries(quickstep_utility_ScopedDeleter
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_ScopedReassignment
                       quickstep_utility_Macros)
-target_link_libraries(quickstep_utility_SqlError
-                      glog)
+target_link_libraries(quickstep_utility_ShardedLockManager
+                      quickstep_storage_StorageConstants
+                      quickstep_threading_Mutex
+                      quickstep_threading_SharedMutex
+                      quickstep_threading_SpinSharedMutex
+                      quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_SortConfiguration
                       glog
                       quickstep_expressions_ExpressionFactories
@@ -326,21 +333,14 @@ target_link_libraries(quickstep_utility_SortConfiguration
                       quickstep_utility_PtrVector
                       quickstep_utility_SortConfiguration_proto)
 target_link_libraries(quickstep_utility_SortConfiguration_proto
-                      quickstep_expressions_Expressions_proto
-                      ${PROTOBUF_LIBRARY})
-target_link_libraries(quickstep_utility_ShardedLockManager
-                      quickstep_storage_StorageConstants
-                      quickstep_threading_Mutex
-                      quickstep_threading_SharedMutex
-                      quickstep_threading_SpinSharedMutex
-                      quickstep_utility_Macros)
+                      ${PROTOBUF_LIBRARY}
+                      quickstep_expressions_Expressions_proto)
+target_link_libraries(quickstep_utility_SqlError
+                      glog)
 target_link_libraries(quickstep_utility_StringUtil
                       glog)
-target_link_libraries(quickstep_utility_TemplateUtil)
 target_link_libraries(quickstep_utility_TextBasedTestDriver
                       glog
-                      gtest
-                      gtest_main
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_ThreadSafeQueue
                       quickstep_threading_ConditionVariable
@@ -349,6 +349,11 @@ target_link_libraries(quickstep_utility_ThreadSafeQueue
 target_link_libraries(quickstep_utility_TreeStringSerializable
                       glog
                       quickstep_utility_Macros)
+
+if (QUICKSTEP_HAVE_TCMALLOC)
+  target_link_libraries(quickstep_utility_Alignment
+                        libtcmalloc_minimal)
+endif()
 
 # Module all-in-one library:
 add_library(quickstep_utility ../empty_src.cpp UtilityModule.hpp)
@@ -397,21 +402,22 @@ target_link_libraries(quickstep_utility
 # Tests:
 add_executable(BitVector_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/BitVector_unittest.cpp")
 target_link_libraries(BitVector_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_BitVector
-                      ${LIBS})
+                      quickstep_utility_BitVector)
 add_test(BitVector_unittest BitVector_unittest)
 
 add_executable(BloomFilter_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/BloomFilter_unittest.cpp")
 target_link_libraries(BloomFilter_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_BloomFilter
-                      ${LIBS})
+                      quickstep_utility_BloomFilter)
 add_test(BloomFilter_unittest BloomFilter_unittest)
 
-add_executable(CalculateInstalledMemory_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/CalculateInstalledMemory_unittest.cpp")
+add_executable(CalculateInstalledMemory_unittest
+               "${CMAKE_CURRENT_SOURCE_DIR}/tests/CalculateInstalledMemory_unittest.cpp")
 target_link_libraries(CalculateInstalledMemory_unittest
                       gtest
                       gtest_main
@@ -420,10 +426,10 @@ add_test(CalculateInstalledMemory_unittest CalculateInstalledMemory_unittest)
 
 add_executable(DAG_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/DAG_unittest.cpp")
 target_link_libraries(DAG_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_DAG
-                      ${LIBS})
+                      quickstep_utility_DAG)
 add_test(DAG_unittest DAG_unittest)
 
 add_executable(DisjointTreeForest_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/DisjointTreeForest_unittest.cpp")
@@ -435,44 +441,44 @@ add_test(DisjointTreeForest_unittest DisjointTreeForest_unittest)
 
 add_executable(EqualsAnyConstant_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/EqualsAnyConstant_unittest.cpp")
 target_link_libraries(EqualsAnyConstant_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_EqualsAnyConstant
-                      ${LIBS})
+                      quickstep_utility_EqualsAnyConstant)
 add_test(EqualsAnyConstant_unittest EqualsAnyConstant_unittest)
 
 add_executable(NetworkUtil_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/NetworkUtil_unittest.cpp")
 target_link_libraries(NetworkUtil_unittest
+                      ${GFLAGS_LIB_NAME}
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_NetworkUtil
-                      ${GFLAGS_LIB_NAME}
-                      ${LIBS})
+                      quickstep_utility_NetworkUtil)
 add_test(NetworkUtil_unittest NetworkUtil_unittest)
 
 add_executable(PrimeNumber_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/PrimeNumber_unittest.cpp")
 target_link_libraries(PrimeNumber_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_PrimeNumber
-                      ${LIBS})
+                      quickstep_utility_PrimeNumber)
 add_test(PrimeNumber_unittest PrimeNumber_unittest)
 
 add_executable(ScopedDeleter_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/ScopedDeleter_unittest.cpp")
 target_link_libraries(ScopedDeleter_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_ScopedDeleter
-                      ${LIBS})
+                      quickstep_utility_ScopedDeleter)
 add_test(ScopedDeleter_unittest ScopedDeleter_unittest)
 
 add_executable(ScopedReassignment_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/ScopedReassignment_unittest.cpp")
 target_link_libraries(ScopedReassignment_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
                       quickstep_utility_Macros
-                      quickstep_utility_ScopedReassignment
-                      ${LIBS})
+                      quickstep_utility_ScopedReassignment)
 add_test(ScopedReassignment_unittest ScopedReassignment_unittest)
 
 add_executable(SqlError_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/SqlError_unittest.cpp")
@@ -495,10 +501,10 @@ add_test(TextBasedTestDriver_unittest TextBasedTestDriver_unittest)
 
 add_executable(ThreadSafeQueue_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/ThreadSafeQueue_unittest.cpp")
 target_link_libraries(ThreadSafeQueue_unittest
+                      ${LIBS}
                       gtest
                       gtest_main
-                      quickstep_utility_ThreadSafeQueue
-                      ${LIBS})
+                      quickstep_utility_ThreadSafeQueue)
 add_test(ThreadSafeQueue_unittest ThreadSafeQueue_unittest)
 
 add_executable(TreeStringSerializable_unittest "${CMAKE_CURRENT_SOURCE_DIR}/tests/TreeStringSerializable_unittest.cpp")
@@ -522,14 +528,14 @@ if (UNIX)
   add_executable(EqualsAnyConstant_benchmark
                  "${CMAKE_CURRENT_SOURCE_DIR}/tests/EqualsAnyConstant_benchmark.cpp")
   target_link_libraries(EqualsAnyConstant_benchmark
+                        ${LIBS}
                         benchmark
-                        quickstep_utility_EqualsAnyConstant
-                        ${LIBS})
+                        quickstep_utility_EqualsAnyConstant)
 
   add_executable(HashPair_benchmark "${CMAKE_CURRENT_SOURCE_DIR}/tests/HashPair_benchmark.cpp")
   target_link_libraries(HashPair_benchmark
+                        ${LIBS}
                         benchmark
-                        quickstep_utility_HashPair
                         quickstep_types_TypedValue
-                        ${LIBS})
+                        quickstep_utility_HashPair)
 endif()

--- a/utility/lip_filter/CMakeLists.txt
+++ b/utility/lip_filter/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(quickstep_utility_lipfilter_SingleIdentityHashFilter ../../empty_src
 
 # Link dependencies:
 target_link_libraries(quickstep_utility_lipfilter_BitVectorExactFilter
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_ValueAccessor
@@ -46,6 +47,7 @@ target_link_libraries(quickstep_utility_lipfilter_LIPFilter
                       quickstep_storage_StorageBlockInfo
                       quickstep_utility_Macros)
 target_link_libraries(quickstep_utility_lipfilter_LIPFilterAdaptiveProber
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_TupleIdSequence
@@ -54,6 +56,7 @@ target_link_libraries(quickstep_utility_lipfilter_LIPFilterAdaptiveProber
                       quickstep_utility_Macros
                       quickstep_utility_lipfilter_LIPFilter)
 target_link_libraries(quickstep_utility_lipfilter_LIPFilterBuilder
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_utility_Macros
                       quickstep_utility_lipfilter_LIPFilter)
@@ -66,10 +69,11 @@ target_link_libraries(quickstep_utility_lipfilter_LIPFilterDeployment
                       quickstep_utility_lipfilter_LIPFilterBuilder
                       quickstep_utility_lipfilter_LIPFilter_proto)
 target_link_libraries(quickstep_utility_lipfilter_LIPFilterFactory
+                      glog
+                      quickstep_utility_Macros
                       quickstep_utility_lipfilter_BitVectorExactFilter
                       quickstep_utility_lipfilter_LIPFilter_proto
-                      quickstep_utility_lipfilter_SingleIdentityHashFilter
-                      quickstep_utility_Macros)
+                      quickstep_utility_lipfilter_SingleIdentityHashFilter)
 target_link_libraries(quickstep_utility_lipfilter_LIPFilterUtil
                       quickstep_queryexecution_QueryContext
                       quickstep_utility_lipfilter_LIPFilterDeployment)
@@ -77,6 +81,7 @@ target_link_libraries(quickstep_utility_lipfilter_LIPFilter_proto
                       ${PROTOBUF_LIBRARY}
                       quickstep_types_Type_proto)
 target_link_libraries(quickstep_utility_lipfilter_SingleIdentityHashFilter
+                      glog
                       quickstep_catalog_CatalogTypedefs
                       quickstep_storage_StorageBlockInfo
                       quickstep_storage_ValueAccessor

--- a/yarn/CMakeLists.txt
+++ b/yarn/CMakeLists.txt
@@ -16,4 +16,3 @@
 # under the License.
 
 option(ENABLE_YARN "Enable optional support for Quickstep on YARN" OFF)
-


### PR DESCRIPTION
This PR fixes and adjusts the style of all `CMakeLists.txt` so that they become stable (i.e. well-formatted) to be processed by an automated tool.

The above mentioned tool will be proposed in a subsequent PR. It is intended to help improve developer productivity as it scans source code dependencies and automatically fixes cmakelists.
