### PR TITLE
QUICKSTEP-123: Fixed the missing 'has_repartition' in FilterJoin.

### DIFF
--- a/query_optimizer/physical/FilterJoin.cpp
+++ b/query_optimizer/physical/FilterJoin.cpp
@@ -78,6 +78,7 @@ bool FilterJoin::maybeCopyWithPrunedExpressions(
                      new_project_expressions,
                      build_side_filter_predicate_,
                      is_anti_join_,
+                     has_repartition_,
                      cloneOutputPartitionSchemeHeader());
     return true;
   }

--- a/query_optimizer/physical/FilterJoin.hpp
+++ b/query_optimizer/physical/FilterJoin.hpp
@@ -109,6 +109,7 @@ class FilterJoin : public BinaryJoin {
                   project_expressions(),
                   build_side_filter_predicate_,
                   is_anti_join_,
+                  has_repartition_,
                   cloneOutputPartitionSchemeHeader());
   }
 
@@ -128,6 +129,7 @@ class FilterJoin : public BinaryJoin {
    * @param build_side_filter_predicate Optional filtering predicate to be
    *        applied to the build side child BEFORE join.
    * @param is_anti_join Whether this is an anti-join.
+   * @param has_repartition Whether this node does repartition.
    * @param partition_scheme_header The optional output partition scheme header.
    *
    * @return An immutable physical FilterJoin.
@@ -140,6 +142,7 @@ class FilterJoin : public BinaryJoin {
       const std::vector<expressions::NamedExpressionPtr> &project_expressions,
       const expressions::PredicatePtr &build_side_filter_predicate,
       const bool is_anti_join,
+      const bool has_repartition = false,
       PartitionSchemeHeader *partition_scheme_header = nullptr) {
     return FilterJoinPtr(
         new FilterJoin(probe_child,
@@ -149,6 +152,7 @@ class FilterJoin : public BinaryJoin {
                        project_expressions,
                        build_side_filter_predicate,
                        is_anti_join,
+                       has_repartition,
                        partition_scheme_header));
   }
 
@@ -170,8 +174,10 @@ class FilterJoin : public BinaryJoin {
       const std::vector<expressions::NamedExpressionPtr> &project_expressions,
       const expressions::PredicatePtr &build_side_filter_predicate,
       const bool is_anti_join,
+      const bool has_repartition,
       PartitionSchemeHeader *partition_scheme_header)
-      : BinaryJoin(probe_child, build_child, project_expressions, partition_scheme_header),
+      : BinaryJoin(probe_child, build_child, project_expressions,
+                   has_repartition, partition_scheme_header),
         probe_attributes_(probe_attributes),
         build_attributes_(build_attributes),
         build_side_filter_predicate_(build_side_filter_predicate),

--- a/query_optimizer/physical/PatternMatcher.hpp
+++ b/query_optimizer/physical/PatternMatcher.hpp
@@ -111,7 +111,9 @@ constexpr PhysicalType SomePhysicalNode<PhysicalClass, physical_types...>::kPhys
 // Specializations for all Physical classes.
 
 using SomeAggregate = SomePhysicalNode<Aggregate, PhysicalType::kAggregate>;
-using SomeBinaryJoin = SomePhysicalNode<BinaryJoin, PhysicalType::kHashJoin, PhysicalType::kNestedLoopsJoin>;
+using SomeBinaryJoin = SomePhysicalNode<BinaryJoin, PhysicalType::kFilterJoin,
+                                                    PhysicalType::kHashJoin,
+                                                    PhysicalType::kNestedLoopsJoin>;
 using SomeCopyFrom = SomePhysicalNode<CopyFrom, PhysicalType::kCopyFrom>;
 using SomeCreateTable = SomePhysicalNode<CreateTable, PhysicalType::kCreateTable>;
 using SomeCrossReferenceCoalesceAggregate = SomePhysicalNode<CrossReferenceCoalesceAggregate,

--- a/query_optimizer/rules/InjectJoinFilters.cpp
+++ b/query_optimizer/rules/InjectJoinFilters.cpp
@@ -183,6 +183,7 @@ P::PhysicalPtr InjectJoinFilters::transformHashJoinToFilters(
                                  hash_join->project_expressions(),
                                  build_side_filter_predicate,
                                  is_anti_join,
+                                 hash_join->hasRepartition(),
                                  hash_join->cloneOutputPartitionSchemeHeader());
   }
 
@@ -256,6 +257,7 @@ physical::PhysicalPtr InjectJoinFilters::pushDownFiltersInternal(
                                  E::ToNamedExpressions(probe_child->getOutputAttributes()),
                                  filter_join->build_side_filter_predicate(),
                                  filter_join->is_anti_join(),
+                                 filter_join->hasRepartition(),
                                  filter_join->cloneOutputPartitionSchemeHeader());
   } else {
     return filter_join;
@@ -332,6 +334,7 @@ physical::PhysicalPtr InjectJoinFilters::addFilterAnchors(
     return P::Selection::Create(filter_join,
                                 filter_join->project_expressions(),
                                 nullptr,
+                                filter_join->hasRepartition(),
                                 filter_join->cloneOutputPartitionSchemeHeader());
   } else {
     return output_with_new_children;


### PR DESCRIPTION
Added the missing `has_repartition` in `FilterJoin`, also added it as a subtype of `BinaryJoin` in `PatternMatcher`.