### PR TITLE
QUICKSTEP-121: Added the self-join support.

### DIFF
--- a/expressions/ExpressionFactories.cpp
+++ b/expressions/ExpressionFactories.cpp
@@ -52,6 +52,8 @@
 
 namespace quickstep {
 
+namespace S = serialization;
+
 class Type;
 
 Predicate* PredicateFactory::ReconstructFromProto(const serialization::Predicate &proto,
@@ -163,9 +165,22 @@ Scalar* ScalarFactory::ReconstructFromProto(const serialization::Scalar &proto,
     case serialization::Scalar::ATTRIBUTE: {
       const relation_id rel_id = proto.GetExtension(serialization::ScalarAttribute::relation_id);
 
+      Scalar::JoinSide join_side;
+      switch (proto.GetExtension(S::ScalarAttribute::join_side)) {
+        case S::ScalarAttribute::NONE:
+          join_side = Scalar::kNone;
+          break;
+        case S::ScalarAttribute::LEFT_SIDE:
+          join_side = Scalar::kLeftSide;
+          break;
+        case S::ScalarAttribute::RIGHT_SIDE:
+          join_side = Scalar::kRightSide;
+          break;
+      }
+
       DCHECK(database.hasRelationWithId(rel_id));
       return new ScalarAttribute(*database.getRelationSchemaById(rel_id).getAttributeById(
-          proto.GetExtension(serialization::ScalarAttribute::attribute_id)));
+          proto.GetExtension(serialization::ScalarAttribute::attribute_id)), join_side);
     }
     case serialization::Scalar::UNARY_EXPRESSION: {
       return new ScalarUnaryExpression(

--- a/expressions/Expressions.proto
+++ b/expressions/Expressions.proto
@@ -95,9 +95,16 @@ message ScalarLiteral {
 }
 
 message ScalarAttribute {
+  enum JoinSide {
+    NONE = 0;
+    LEFT_SIDE = 1;
+    RIGHT_SIDE = 2;
+  }
+
   extend Scalar {
     optional int32 relation_id = 64;
     optional int32 attribute_id = 65;
+    optional JoinSide join_side = 66;
   }
 }
 

--- a/expressions/predicate/ComparisonPredicate.cpp
+++ b/expressions/predicate/ComparisonPredicate.cpp
@@ -94,28 +94,22 @@ bool ComparisonPredicate::matchesForSingleTuple(const ValueAccessor &accessor,
 
 bool ComparisonPredicate::matchesForJoinedTuples(
     const ValueAccessor &left_accessor,
-    const relation_id left_relation_id,
     const tuple_id left_tuple_id,
     const ValueAccessor &right_accessor,
-    const relation_id right_relation_id,
     const tuple_id right_tuple_id) const {
   if (fast_comparator_.get() == nullptr) {
     return static_result_;
-  } else {
-    return fast_comparator_->compareTypedValues(
-        left_operand_->getValueForJoinedTuples(left_accessor,
-                                               left_relation_id,
-                                               left_tuple_id,
-                                               right_accessor,
-                                               right_relation_id,
-                                               right_tuple_id),
-        right_operand_->getValueForJoinedTuples(left_accessor,
-                                                left_relation_id,
-                                                left_tuple_id,
-                                                right_accessor,
-                                                right_relation_id,
-                                                right_tuple_id));
   }
+
+  return fast_comparator_->compareTypedValues(
+      left_operand_->getValueForJoinedTuples(left_accessor,
+                                             left_tuple_id,
+                                             right_accessor,
+                                             right_tuple_id),
+      right_operand_->getValueForJoinedTuples(left_accessor,
+                                              left_tuple_id,
+                                              right_accessor,
+                                              right_tuple_id));
 }
 
 TupleIdSequence* ComparisonPredicate::getAllMatches(

--- a/expressions/predicate/ComparisonPredicate.hpp
+++ b/expressions/predicate/ComparisonPredicate.hpp
@@ -83,10 +83,8 @@ class ComparisonPredicate : public Predicate {
 
   bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   TupleIdSequence* getAllMatches(ValueAccessor *accessor,

--- a/expressions/predicate/ConjunctionPredicate.cpp
+++ b/expressions/predicate/ConjunctionPredicate.cpp
@@ -85,10 +85,8 @@ bool ConjunctionPredicate::matchesForSingleTuple(const ValueAccessor &accessor,
 
 bool ConjunctionPredicate::matchesForJoinedTuples(
     const ValueAccessor &left_accessor,
-    const relation_id left_relation_id,
     const tuple_id left_tuple_id,
     const ValueAccessor &right_accessor,
-    const relation_id right_relation_id,
     const tuple_id right_tuple_id) const {
   if (has_static_result_) {
     return static_result_;
@@ -97,10 +95,8 @@ bool ConjunctionPredicate::matchesForJoinedTuples(
          it != dynamic_operand_list_.end();
          ++it) {
       if (!it->matchesForJoinedTuples(left_accessor,
-                                      left_relation_id,
                                       left_tuple_id,
                                       right_accessor,
-                                      right_relation_id,
                                       right_tuple_id)) {
         return false;
       }

--- a/expressions/predicate/ConjunctionPredicate.hpp
+++ b/expressions/predicate/ConjunctionPredicate.hpp
@@ -63,10 +63,8 @@ class ConjunctionPredicate : public PredicateWithList {
 
   bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   TupleIdSequence* getAllMatches(ValueAccessor *accessor,

--- a/expressions/predicate/DisjunctionPredicate.cpp
+++ b/expressions/predicate/DisjunctionPredicate.cpp
@@ -85,10 +85,8 @@ bool DisjunctionPredicate::matchesForSingleTuple(const ValueAccessor &accessor,
 
 bool DisjunctionPredicate::matchesForJoinedTuples(
     const ValueAccessor &left_accessor,
-    const relation_id left_relation_id,
     const tuple_id left_tuple_id,
     const ValueAccessor &right_accessor,
-    const relation_id right_relation_id,
     const tuple_id right_tuple_id) const {
   if (has_static_result_) {
     return static_result_;
@@ -97,10 +95,8 @@ bool DisjunctionPredicate::matchesForJoinedTuples(
          it != dynamic_operand_list_.end();
          ++it) {
       if (it->matchesForJoinedTuples(left_accessor,
-                                     left_relation_id,
                                      left_tuple_id,
                                      right_accessor,
-                                     right_relation_id,
                                      right_tuple_id)) {
         return true;
       }

--- a/expressions/predicate/DisjunctionPredicate.hpp
+++ b/expressions/predicate/DisjunctionPredicate.hpp
@@ -63,10 +63,8 @@ class DisjunctionPredicate : public PredicateWithList {
 
   bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   TupleIdSequence* getAllMatches(ValueAccessor *accessor,

--- a/expressions/predicate/NegationPredicate.cpp
+++ b/expressions/predicate/NegationPredicate.cpp
@@ -54,19 +54,15 @@ bool NegationPredicate::matchesForSingleTuple(const ValueAccessor &accessor,
 
 bool NegationPredicate::matchesForJoinedTuples(
     const ValueAccessor &left_accessor,
-    const relation_id left_relation_id,
     const tuple_id left_tuple_id,
     const ValueAccessor &right_accessor,
-    const relation_id right_relation_id,
     const tuple_id right_tuple_id) const {
   if (has_static_result_) {
     return static_result_;
   } else {
     return !(operand_->matchesForJoinedTuples(left_accessor,
-                                              left_relation_id,
                                               left_tuple_id,
                                               right_accessor,
-                                              right_relation_id,
                                               right_tuple_id));
   }
 }

--- a/expressions/predicate/NegationPredicate.hpp
+++ b/expressions/predicate/NegationPredicate.hpp
@@ -91,10 +91,8 @@ class NegationPredicate : public Predicate {
 
   bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   TupleIdSequence* getAllMatches(ValueAccessor *accessor,

--- a/expressions/predicate/Predicate.hpp
+++ b/expressions/predicate/Predicate.hpp
@@ -123,15 +123,11 @@ class Predicate : public Expression {
    * @param left_accessor The ValueAccessor that the first of the joined tuples
    *        will be read from (this does NOT necessarily correspond to the left
    *        operand of a binary operation).
-   * @param left_relation_id The ID of the relation that left_accessor provides
-   *        access to.
    * @param left_tuple_id The ID of the tuple (the absolute position) from
    *        left_accessor to evaluate this Predicate for.
    * @param right_accessor The ValueAccessor that the second of the joined
    *        tuples will be read from (this does NOT necessarily correspond to
    *        the right operand of a binary operation).
-   * @param right_relation_id The ID of the relation that right_accessor
-   *        provides access to.
    * @param right_tuple_id The ID of the tuple (the absolute position) from
    *        right_accessor to evaluate this Predicate for.
    * @return Whether this predicate is true for the given tuples.
@@ -144,10 +140,8 @@ class Predicate : public Expression {
   // a smallish set of matches from a hash-join by a residual predicate).
   virtual bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const = 0;
 
   /**

--- a/expressions/predicate/TrivialPredicates.hpp
+++ b/expressions/predicate/TrivialPredicates.hpp
@@ -84,10 +84,8 @@ class TruePredicate : public TrivialPredicate {
 
   bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override {
     return true;
   }
@@ -137,10 +135,8 @@ class FalsePredicate : public TrivialPredicate {
 
   bool matchesForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override {
     return false;
   }

--- a/expressions/scalar/ScalarAttribute.hpp
+++ b/expressions/scalar/ScalarAttribute.hpp
@@ -53,8 +53,10 @@ class ScalarAttribute : public Scalar {
    * @brief Constructor.
    *
    * @param attribute The attribute to use.
+   * @param join_side The join side of which this attribute belongs to.
    **/
-  explicit ScalarAttribute(const CatalogAttribute &attribute);
+  explicit ScalarAttribute(const CatalogAttribute &attribute,
+                           const JoinSide join_side = kNone);
 
   serialization::Scalar getProto() const override;
 
@@ -69,24 +71,18 @@ class ScalarAttribute : public Scalar {
 
   TypedValue getValueForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   attribute_id getAttributeIdForValueAccessor() const override;
-
-  relation_id getRelationIdForValueAccessor() const override;
 
   ColumnVectorPtr getAllValues(ValueAccessor *accessor,
                                const SubBlocksReference *sub_blocks_ref,
                                ColumnVectorCache *cv_cache) const override;
 
   ColumnVectorPtr getAllValuesForJoin(
-      const relation_id left_relation_id,
       ValueAccessor *left_accessor,
-      const relation_id right_relation_id,
       ValueAccessor *right_accessor,
       const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
       ColumnVectorCache *cv_cache) const override;

--- a/expressions/scalar/ScalarBinaryExpression.hpp
+++ b/expressions/scalar/ScalarBinaryExpression.hpp
@@ -84,10 +84,8 @@ class ScalarBinaryExpression : public Scalar {
 
   TypedValue getValueForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   bool hasStaticValue() const override {
@@ -104,9 +102,7 @@ class ScalarBinaryExpression : public Scalar {
                                ColumnVectorCache *cv_cache) const override;
 
   ColumnVectorPtr getAllValuesForJoin(
-      const relation_id left_relation_id,
       ValueAccessor *left_accessor,
-      const relation_id right_relation_id,
       ValueAccessor *right_accessor,
       const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
       ColumnVectorCache *cv_cache) const override;

--- a/expressions/scalar/ScalarCaseExpression.hpp
+++ b/expressions/scalar/ScalarCaseExpression.hpp
@@ -101,10 +101,8 @@ class ScalarCaseExpression : public Scalar {
 
   TypedValue getValueForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   bool hasStaticValue() const override {
@@ -129,9 +127,7 @@ class ScalarCaseExpression : public Scalar {
                                ColumnVectorCache *cv_cache) const override;
 
   ColumnVectorPtr getAllValuesForJoin(
-      const relation_id left_relation_id,
       ValueAccessor *left_accessor,
-      const relation_id right_relation_id,
       ValueAccessor *right_accessor,
       const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
       ColumnVectorCache *cv_cache) const override;

--- a/expressions/scalar/ScalarLiteral.cpp
+++ b/expressions/scalar/ScalarLiteral.cpp
@@ -59,9 +59,7 @@ ColumnVectorPtr ScalarLiteral::getAllValues(
 }
 
 ColumnVectorPtr ScalarLiteral::getAllValuesForJoin(
-    const relation_id left_relation_id,
     ValueAccessor *left_accessor,
-    const relation_id right_relation_id,
     ValueAccessor *right_accessor,
     const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
     ColumnVectorCache *cv_cache) const {

--- a/expressions/scalar/ScalarLiteral.hpp
+++ b/expressions/scalar/ScalarLiteral.hpp
@@ -87,10 +87,8 @@ class ScalarLiteral : public Scalar {
 
   TypedValue getValueForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override {
     return internal_literal_.makeReferenceToThis();
   }
@@ -108,9 +106,7 @@ class ScalarLiteral : public Scalar {
                                ColumnVectorCache *cv_cache) const override;
 
   ColumnVectorPtr getAllValuesForJoin(
-      const relation_id left_relation_id,
       ValueAccessor *left_accessor,
-      const relation_id right_relation_id,
       ValueAccessor *right_accessor,
       const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
       ColumnVectorCache *cv_cache) const override;

--- a/expressions/scalar/ScalarSharedExpression.cpp
+++ b/expressions/scalar/ScalarSharedExpression.cpp
@@ -55,16 +55,12 @@ TypedValue ScalarSharedExpression::getValueForSingleTuple(const ValueAccessor &a
 
 TypedValue ScalarSharedExpression::getValueForJoinedTuples(
     const ValueAccessor &left_accessor,
-    const relation_id left_relation_id,
     const tuple_id left_tuple_id,
     const ValueAccessor &right_accessor,
-    const relation_id right_relation_id,
     const tuple_id right_tuple_id) const {
   return operand_->getValueForJoinedTuples(left_accessor,
-                                           left_relation_id,
                                            left_tuple_id,
                                            right_accessor,
-                                           right_relation_id,
                                            right_tuple_id);
 }
 
@@ -87,16 +83,12 @@ ColumnVectorPtr ScalarSharedExpression::getAllValues(
 }
 
 ColumnVectorPtr ScalarSharedExpression::getAllValuesForJoin(
-    const relation_id left_relation_id,
     ValueAccessor *left_accessor,
-    const relation_id right_relation_id,
     ValueAccessor *right_accessor,
     const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
     ColumnVectorCache *cv_cache) const {
   if (cv_cache == nullptr) {
-    return operand_->getAllValuesForJoin(left_relation_id,
-                                         left_accessor,
-                                         right_relation_id,
+    return operand_->getAllValuesForJoin(left_accessor,
                                          right_accessor,
                                          joined_tuple_ids,
                                          cv_cache);
@@ -106,9 +98,7 @@ ColumnVectorPtr ScalarSharedExpression::getAllValuesForJoin(
   if (cv_cache->contains(share_id_)) {
     result = cv_cache->get(share_id_);
   } else {
-    result = operand_->getAllValuesForJoin(left_relation_id,
-                                           left_accessor,
-                                           right_relation_id,
+    result = operand_->getAllValuesForJoin(left_accessor,
                                            right_accessor,
                                            joined_tuple_ids,
                                            cv_cache);

--- a/expressions/scalar/ScalarSharedExpression.hpp
+++ b/expressions/scalar/ScalarSharedExpression.hpp
@@ -83,10 +83,8 @@ class ScalarSharedExpression : public Scalar {
 
   TypedValue getValueForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   bool hasStaticValue() const override {
@@ -102,9 +100,7 @@ class ScalarSharedExpression : public Scalar {
                                ColumnVectorCache *cv_cache) const override;
 
   ColumnVectorPtr getAllValuesForJoin(
-      const relation_id left_relation_id,
       ValueAccessor *left_accessor,
-      const relation_id right_relation_id,
       ValueAccessor *right_accessor,
       const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
       ColumnVectorCache *cv_cache) const override;

--- a/expressions/scalar/ScalarUnaryExpression.hpp
+++ b/expressions/scalar/ScalarUnaryExpression.hpp
@@ -79,10 +79,8 @@ class ScalarUnaryExpression : public Scalar {
 
   TypedValue getValueForJoinedTuples(
       const ValueAccessor &left_accessor,
-      const relation_id left_relation_id,
       const tuple_id left_tuple_id,
       const ValueAccessor &right_accessor,
-      const relation_id right_relation_id,
       const tuple_id right_tuple_id) const override;
 
   bool hasStaticValue() const override {
@@ -99,9 +97,7 @@ class ScalarUnaryExpression : public Scalar {
                                ColumnVectorCache *cv_cache) const override;
 
   ColumnVectorPtr getAllValuesForJoin(
-      const relation_id left_relation_id,
       ValueAccessor *left_accessor,
-      const relation_id right_relation_id,
       ValueAccessor *right_accessor,
       const std::vector<std::pair<tuple_id, tuple_id>> &joined_tuple_ids,
       ColumnVectorCache *cv_cache) const override;

--- a/expressions/scalar/tests/ScalarCaseExpression_unittest.cpp
+++ b/expressions/scalar/tests/ScalarCaseExpression_unittest.cpp
@@ -916,8 +916,8 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchConstantTest) {
       new ScalarLiteral(TypedValue(static_cast<int>(2)), int_type)));
   result_expressions.emplace_back(new ScalarBinaryExpression(
       BinaryOperationFactory::GetBinaryOperation(BinaryOperationID::kAdd),
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)),
-      new ScalarAttribute(*other_relation.getAttributeById(1))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(1), Scalar::kRightSide)));
 
   const int kConstant = 72;
   // WHEN 1 < 2 THEN kConstant
@@ -931,8 +931,8 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchConstantTest) {
   // WHEN double_attr = other_double THEN 0
   when_predicates.emplace_back(new ComparisonPredicate(
       ComparisonFactory::GetComparison(ComparisonID::kEqual),
-      new ScalarAttribute(*sample_relation_->getAttributeById(1)),
-      new ScalarAttribute(*other_relation.getAttributeById(0))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(1), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(0), Scalar::kRightSide)));
   result_expressions.emplace_back(new ScalarLiteral(TypedValue(0), TypeFactory::GetType(kInt)));
 
   const Type &int_nullable_type = TypeFactory::GetType(kInt, true);
@@ -947,14 +947,13 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchConstantTest) {
   // Create a list of joined tuple-id pairs (just the cross-product of tuples).
   std::vector<std::pair<tuple_id, tuple_id>> joined_tuple_ids;
   for (std::size_t tuple_num = 0; tuple_num < kNumSampleTuples; ++tuple_num) {
+    // <LeftSide-tid, RightSide-tid>.
     joined_tuple_ids.emplace_back(tuple_num, 0);
     joined_tuple_ids.emplace_back(tuple_num, 1);
   }
 
   ColumnVectorPtr result_cv(case_expr.getAllValuesForJoin(
-      0,
       &sample_data_value_accessor_,
-      1,
       &other_accessor,
       joined_tuple_ids,
       nullptr /* cv_cache */));
@@ -1012,8 +1011,8 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchOnScalarAttributeTest) {
       new ScalarLiteral(TypedValue(static_cast<int>(2)), int_type)));
   result_expressions.emplace_back(new ScalarBinaryExpression(
       BinaryOperationFactory::GetBinaryOperation(BinaryOperationID::kAdd),
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)),
-      new ScalarAttribute(*other_relation.getAttributeById(1))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(1), Scalar::kRightSide)));
 
   // WHEN 1 < 2 THEN int_attr
   when_predicates.emplace_back(new ComparisonPredicate(
@@ -1021,13 +1020,13 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchOnScalarAttributeTest) {
       new ScalarLiteral(TypedValue(static_cast<int>(1)), int_type),
       new ScalarLiteral(TypedValue(static_cast<int>(2)), int_type)));
   result_expressions.emplace_back(
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide));
 
   // WHEN double_attr = other_double THEN 0
   when_predicates.emplace_back(new ComparisonPredicate(
       ComparisonFactory::GetComparison(ComparisonID::kEqual),
-      new ScalarAttribute(*sample_relation_->getAttributeById(1)),
-      new ScalarAttribute(*other_relation.getAttributeById(0))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(1), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(0), Scalar::kRightSide)));
   result_expressions.emplace_back(new ScalarLiteral(TypedValue(0), TypeFactory::GetType(kInt)));
 
   const Type &int_nullable_type = TypeFactory::GetType(kInt, true);
@@ -1042,14 +1041,13 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchOnScalarAttributeTest) {
   // Create a list of joined tuple-id pairs (just the cross-product of tuples).
   std::vector<std::pair<tuple_id, tuple_id>> joined_tuple_ids;
   for (std::size_t tuple_num = 0; tuple_num < kNumSampleTuples; ++tuple_num) {
+    // <LeftSide-tid, RightSide-tid>.
     joined_tuple_ids.emplace_back(tuple_num, 0);
     joined_tuple_ids.emplace_back(tuple_num, 1);
   }
 
   ColumnVectorPtr result_cv(case_expr.getAllValuesForJoin(
-      0,
       &sample_data_value_accessor_,
-      1,
       &other_accessor,
       joined_tuple_ids,
       nullptr /* cv_cache */));
@@ -1116,8 +1114,8 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchTest) {
       new ScalarLiteral(TypedValue(static_cast<int>(2)), int_type)));
   result_expressions.emplace_back(new ScalarBinaryExpression(
       BinaryOperationFactory::GetBinaryOperation(BinaryOperationID::kAdd),
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)),
-      new ScalarAttribute(*other_relation.getAttributeById(1))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(1), Scalar::kRightSide)));
 
   // WHEN 1 < 2 THEN int_attr * other_int
   when_predicates.emplace_back(new ComparisonPredicate(
@@ -1126,14 +1124,14 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchTest) {
       new ScalarLiteral(TypedValue(static_cast<int>(2)), int_type)));
   result_expressions.emplace_back(new ScalarBinaryExpression(
       BinaryOperationFactory::GetBinaryOperation(BinaryOperationID::kMultiply),
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)),
-      new ScalarAttribute(*other_relation.getAttributeById(1))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(1), Scalar::kRightSide)));
 
   // WHEN double_attr = other_double THEN 0
   when_predicates.emplace_back(new ComparisonPredicate(
       ComparisonFactory::GetComparison(ComparisonID::kEqual),
-      new ScalarAttribute(*sample_relation_->getAttributeById(1)),
-      new ScalarAttribute(*other_relation.getAttributeById(0))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(1), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(0), Scalar::kRightSide)));
   result_expressions.emplace_back(new ScalarLiteral(TypedValue(0), TypeFactory::GetType(kInt)));
 
   const Type &int_nullable_type = TypeFactory::GetType(kInt, true);
@@ -1148,14 +1146,13 @@ TEST_F(ScalarCaseExpressionTest, JoinStaticBranchTest) {
   // Create a list of joined tuple-id pairs (just the cross-product of tuples).
   std::vector<std::pair<tuple_id, tuple_id>> joined_tuple_ids;
   for (std::size_t tuple_num = 0; tuple_num < kNumSampleTuples; ++tuple_num) {
+    // <LeftSide-tid, RightSide-tid>.
     joined_tuple_ids.emplace_back(tuple_num, 0);
     joined_tuple_ids.emplace_back(tuple_num, 1);
   }
 
   ColumnVectorPtr result_cv(case_expr.getAllValuesForJoin(
-      0,
       &sample_data_value_accessor_,
-      1,
       &other_accessor,
       joined_tuple_ids,
       nullptr /* cv_cache */));
@@ -1217,22 +1214,22 @@ TEST_F(ScalarCaseExpressionTest, JoinTest) {
   // WHEN double_attr > other_double THEN int_attr + other_int
   when_predicates.emplace_back(new ComparisonPredicate(
       ComparisonFactory::GetComparison(ComparisonID::kGreater),
-      new ScalarAttribute(*sample_relation_->getAttributeById(1)),
-      new ScalarAttribute(*other_relation.getAttributeById(0))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(1), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(0), Scalar::kRightSide)));
   result_expressions.emplace_back(new ScalarBinaryExpression(
       BinaryOperationFactory::GetBinaryOperation(BinaryOperationID::kAdd),
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)),
-      new ScalarAttribute(*other_relation.getAttributeById(1))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(1), Scalar::kRightSide)));
 
   // WHEN double_attr < other_double THEN int_attr * other_int
   when_predicates.emplace_back(new ComparisonPredicate(
       ComparisonFactory::GetComparison(ComparisonID::kLess),
-      new ScalarAttribute(*sample_relation_->getAttributeById(1)),
-      new ScalarAttribute(*other_relation.getAttributeById(0))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(1), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(0), Scalar::kRightSide)));
   result_expressions.emplace_back(new ScalarBinaryExpression(
       BinaryOperationFactory::GetBinaryOperation(BinaryOperationID::kMultiply),
-      new ScalarAttribute(*sample_relation_->getAttributeById(0)),
-      new ScalarAttribute(*other_relation.getAttributeById(1))));
+      new ScalarAttribute(*sample_relation_->getAttributeById(0), Scalar::kLeftSide),
+      new ScalarAttribute(*other_relation.getAttributeById(1), Scalar::kRightSide)));
 
   // ELSE 0
   ScalarCaseExpression case_expr(
@@ -1244,14 +1241,13 @@ TEST_F(ScalarCaseExpressionTest, JoinTest) {
   // Create a list of joined tuple-id pairs (just the cross-product of tuples).
   std::vector<std::pair<tuple_id, tuple_id>> joined_tuple_ids;
   for (std::size_t tuple_num = 0; tuple_num < kNumSampleTuples; ++tuple_num) {
+    // <LeftSide-tid, RightSide-tid>.
     joined_tuple_ids.emplace_back(tuple_num, 0);
     joined_tuple_ids.emplace_back(tuple_num, 1);
   }
 
   ColumnVectorPtr result_cv(case_expr.getAllValuesForJoin(
-      0,
       &sample_data_value_accessor_,
-      1,
       &other_accessor,
       joined_tuple_ids,
       nullptr /* cv_cache */));

--- a/query_optimizer/ExecutionGenerator.hpp
+++ b/query_optimizer/ExecutionGenerator.hpp
@@ -24,11 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-
-#ifdef QUICKSTEP_DISTRIBUTED
 #include <unordered_set>
-#endif
-
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -388,10 +384,16 @@ class ExecutionGenerator {
    * @param named_expressions The list of NamedExpressions to be converted.
    * @param scalar_group_proto The corresponding scalars proto in QueryContext
    *        proto.
+   * @param left_expr_ids The ExprIds from the left hand side.
+   * @param right_expr_ids The ExprIds from the right hand side.
    */
   void convertNamedExpressions(
       const std::vector<expressions::NamedExpressionPtr> &named_expressions,
-      serialization::QueryContext::ScalarGroup *scalar_group_proto);
+      serialization::QueryContext::ScalarGroup *scalar_group_proto,
+      const std::unordered_set<expressions::ExprId> &left_expr_ids =
+          std::unordered_set<expressions::ExprId>(),
+      const std::unordered_set<expressions::ExprId> &right_expr_ids =
+          std::unordered_set<expressions::ExprId>());
 
   /**
    * @brief Converts a Predicate in the optimizer expression system to a
@@ -399,9 +401,16 @@ class ExecutionGenerator {
    *        takes ownership of the returned pointer.
    *
    * @param optimizer_predicate The Predicate to be converted.
+   * @param left_expr_ids The ExprIds from the left hand side.
+   * @param right_expr_ids The ExprIds from the right hand side.
    * @return The corresponding Predicate in the execution expression system.
    */
-  Predicate* convertPredicate(const expressions::PredicatePtr &optimizer_predicate) const;
+  Predicate* convertPredicate(
+      const expressions::PredicatePtr &optimizer_predicate,
+      const std::unordered_set<expressions::ExprId> &left_expr_ids =
+          std::unordered_set<expressions::ExprId>(),
+      const std::unordered_set<expressions::ExprId> &right_expr_ids =
+          std::unordered_set<expressions::ExprId>()) const;
 
   /**
    * @brief Drops all temporary relations created by the generator

--- a/query_optimizer/expressions/Alias.cpp
+++ b/query_optimizer/expressions/Alias.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -65,7 +66,9 @@ ExpressionPtr Alias::copyWithNewChildren(
 }
 
 ::quickstep::Scalar *Alias::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   // Alias should be converted to a CatalogAttribute.
   LOG(FATAL) << "Cannot concretize Alias to a scalar for evaluation";
 }

--- a/query_optimizer/expressions/Alias.hpp
+++ b/query_optimizer/expressions/Alias.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -81,7 +82,9 @@ class Alias : public NamedExpression {
   }
 
   ::quickstep::Scalar *concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable Alias. If \p expression is also an Alias,

--- a/query_optimizer/expressions/AttributeReference.hpp
+++ b/query_optimizer/expressions/AttributeReference.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "catalog/CatalogTypedefs.hpp"
@@ -88,7 +89,9 @@ class AttributeReference : public NamedExpression {
   std::vector<AttributeReferencePtr> getReferencedAttributes() const override;
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   bool equals(const ScalarPtr &other) const override;
 

--- a/query_optimizer/expressions/BinaryExpression.cpp
+++ b/query_optimizer/expressions/BinaryExpression.cpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -101,11 +102,13 @@ std::vector<AttributeReferencePtr> BinaryExpression::getReferencedAttributes() c
 }
 
 ::quickstep::Scalar *BinaryExpression::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   return new ::quickstep::ScalarBinaryExpression(
       operation_,
-      left_->concretize(substitution_map),
-      right_->concretize(substitution_map));
+      left_->concretize(substitution_map, left_expr_ids, right_expr_ids),
+      right_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 std::size_t BinaryExpression::computeHash() const {

--- a/query_optimizer/expressions/BinaryExpression.hpp
+++ b/query_optimizer/expressions/BinaryExpression.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -88,7 +89,9 @@ class BinaryExpression : public Scalar {
   std::vector<AttributeReferencePtr> getReferencedAttributes() const override;
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   bool equals(const ScalarPtr &other) const override;
 

--- a/query_optimizer/expressions/CMakeLists.txt
+++ b/query_optimizer/expressions/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(quickstep_queryoptimizer_expressions_Alias
 target_link_libraries(quickstep_queryoptimizer_expressions_AttributeReference
                       glog
                       quickstep_catalog_CatalogTypedefs
+                      quickstep_expressions_scalar_Scalar
                       quickstep_expressions_scalar_ScalarAttribute
                       quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_Expression

--- a/query_optimizer/expressions/Cast.cpp
+++ b/query_optimizer/expressions/Cast.cpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/scalar/Scalar.hpp"
@@ -52,9 +53,12 @@ ExpressionPtr Cast::copyWithNewChildren(
 }
 
 ::quickstep::Scalar *Cast::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
-  return new ::quickstep::ScalarUnaryExpression(::quickstep::NumericCastOperation::Instance(target_type_),
-                                                operand_->concretize(substitution_map));
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
+  return new ::quickstep::ScalarUnaryExpression(
+      ::quickstep::NumericCastOperation::Instance(target_type_),
+      operand_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 std::size_t Cast::computeHash() const {

--- a/query_optimizer/expressions/Cast.hpp
+++ b/query_optimizer/expressions/Cast.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -76,7 +77,9 @@ class Cast : public Scalar {
       const std::vector<ExpressionPtr> &new_children) const override;
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   bool equals(const ScalarPtr &other) const override;
 

--- a/query_optimizer/expressions/CommonSubexpression.cpp
+++ b/query_optimizer/expressions/CommonSubexpression.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/scalar/ScalarSharedExpression.hpp"
@@ -47,10 +48,12 @@ ExpressionPtr CommonSubexpression::copyWithNewChildren(
 }
 
 ::quickstep::Scalar* CommonSubexpression::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   return new ::quickstep::ScalarSharedExpression(
       static_cast<int>(common_subexpression_id_),
-      operand_->concretize(substitution_map));
+      operand_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 void CommonSubexpression::getFieldStringItems(

--- a/query_optimizer/expressions/CommonSubexpression.hpp
+++ b/query_optimizer/expressions/CommonSubexpression.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/expressions/AttributeReference.hpp"
@@ -93,7 +94,9 @@ class CommonSubexpression : public Scalar {
   }
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable CommonSubexpression.

--- a/query_optimizer/expressions/ComparisonExpression.cpp
+++ b/query_optimizer/expressions/ComparisonExpression.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/predicate/ComparisonPredicate.hpp"
@@ -80,11 +81,13 @@ ComparisonExpression::getReferencedAttributes() const {
 }
 
 ::quickstep::Predicate* ComparisonExpression::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   return new ::quickstep::ComparisonPredicate(
       comparison_,
-      left_->concretize(substitution_map),
-      right_->concretize(substitution_map));
+      left_->concretize(substitution_map, left_expr_ids, right_expr_ids),
+      right_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 void ComparisonExpression::getFieldStringItems(

--- a/query_optimizer/expressions/ComparisonExpression.hpp
+++ b/query_optimizer/expressions/ComparisonExpression.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -89,7 +90,9 @@ class ComparisonExpression : public Predicate {
   std::vector<AttributeReferencePtr> getReferencedAttributes() const override;
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable ComparisonExpression.

--- a/query_optimizer/expressions/Exists.cpp
+++ b/query_optimizer/expressions/Exists.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -38,7 +39,9 @@ namespace optimizer {
 namespace expressions {
 
 ::quickstep::Predicate* Exists::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   LOG(FATAL) << "Exists predicate should not be concretized";
   return nullptr;
 }

--- a/query_optimizer/expressions/Exists.hpp
+++ b/query_optimizer/expressions/Exists.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -86,7 +87,9 @@ class Exists : public Predicate {
   }
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Create an Exists predicate expression.

--- a/query_optimizer/expressions/InTableQuery.cpp
+++ b/query_optimizer/expressions/InTableQuery.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -33,7 +34,9 @@ namespace optimizer {
 namespace expressions {
 
 ::quickstep::Predicate* InTableQuery::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   LOG(FATAL) << "InTableQuery predicate should not be concretized";
 }
 

--- a/query_optimizer/expressions/InTableQuery.hpp
+++ b/query_optimizer/expressions/InTableQuery.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -96,7 +97,9 @@ class InTableQuery : public Predicate {
   }
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Create an IN predicate with a subquery.

--- a/query_optimizer/expressions/InValueList.cpp
+++ b/query_optimizer/expressions/InValueList.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/predicate/DisjunctionPredicate.hpp"
@@ -40,7 +41,9 @@ namespace optimizer {
 namespace expressions {
 
 ::quickstep::Predicate* InValueList::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   std::unique_ptr<quickstep::DisjunctionPredicate>
       disjunction_predicate(new quickstep::DisjunctionPredicate());
   for (const ScalarPtr &match_expression : match_expressions_) {
@@ -51,7 +54,7 @@ namespace expressions {
             match_expression);
 
     disjunction_predicate->addPredicate(
-        match_predicate->concretize(substitution_map));
+        match_predicate->concretize(substitution_map, left_expr_ids, right_expr_ids));
   }
   return disjunction_predicate.release();
 }

--- a/query_optimizer/expressions/InValueList.hpp
+++ b/query_optimizer/expressions/InValueList.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -109,7 +110,9 @@ class InValueList : public Predicate {
   }
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Create an IN predicate with a value list.

--- a/query_optimizer/expressions/LogicalAnd.cpp
+++ b/query_optimizer/expressions/LogicalAnd.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/predicate/ConjunctionPredicate.hpp"
@@ -86,13 +87,15 @@ std::vector<AttributeReferencePtr> LogicalAnd::getReferencedAttributes() const {
 }
 
 ::quickstep::Predicate* LogicalAnd::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   if (operands_.empty()) {
     return new TruePredicate();
   }
 
   if (operands_.size() == 1u) {
-    return operands_[0]->concretize(substitution_map);
+    return operands_[0]->concretize(substitution_map, left_expr_ids, right_expr_ids);
   }
 
   std::unique_ptr<::quickstep::ConjunctionPredicate> concretized_predicate;
@@ -100,7 +103,7 @@ std::vector<AttributeReferencePtr> LogicalAnd::getReferencedAttributes() const {
 
   for (const PredicatePtr &operand : operands_) {
     concretized_predicate->addPredicate(
-        operand->concretize(substitution_map));
+        operand->concretize(substitution_map, left_expr_ids, right_expr_ids));
   }
 
   return concretized_predicate.release();

--- a/query_optimizer/expressions/LogicalAnd.hpp
+++ b/query_optimizer/expressions/LogicalAnd.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -88,7 +89,9 @@ class LogicalAnd : public Predicate {
   std::vector<AttributeReferencePtr> getReferencedAttributes() const override;
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable LogicalAnd. If any operand is also a LogicalAnd,

--- a/query_optimizer/expressions/LogicalNot.cpp
+++ b/query_optimizer/expressions/LogicalNot.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/predicate/NegationPredicate.hpp"
@@ -44,9 +45,11 @@ ExpressionPtr LogicalNot::copyWithNewChildren(
 }
 
 ::quickstep::Predicate* LogicalNot::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   return new ::quickstep::NegationPredicate(
-      operand_->concretize(substitution_map));
+      operand_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 void LogicalNot::getFieldStringItems(

--- a/query_optimizer/expressions/LogicalNot.hpp
+++ b/query_optimizer/expressions/LogicalNot.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -73,7 +74,9 @@ class LogicalNot : public Predicate {
   }
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable LogicalNot.

--- a/query_optimizer/expressions/LogicalOr.cpp
+++ b/query_optimizer/expressions/LogicalOr.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/predicate/DisjunctionPredicate.hpp"
@@ -84,13 +85,15 @@ std::vector<AttributeReferencePtr> LogicalOr::getReferencedAttributes() const {
 }
 
 ::quickstep::Predicate* LogicalOr::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   if (operands_.empty()) {
     return new FalsePredicate();
   }
 
   if (operands_.size() == 1u) {
-    return operands_[0]->concretize(substitution_map);
+    return operands_[0]->concretize(substitution_map, left_expr_ids, right_expr_ids);
   }
 
   std::unique_ptr<::quickstep::DisjunctionPredicate> concretized_predicate;
@@ -98,7 +101,7 @@ std::vector<AttributeReferencePtr> LogicalOr::getReferencedAttributes() const {
 
   for (const PredicatePtr &operand : operands_) {
     concretized_predicate->addPredicate(
-        operand->concretize(substitution_map));
+        operand->concretize(substitution_map, left_expr_ids, right_expr_ids));
   }
 
   return concretized_predicate.release();

--- a/query_optimizer/expressions/LogicalOr.hpp
+++ b/query_optimizer/expressions/LogicalOr.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -88,7 +89,9 @@ class LogicalOr : public Predicate {
   std::vector<AttributeReferencePtr> getReferencedAttributes() const override;
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable LogicalOr. If any operand is also a LogicalOr,

--- a/query_optimizer/expressions/Predicate.hpp
+++ b/query_optimizer/expressions/Predicate.hpp
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "query_optimizer/expressions/ExprId.hpp"
 #include "query_optimizer/expressions/Expression.hpp"
@@ -70,10 +71,14 @@ class Predicate : public Expression {
    *
    * @param substitution_map Map from ExprId to CatalogAttribute for use in
    *                         replacing AttributeReference.
+   * @param left_expr_ids The ExprIds from the left hand side.
+   * @param right_expr_ids The ExprIds from the right hand side.
    * @return A concretized predicate for evaluation.
    */
   virtual ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const = 0;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const = 0;
 
  protected:
   Predicate() {}

--- a/query_optimizer/expressions/PredicateLiteral.cpp
+++ b/query_optimizer/expressions/PredicateLiteral.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/predicate/TrivialPredicates.hpp"
@@ -40,7 +41,9 @@ ExpressionPtr PredicateLiteral::copyWithNewChildren(
 }
 
 ::quickstep::Predicate* PredicateLiteral::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   if (is_true()) {
     return new TruePredicate();
   } else {

--- a/query_optimizer/expressions/PredicateLiteral.hpp
+++ b/query_optimizer/expressions/PredicateLiteral.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -70,7 +71,9 @@ class PredicateLiteral : public Predicate {
   }
 
   ::quickstep::Predicate* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable PredicateLiteral.

--- a/query_optimizer/expressions/Scalar.hpp
+++ b/query_optimizer/expressions/Scalar.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "query_optimizer/expressions/Expression.hpp"
 #include "query_optimizer/expressions/ExprId.hpp"
@@ -61,11 +62,14 @@ class Scalar : public Expression {
    * @param substitution_map Map from ExprId to CatalogAttribute for use in
    *                         substituting CatalogAttribute for
    *                         AttributeReference.
+   * @param left_expr_ids The ExprIds from the left hand side.
+   * @param right_expr_ids The ExprIds from the right hand side.
    * @return Concretized expression for evaluation.
    */
   virtual ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map)
-      const = 0;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const = 0;
 
   /**
    * @brief Check whether this scalar is semantically equivalent to \p other.

--- a/query_optimizer/expressions/ScalarLiteral.cpp
+++ b/query_optimizer/expressions/ScalarLiteral.cpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/scalar/ScalarLiteral.hpp"
@@ -50,7 +51,9 @@ ExpressionPtr ScalarLiteral::copyWithNewChildren(
 }
 
 ::quickstep::Scalar *ScalarLiteral::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   return new ::quickstep::ScalarLiteral(value_, value_type_);
 }
 

--- a/query_optimizer/expressions/ScalarLiteral.hpp
+++ b/query_optimizer/expressions/ScalarLiteral.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -80,7 +81,9 @@ class ScalarLiteral : public Scalar {
   }
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   bool equals(const ScalarPtr &other) const override;
 

--- a/query_optimizer/expressions/SearchedCase.cpp
+++ b/query_optimizer/expressions/SearchedCase.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -114,15 +115,21 @@ ExpressionPtr SearchedCase::copyWithNewChildren(
 }
 
 ::quickstep::Scalar* SearchedCase::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   std::vector<std::unique_ptr<quickstep::Predicate>> when_predicates;
+  when_predicates.reserve(condition_predicates_.size());
   for (const PredicatePtr &predicate : condition_predicates_) {
-    when_predicates.emplace_back(predicate->concretize(substitution_map));
+    when_predicates.emplace_back(
+        predicate->concretize(substitution_map, left_expr_ids, right_expr_ids));
   }
 
   std::vector<std::unique_ptr<quickstep::Scalar>> result_expressions;
+  result_expressions.reserve(conditional_result_expressions_.size());
   for (const ScalarPtr &expression : conditional_result_expressions_) {
-    result_expressions.emplace_back(expression->concretize(substitution_map));
+    result_expressions.emplace_back(
+        expression->concretize(substitution_map, left_expr_ids, right_expr_ids));
   }
 
   std::unique_ptr<quickstep::Scalar> else_result_expression;
@@ -131,14 +138,14 @@ ExpressionPtr SearchedCase::copyWithNewChildren(
         new quickstep::ScalarLiteral(value_type_.makeNullValue(), value_type_));
   } else {
     else_result_expression.reset(
-        else_result_expression_->concretize(substitution_map));
+        else_result_expression_->concretize(substitution_map, left_expr_ids, right_expr_ids));
   }
 
   return new quickstep::ScalarCaseExpression(
       value_type_,
       std::move(when_predicates),
       std::move(result_expressions),
-      else_result_expression_->concretize(substitution_map));
+      else_result_expression_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 void SearchedCase::getFieldStringItems(

--- a/query_optimizer/expressions/SearchedCase.hpp
+++ b/query_optimizer/expressions/SearchedCase.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/scalar/Scalar.hpp"
@@ -101,7 +102,9 @@ class SearchedCase : public Scalar {
       const std::vector<ExpressionPtr> &new_children) const override;
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates an immutable SearchedCase.

--- a/query_optimizer/expressions/SimpleCase.cpp
+++ b/query_optimizer/expressions/SimpleCase.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -133,8 +134,11 @@ ExpressionPtr SimpleCase::copyWithNewChildren(const std::vector<ExpressionPtr> &
 }
 
 ::quickstep::Scalar* SimpleCase::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   std::vector<std::unique_ptr<quickstep::Predicate>> when_predicates;
+  when_predicates.reserve(condition_operands_.size());
   for (const ScalarPtr &condition_operand : condition_operands_) {
     const PredicatePtr predicate =
         ComparisonExpression::Create(
@@ -145,6 +149,7 @@ ExpressionPtr SimpleCase::copyWithNewChildren(const std::vector<ExpressionPtr> &
   }
 
   std::vector<std::unique_ptr<quickstep::Scalar>> result_expressions;
+  result_expressions.reserve(conditional_result_expressions_.size());
   for (const ScalarPtr &expression : conditional_result_expressions_) {
     result_expressions.emplace_back(expression->concretize(substitution_map));
   }

--- a/query_optimizer/expressions/SimpleCase.hpp
+++ b/query_optimizer/expressions/SimpleCase.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/scalar/Scalar.hpp"
@@ -109,7 +110,9 @@ class SimpleCase : public Scalar {
       const std::vector<ExpressionPtr> &new_children) const override;
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*>& substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   bool equals(const ScalarPtr &other) const override;
 

--- a/query_optimizer/expressions/SubqueryExpression.cpp
+++ b/query_optimizer/expressions/SubqueryExpression.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/OptimizerTree.hpp"
@@ -38,7 +39,9 @@ namespace optimizer {
 namespace expressions {
 
 ::quickstep::Scalar* SubqueryExpression::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   LOG(FATAL) << "SubqueryExpression should not be concretized";
 }
 

--- a/query_optimizer/expressions/SubqueryExpression.hpp
+++ b/query_optimizer/expressions/SubqueryExpression.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/expressions/AttributeReference.hpp"
@@ -87,7 +88,9 @@ class SubqueryExpression : public Scalar {
   }
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   /**
    * @brief Creates a subquery expression.

--- a/query_optimizer/expressions/UnaryExpression.cpp
+++ b/query_optimizer/expressions/UnaryExpression.cpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "expressions/scalar/ScalarUnaryExpression.hpp"
@@ -53,9 +54,11 @@ ExpressionPtr UnaryExpression::copyWithNewChildren(
 }
 
 ::quickstep::Scalar* UnaryExpression::concretize(
-    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const {
+    const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+    const std::unordered_set<ExprId> &left_expr_ids,
+    const std::unordered_set<ExprId> &right_expr_ids) const {
   return new ::quickstep::ScalarUnaryExpression(
-      operation_, operand_->concretize(substitution_map));
+      operation_, operand_->concretize(substitution_map, left_expr_ids, right_expr_ids));
 }
 
 std::size_t UnaryExpression::computeHash() const {

--- a/query_optimizer/expressions/UnaryExpression.hpp
+++ b/query_optimizer/expressions/UnaryExpression.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "query_optimizer/expressions/AttributeReference.hpp"
@@ -84,7 +85,9 @@ class UnaryExpression : public Scalar {
   }
 
   ::quickstep::Scalar* concretize(
-      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map) const override;
+      const std::unordered_map<ExprId, const CatalogAttribute*> &substitution_map,
+      const std::unordered_set<ExprId> &left_expr_ids = std::unordered_set<ExprId>(),
+      const std::unordered_set<ExprId> &right_expr_ids = std::unordered_set<ExprId>()) const override;
 
   bool equals(const ScalarPtr &other) const override;
 

--- a/query_optimizer/tests/execution_generator/Select.test
+++ b/query_optimizer/tests/execution_generator/Select.test
@@ -269,7 +269,6 @@ WHERE int_col < 10
 +-----------+--------------------+
 ==
 
-# The execution engine currently does not support self-join.
 SELECT a.int_col,
        a.int_col*b.int_col,
        b.long_col
@@ -277,7 +276,32 @@ FROM test AS a,
      test AS b
 WHERE a.int_col*b.int_col = b.long_col;
 --
-ERROR: NestedLoopsJoin does not support self-join yet
++-----------+---------------------+--------------------+
+|int_col    |(a.int_col*b.int_col)|long_col            |
++-----------+---------------------+--------------------+
+|         -1|                    1|                   1|
+|          2|                    4|                   4|
+|         -3|                    9|                   9|
+|          4|                   16|                  16|
+|         -5|                   25|                  25|
+|          6|                   36|                  36|
+|         -7|                   49|                  49|
+|          8|                   64|                  64|
+|         -9|                   81|                  81|
+|        -11|                  121|                 121|
+|         12|                  144|                 144|
+|        -13|                  169|                 169|
+|         14|                  196|                 196|
+|        -15|                  225|                 225|
+|         16|                  256|                 256|
+|        -17|                  289|                 289|
+|         18|                  324|                 324|
+|        -19|                  361|                 361|
+|        -21|                  441|                 441|
+|         22|                  484|                 484|
+|        -23|                  529|                 529|
+|         24|                  576|                 576|
++-----------+---------------------+--------------------+
 ==
 
 # The nested loops join is not a self-join, because the predicate "a.int_col<10" is pushed under the join, which results
@@ -305,14 +329,38 @@ WHERE a.long_col < 100
 +-----------+---------------------+--------------------+
 ==
 
-# Hash join does not support the self-join.
 SELECT a.int_col,
        b.int_col
 FROM test AS a,
      test AS b
 WHERE a.int_col = b.int_col;
 --
-ERROR: Self-join is not supported
++-----------+-----------+
+|int_col    |int_col    |
++-----------+-----------+
+|         -1|         -1|
+|          2|          2|
+|         -3|         -3|
+|          4|          4|
+|         -5|         -5|
+|          6|          6|
+|         -7|         -7|
+|          8|          8|
+|         -9|         -9|
+|        -11|        -11|
+|         12|         12|
+|        -13|        -13|
+|         14|         14|
+|        -15|        -15|
+|         16|         16|
+|        -17|        -17|
+|         18|         18|
+|        -19|        -19|
+|        -21|        -21|
+|         22|         22|
+|        -23|        -23|
+|         24|         24|
++-----------+-----------+
 ==
 
 # This is not a self-join, because there is a Select under the HashJoin for "a.long_col < 50".

--- a/relational_operators/NestedLoopsJoinOperator.cpp
+++ b/relational_operators/NestedLoopsJoinOperator.cpp
@@ -407,9 +407,6 @@ serialization::WorkOrder* NestedLoopsJoinOperator::createWorkOrderProto(const pa
 template <bool LEFT_PACKED, bool RIGHT_PACKED>
 void NestedLoopsJoinWorkOrder::executeHelper(const TupleStorageSubBlock &left_store,
                                              const TupleStorageSubBlock &right_store) {
-  const relation_id left_input_relation_id = left_input_relation_.getID();
-  const relation_id right_input_relation_id = right_input_relation_.getID();
-
   const tuple_id left_max_tid = left_store.getMaxTupleID();
   const tuple_id right_max_tid = right_store.getMaxTupleID();
 
@@ -428,10 +425,8 @@ void NestedLoopsJoinWorkOrder::executeHelper(const TupleStorageSubBlock &left_st
         if (RIGHT_PACKED || right_store.hasTupleWithID(right_tid)) {
           // For each tuple in the right block...
           if (join_predicate_->matchesForJoinedTuples(*left_accessor,
-                                                      left_input_relation_id,
                                                       left_tid,
                                                       *right_accessor,
-                                                      right_input_relation_id,
                                                       right_tid)) {
             joined_tuple_ids.emplace_back(left_tid, right_tid);
           }
@@ -460,9 +455,7 @@ void NestedLoopsJoinWorkOrder::executeHelper(const TupleStorageSubBlock &left_st
     for (vector<unique_ptr<const Scalar>>::const_iterator selection_cit = selection_.begin();
          selection_cit != selection_.end();
          ++selection_cit) {
-      temp_result.addColumn((*selection_cit)->getAllValuesForJoin(left_input_relation_id,
-                                                                  left_accessor.get(),
-                                                                  right_input_relation_id,
+      temp_result.addColumn((*selection_cit)->getAllValuesForJoin(left_accessor.get(),
                                                                   right_accessor.get(),
                                                                   joined_tuple_ids,
                                                                   cv_cache.get()));

--- a/relational_operators/tests/HashJoinOperator_unittest.cpp
+++ b/relational_operators/tests/HashJoinOperator_unittest.cpp
@@ -432,7 +432,7 @@ TEST_P(HashJoinOperatorTest, LongKeyHashJoinTest) {
 
   // Create the prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
-  ScalarAttribute scalar_attr(dim_col_long);
+  ScalarAttribute scalar_attr(dim_col_long, Scalar::kRightSide);
   query_context_proto.add_scalar_groups()->add_scalars()->MergeFrom(scalar_attr.getProto());
 
   // Create result_table, owned by db_.
@@ -581,9 +581,9 @@ TEST_P(HashJoinOperatorTest, IntDuplicateKeyHashJoinTest) {
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
   serialization::QueryContext::ScalarGroup *scalar_group_proto = query_context_proto.add_scalar_groups();
 
-  ScalarAttribute scalar_attr_dim(dim_col_long);
+  ScalarAttribute scalar_attr_dim(dim_col_long, Scalar::kRightSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_dim.getProto());
-  ScalarAttribute scalar_attr_fact(fact_col_long);
+  ScalarAttribute scalar_attr_fact(fact_col_long, Scalar::kLeftSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_fact.getProto());
 
   // Create result_table, owned by db_.
@@ -745,7 +745,7 @@ TEST_P(HashJoinOperatorTest, CharKeyCartesianProductHashJoinTest) {
 
   // Create prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
-  ScalarAttribute scalar_attr(dim_col_long);
+  ScalarAttribute scalar_attr(dim_col_long, Scalar::kRightSide);
   query_context_proto.add_scalar_groups()->add_scalars()->MergeFrom(scalar_attr.getProto());
 
   // Create result_table, owned by db_.
@@ -887,9 +887,9 @@ TEST_P(HashJoinOperatorTest, VarCharDuplicateKeyHashJoinTest) {
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
   serialization::QueryContext::ScalarGroup *scalar_group_proto = query_context_proto.add_scalar_groups();
 
-  ScalarAttribute scalar_attr_dim(dim_col_long);
+  ScalarAttribute scalar_attr_dim(dim_col_long, Scalar::kRightSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_dim.getProto());
-  ScalarAttribute scalar_attr_fact(fact_col_long);
+  ScalarAttribute scalar_attr_fact(fact_col_long, Scalar::kLeftSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_fact.getProto());
 
   // Create result_table, owned by db_.
@@ -1063,9 +1063,9 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinTest) {
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
   serialization::QueryContext::ScalarGroup *scalar_group_proto = query_context_proto.add_scalar_groups();
 
-  ScalarAttribute scalar_attr_dim(dim_col_long);
+  ScalarAttribute scalar_attr_dim(dim_col_long, Scalar::kRightSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_dim.getProto());
-  ScalarAttribute scalar_attr_fact(fact_col_long);
+  ScalarAttribute scalar_attr_fact(fact_col_long, Scalar::kLeftSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_fact.getProto());
 
   // Create result_table, owned by db_.
@@ -1244,9 +1244,9 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
   serialization::QueryContext::ScalarGroup *scalar_group_proto = query_context_proto.add_scalar_groups();
 
-  ScalarAttribute scalar_attr_dim(dim_col_long);
+  ScalarAttribute scalar_attr_dim(dim_col_long, Scalar::kRightSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_dim.getProto());
-  ScalarAttribute scalar_attr_fact(fact_col_long);
+  ScalarAttribute scalar_attr_fact(fact_col_long, Scalar::kLeftSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_fact.getProto());
 
   // Create result_table, owned by db_.
@@ -1269,7 +1269,7 @@ TEST_P(HashJoinOperatorTest, CompositeKeyHashJoinWithResidualPredicateTest) {
   unique_ptr<Predicate> residual_pred(new ComparisonPredicate(
       ComparisonFactory::GetComparison(
           ComparisonID::kLess),
-          new ScalarAttribute(dim_col_long),
+          new ScalarAttribute(dim_col_long, Scalar::kRightSide),
           new ScalarLiteral(TypedValue(static_cast<std::int64_t>(15)), LongType::InstanceNonNullable())));
 
   std::vector<attribute_id> fact_key_attrs;
@@ -1436,7 +1436,7 @@ TEST_P(HashJoinOperatorTest, SingleAttributePartitionedLongKeyHashJoinTest) {
 
   // Create the prober operator with one selection attribute.
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
-  ScalarAttribute scalar_attr(dim_col_long);
+  ScalarAttribute scalar_attr(dim_col_long, Scalar::kRightSide);
   query_context_proto.add_scalar_groups()->add_scalars()->MergeFrom(scalar_attr.getProto());
 
   // Create result_table, owned by db_.
@@ -1580,9 +1580,9 @@ TEST_P(HashJoinOperatorTest, SingleAttributePartitionedCompositeKeyHashJoinTest)
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
   serialization::QueryContext::ScalarGroup *scalar_group_proto = query_context_proto.add_scalar_groups();
 
-  ScalarAttribute scalar_attr_dim(dim_col_long);
+  ScalarAttribute scalar_attr_dim(dim_col_long, Scalar::kRightSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_dim.getProto());
-  ScalarAttribute scalar_attr_fact(fact_col_long);
+  ScalarAttribute scalar_attr_fact(fact_col_long, Scalar::kLeftSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_fact.getProto());
 
   // Create result_table, owned by db_.
@@ -1752,9 +1752,9 @@ TEST_P(HashJoinOperatorTest, SingleAttributePartitionedCompositeKeyHashJoinWithR
   const QueryContext::scalar_group_id selection_index = query_context_proto.scalar_groups_size();
   serialization::QueryContext::ScalarGroup *scalar_group_proto = query_context_proto.add_scalar_groups();
 
-  ScalarAttribute scalar_attr_dim(dim_col_long);
+  ScalarAttribute scalar_attr_dim(dim_col_long, Scalar::kRightSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_dim.getProto());
-  ScalarAttribute scalar_attr_fact(fact_col_long);
+  ScalarAttribute scalar_attr_fact(fact_col_long, Scalar::kLeftSide);
   scalar_group_proto->add_scalars()->MergeFrom(scalar_attr_fact.getProto());
 
   // Create result_table, owned by db_.
@@ -1777,7 +1777,7 @@ TEST_P(HashJoinOperatorTest, SingleAttributePartitionedCompositeKeyHashJoinWithR
   unique_ptr<Predicate> residual_pred(new ComparisonPredicate(
       ComparisonFactory::GetComparison(
           ComparisonID::kLess),
-          new ScalarAttribute(dim_col_long),
+          new ScalarAttribute(dim_col_long, Scalar::kRightSide),
           new ScalarLiteral(TypedValue(static_cast<std::int64_t>(15)), LongType::InstanceNonNullable())));
 
   const QueryContext::predicate_id residual_pred_index = query_context_proto.predicates_size();


### PR DESCRIPTION
This PR added the self-join support by assigning the join side info, instead of relying on the relation id.

Note that now the join result pair of all `HashJoin`s (except for `AntiJoin`) is in the format of `<probe-tid, build-tid>`, consistent with `NestedLoopsJoin` (<left-tid, right-tid>).

Some benchmark results (10 warm runs):

```
CREATE TABLE s (x int, y int);
INSERT INTO s SELECT i, i FROM gererate_series(1, 100000000) AS gs(i);
SELECT COUNT(*) FROM s s0, s s1 WHERE s0.y = s1.x AND s0.y != -1;
```
![chart-3](https://user-images.githubusercontent.com/2245572/39652983-de83e61e-4fb4-11e8-9b86-3f0e76b687ac.png)

On the other hand, the following self-join query takes about 200 ms if using `LIP`:
```
SELECT COUNT(*) FROM s s0, s s1 WHERE s0.y = s1.x;
```