### PR TITLE
Fixed the bug regarding EliminateEmptyNode on an aggregate query.

### DIFF
--- a/cli/tests/command_executor/Analyze.test
+++ b/cli/tests/command_executor/Analyze.test
@@ -27,11 +27,38 @@ INSERT INTO t VALUES(0, 0);
 --
 ==
 
+SELECT COUNT(*) FROM r;
+--
++--------------------+
+|COUNT(*)            |
++--------------------+
+|                   0|
++--------------------+
+==
+
 \analyze
 --
 Analyzing r ... done
 Analyzing s ... done
 Analyzing t ... done
+==
+
+SELECT COUNT(*) FROM r;
+--
++--------------------+
+|COUNT(*)            |
++--------------------+
+|                   0|
++--------------------+
+==
+
+SELECT MIN(src) FROM r;
+--
++-----------+
+|MIN(src)   |
++-----------+
+|       NULL|
++-----------+
 ==
 
 SELECT r.src, r.dst FROM r;

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -1956,6 +1956,9 @@ void ExecutionGenerator::convertAggregate(
     execution_plan_->addDirectDependency(aggregation_operator_index,
                                          input_relation_info->producer_operator_index,
                                          false /* is_pipeline_breaker */);
+  } else if (input_relation.isTemporary()) {
+    // NOTE(zuyu): drop the temp relation created by EliminateEmptyNode rule.
+    temporary_relation_info_vec_.emplace_back(aggregation_operator_index, &input_relation);
   }
 
   if (use_parallel_initialization) {
@@ -2451,6 +2454,9 @@ void ExecutionGenerator::convertWindowAggregate(
     execution_plan_->addDirectDependency(window_aggregation_operator_index,
                                          input_relation_info->producer_operator_index,
                                          true /* is_pipeline_breaker */);
+  } else if (input_relation.isTemporary()) {
+    // NOTE(zuyu): drop the temp relation created by EliminateEmptyNode rule.
+    temporary_relation_info_vec_.emplace_back(window_aggregation_operator_index, &input_relation);
   }
 
   insert_destination_proto->set_relational_op_index(window_aggregation_operator_index);

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -111,6 +111,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_EliminateEmptyNode
                       quickstep_queryoptimizer_OptimizerContext
                       quickstep_queryoptimizer_expressions_Alias
                       quickstep_queryoptimizer_expressions_AttributeReference
+                      quickstep_queryoptimizer_expressions_ExprId
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
                       quickstep_queryoptimizer_expressions_PatternMatcher


### PR DESCRIPTION
This PR fixed a bug introduced in #342 that incorrectly reduces an aggregate query on an empty table into a temp table scan. Ironically, `quickstep_cli_tests_commandexecutor_analyze` does not proof the correctness of the rule because the `\analyze` command does not set stats due to the bug mentioned before.

In other words, we could easily reproduce the bug:
```
CREATE TABLE r (a int);
\analyze r
SELECT COUNT(*) FROM r;  // this produce nothing (in 0 row), instead of a ZERO (in 1 row).
```

This fix transforms an aggregate query correctly, and adds more tests.