### PR TITLE
Fixed the bug regarding EliminateEmptyNode and InsertSelection.

### DIFF
--- a/cli/tests/command_executor/Analyze.test
+++ b/cli/tests/command_executor/Analyze.test
@@ -61,11 +61,15 @@ SELECT MIN(src) FROM r;
 +-----------+
 ==
 
+INSERT INTO r SELECT * FROM s;
 SELECT r.src, r.dst FROM r;
+DELETE FROM r;
 --
 +-----------+-----------+
 |src        |dst        |
 +-----------+-----------+
+|          0|          0|
+|          1|          5|
 +-----------+-----------+
 ==
 

--- a/query_optimizer/rules/EliminateEmptyNode.cpp
+++ b/query_optimizer/rules/EliminateEmptyNode.cpp
@@ -208,12 +208,21 @@ P::PhysicalPtr Apply(const P::PhysicalPtr &node) {
   for (const auto &child : new_node->children()) {
     const auto new_child = Apply(child);
     if (new_child == nullptr) {
-      if (P::SomeUnionAll::Matches(node)) {
-        has_changed_children = true;
-        continue;
+      switch (node->getPhysicalType()) {
+        case P::PhysicalType::kUnionAll:
+          has_changed_children = true;
+          break;
+        case P::PhysicalType::kInsertSelection:
+          if (!new_children.empty()) {
+            // The actual input is empty.
+            return nullptr;
+          }
+          new_children.push_back(child);
+          break;
+        default:
+          return nullptr;
       }
-
-      return nullptr;
+      continue;
     } else if (child != new_child && !has_changed_children) {
       has_changed_children = true;
     }


### PR DESCRIPTION
This PR fixed a bug regarding `EliminateEmptyNode` and `InsertSelection` that could be easily reproduced as the following:
```
CREATE TABLE temp (a int);
\analyze
INSERT INTO temp SELECT i FROM generate_series(1, 100) AS gs(i);
```

The problem is that `InsertSelection` allows the destination table to be empty, but the rule does not catch that.