### PR TITLE
Fixed the union-all elimiation case where some project expression is not an AttributeReference.

### DIFF
--- a/cli/tests/command_executor/Analyze.test
+++ b/cli/tests/command_executor/Analyze.test
@@ -36,6 +36,7 @@ SELECT COUNT(*) FROM r;
 +--------------------+
 ==
 
+# EliminateEmptyNode applies after having the exact stats.
 \analyze
 --
 Analyzing r ... done
@@ -43,6 +44,7 @@ Analyzing s ... done
 Analyzing t ... done
 ==
 
+# Aggregate on an empty table.
 SELECT COUNT(*) FROM r;
 --
 +--------------------+
@@ -52,6 +54,7 @@ SELECT COUNT(*) FROM r;
 +--------------------+
 ==
 
+# Aggregate on an empty table.
 SELECT MIN(src) FROM r;
 --
 +-----------+
@@ -61,6 +64,7 @@ SELECT MIN(src) FROM r;
 +-----------+
 ==
 
+# InsertSelection on an empty table.
 INSERT INTO r SELECT * FROM s;
 SELECT r.src, r.dst FROM r;
 DELETE FROM r;
@@ -71,6 +75,12 @@ DELETE FROM r;
 |          0|          0|
 |          1|          5|
 +-----------+-----------+
+==
+
+# Compute the exact stats for r after updates.
+\analyze r
+--
+Analyzing r ... done
 ==
 
 # One side of InnerJoin is empty.
@@ -136,9 +146,9 @@ SELECT t.src, t.dst FROM t;
 ==
 
 # Union on two InnerJoins, one of which involves an empty relation.
-SELECT r.src, r.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
+SELECT r.src, s.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
 UNION
-SELECT s.src, s.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
+SELECT s.src, t.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
 --
 +-----------+-----------+
 |src        |dst        |
@@ -148,15 +158,29 @@ SELECT s.src, s.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
 ==
 
 # Union All on two InnerJoins, one of which involves an empty relation.
-SELECT r.src, r.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
+SELECT r.src, s.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
 UNION ALL
-SELECT s.src, s.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
+SELECT s.src, t.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
 --
 +-----------+-----------+
 |src        |dst        |
 +-----------+-----------+
 |          0|          0|
 |          0|          0|
++-----------+-----------+
+==
+
+# Union All on two InnerJoins, one of which involves an empty relation.
+# One of the project expressions is a ScalarLiteral.
+SELECT s.src, r.dst FROM r, s WHERE r.src=s.src AND r.dst=s.dst
+UNION ALL
+SELECT 1 AS src, s.dst FROM s, t WHERE s.src=t.src AND s.dst=t.dst;
+--
++-----------+-----------+
+|src        |dst        |
++-----------+-----------+
+|          1|          0|
+|          1|          0|
 +-----------+-----------+
 ==
 

--- a/query_optimizer/physical/Aggregate.cpp
+++ b/query_optimizer/physical/Aggregate.cpp
@@ -27,7 +27,6 @@
 #include "query_optimizer/expressions/AttributeReference.hpp"
 #include "query_optimizer/expressions/ExpressionUtil.hpp"
 #include "query_optimizer/expressions/NamedExpression.hpp"
-#include "query_optimizer/expressions/PatternMatcher.hpp"
 #include "query_optimizer/expressions/Predicate.hpp"
 #include "query_optimizer/physical/PartitionSchemeHeader.hpp"
 #include "query_optimizer/physical/Physical.hpp"
@@ -91,22 +90,6 @@ std::vector<E::AttributeReferencePtr> Aggregate::getReferencedAttributes()
   }
 
   return referenced_attributes;
-}
-
-PhysicalPtr Aggregate::copyWithNewProjectExpressions(
-    const std::vector<E::NamedExpressionPtr> &output_expressions) const {
-  DCHECK_EQ(aggregate_expressions_.size(), output_expressions.size());
-
-  std::vector<E::AliasPtr> new_aggregate_expressions;
-  new_aggregate_expressions.reserve(aggregate_expressions_.size());
-  for (const auto &output_expression : output_expressions) {
-    DCHECK(E::SomeAlias::Matches(output_expression));
-
-    new_aggregate_expressions.push_back(
-        std::static_pointer_cast<const E::Alias>(output_expression));
-  }
-
-  return Create(input_, grouping_expressions_, new_aggregate_expressions, filter_predicate_);
 }
 
 void Aggregate::getFieldStringItems(

--- a/query_optimizer/physical/Aggregate.hpp
+++ b/query_optimizer/physical/Aggregate.hpp
@@ -103,9 +103,6 @@ class Aggregate : public Physical {
                   has_repartition, partition_scheme_header);
   }
 
-  PhysicalPtr copyWithNewProjectExpressions(
-      const std::vector<expressions::NamedExpressionPtr> &output_expressions) const override;
-
   bool maybeCopyWithPrunedExpressions(
       const expressions::UnorderedNamedExpressionSet &referenced_expressions,
       PhysicalPtr *output) const override {

--- a/query_optimizer/physical/CMakeLists.txt
+++ b/query_optimizer/physical/CMakeLists.txt
@@ -59,7 +59,6 @@ target_link_libraries(quickstep_queryoptimizer_physical_Aggregate
                       quickstep_queryoptimizer_expressions_AttributeReference
                       quickstep_queryoptimizer_expressions_ExpressionUtil
                       quickstep_queryoptimizer_expressions_NamedExpression
-                      quickstep_queryoptimizer_expressions_PatternMatcher
                       quickstep_queryoptimizer_expressions_Predicate
                       quickstep_queryoptimizer_physical_PartitionSchemeHeader
                       quickstep_queryoptimizer_physical_Physical


### PR DESCRIPTION
This PR fixed for the case where the only one child of the union-all query is non-empty, and the child has a non-AttributeReference project expression:

```
SELECT 1 AS a FROM not_empty
UNION ALL
SELECT 0 AS a FROM empty;
```